### PR TITLE
Support for county rankings.

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,0 +1,9 @@
+This app attempts to help people understand how their community changed as a result of Covid-19. The thesis is that using data from the [American Community Survey](https://en.wikipedia.org/wiki/American_Community_Survey) (ACS) can help with that. All data comes from the ACS 1-year estimates. 
+
+Note that counties are only included in this dataset if they have a population of at least 65,000. And data was not published for 2020 due to Covid-19.
+
+I have written several blog posts that go into more detail about this project. Two notable ones are:
+ * [Visualizing the Impact of Covid-19 on US Counties](https://arilamstein.com/blog/2024/05/04/visualizing-the-impact-of-covid-19-on-us-counties/) describes the current version of the app.
+ * [Building a Census Explorer in Python: Part 1](https://arilamstein.com/blog/2024/02/04/building-a-census-explorer-in-python-part-1/) discusses the technology choices made at the start of the project.
+
+This project is under active development. If you'd like to be notified of new versions then please subscribe to my [blog](https://arilamstein.com/).

--- a/backend.py
+++ b/backend.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 from census_vars import census_vars
 
 df = pd.read_csv('county_data.csv')
@@ -46,7 +47,8 @@ def get_ranking_df(column):
     df2 = (
         df2
         .loc[df['YEAR'] == 2021]
-        [['STATE_NAME', 'COUNTY_NAME', 'YEAR', column, 'Percent Change']]
+        [['STATE_NAME', 'COUNTY_NAME', column, 'Percent Change']]
+        .replace([np.inf, -np.inf], np.nan) # Happens when we divide by 0 
         .dropna()
         .sort_values('Percent Change', ascending=False)
     )

--- a/backend.py
+++ b/backend.py
@@ -31,3 +31,28 @@ def get_census_data(state_name, county_name, var):
 # See: https://stackoverflow.com/a/17016257/2518602
 def get_unique_census_labels():
     return list(dict.fromkeys(census_vars.values()))
+
+def get_ranking_df(column):
+    df2 = df.copy() # We don't want to modify the global variable
+
+    df2['Percent Change'] = (
+        df2
+        .groupby(['STATE_NAME', 'COUNTY_NAME'])
+        [column]
+        .pct_change() * 100
+    )
+
+    # Limit to 2021 and just the columns we want
+    df2 = (
+        df2
+        .loc[df['YEAR'] == 2021]
+        [['STATE_NAME', 'COUNTY_NAME', 'YEAR', column, 'Percent Change']]
+        .dropna()
+        .sort_values('Percent Change', ascending=False)
+    )
+
+    # Create an index called "Rank"
+    df2['Rank'] = list(range(1, len(df2.index) + 1))
+    df2 = df2.set_index('Rank')
+    
+    return df2

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,7 +3,7 @@ import streamlit as st
 import matplotlib.pyplot as plt
 
 st.header('Census Covid Explorer')
-st.write('This goal of this app is to shine a light on how US Demographics changed during Covid-19. The app is still under development. Data comes from the American Community Survey 1-year estimates.')
+st.write('This goal of this app is to shine a light on how US Demographics changed during Covid-19. The app is still under development. Data comes from the American Community Survey (ACS) 1-year estimates.')
 
 # Set up nice defaults for the various UI elements
 state_name = st.selectbox("Select a State:", be.get_state_names(), index=4) # 4 = California
@@ -17,18 +17,24 @@ county_name = st.selectbox("Select a County:", be.get_county_names(state_name), 
 # Something like "Total Population"
 var = st.selectbox("Select a demographic", be.get_unique_census_labels())
 
-# Get and chart data
-df = be.get_census_data(state_name, county_name, var)
-col1, col2 = st.columns(2)
-with col1:
-    # Line graph of raw data
-    st.pyplot(df.plot(x='YEAR', y=var).figure)
-with col2:
-    # Bar plot showing % change
-    df['Percent Change'] = df[var].pct_change() * 100
-    st.pyplot(df.plot(kind='bar', x='YEAR', y='Percent Change').figure)
+tab1, tab2 = st.tabs(["📈 County Details", "🥇 National Rankings"])
 
-st.write("Here's how all the counties ranked")
-st.dataframe(be.get_ranking_df(var))
+with tab1:
+    st.write(f"All data for {state_name}, {county_name} for {var}. Note that data was not provided for 2020.")
+
+    # Get and chart data
+    df = be.get_census_data(state_name, county_name, var)
+    col1, col2 = st.columns(2)
+    with col1:
+        # Line graph of raw data
+        st.pyplot(df.plot(x='YEAR', y=var).figure)
+    with col2:
+        # Bar plot showing % change
+        df['Percent Change'] = df[var].pct_change() * 100
+        st.pyplot(df.plot(kind='bar', x='YEAR', y='Percent Change').figure)
+
+with tab2:
+    st.write("Here's how all the counties ranked")
+    st.dataframe(be.get_ranking_df(var))
 
 st.write("Created by [Ari Lamstein](https://www.arilamstein.com). View the code [here](https://github.com/arilamstein/censusdis-streamlit).")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,25 +2,28 @@ import backend as be
 import streamlit as st
 import matplotlib.pyplot as plt
 
-st.header('Census Covid Explorer')
-st.write('This goal of this app is to shine a light on how US Demographics changed during Covid-19. The app is still under development. Data comes from the American Community Survey (ACS) 1-year estimates.')
+st.header('How did your County Change During Covid?')
 
 # Set up nice defaults for the various UI elements
-state_name = st.selectbox("Select a State:", be.get_state_names(), index=4) # 4 = California
-county_name_index = 0
-if state_name == "California":
-    county_name_index = 25 # San Francisco
-elif state_name == "New York":
-    county_name_index = 15 # New York (Manhattan)
-county_name = st.selectbox("Select a County:", be.get_county_names(state_name), index=county_name_index)
+state_col, county_col = st.columns(2)
+with state_col:
+    state_name = st.selectbox("State:", be.get_state_names(), index=4) # 4 = California
+    county_name_index = 0
+    if state_name == "California":
+        county_name_index = 25 # San Francisco
+    elif state_name == "New York":
+        county_name_index = 15 # New York (Manhattan)
+
+with county_col:
+    county_name = st.selectbox("County:", be.get_county_names(state_name), index=county_name_index)
 
 # Something like "Total Population"
-var = st.selectbox("Select a demographic", be.get_unique_census_labels())
+var = st.selectbox("Demographic:", be.get_unique_census_labels())
 
-tab1, tab2 = st.tabs(["📈 County Details", "🥇 National Rankings"])
+tab1, tab2, tab3 = st.tabs(["📈 County Details", "🥇 National Rankings", "ℹ️ About"])
 
 with tab1:
-    st.write(f"All data for {state_name}, {county_name} for {var}. Note that data was not provided for 2020.")
+    st.write(f"All data for {county_name}, {state_name} for {var}. Data was not published for 2020.")
 
     # Get and chart data
     df = be.get_census_data(state_name, county_name, var)
@@ -34,7 +37,10 @@ with tab1:
         st.pyplot(df.plot(kind='bar', x='YEAR', y='Percent Change').figure)
 
 with tab2:
-    st.write("Here's how all the counties ranked")
+    st.write("Here's how the counties ranked in terms of percent change between 2019-2021.")
     st.dataframe(be.get_ranking_df(var))
+
+with tab3:
+    st.write("All data comes from the American Community Survey (ACS) 1-year estimates.")
 
 st.write("Created by [Ari Lamstein](https://www.arilamstein.com). View the code [here](https://github.com/arilamstein/censusdis-streamlit).")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -23,7 +23,7 @@ var = st.selectbox("Demographic:", be.get_unique_census_labels())
 tab1, tab2, tab3 = st.tabs(["📈 County Details", "🥇 National Rankings", "ℹ️ About"])
 
 with tab1:
-    st.write(f"All data for {county_name}, {state_name} for {var}. Data was not published for 2020.")
+    st.write(f"All data for `{county_name}, {state_name}` for `{var}`.")
 
     # Get and chart data
     df = be.get_census_data(state_name, county_name, var)
@@ -37,10 +37,11 @@ with tab1:
         st.pyplot(df.plot(kind='bar', x='YEAR', y='Percent Change').figure)
 
 with tab2:
-    st.write("Here's how the counties ranked in terms of percent change between 2019-2021.")
+    st.write(f"Here's how the counties ranked in terms of percent change of `{var}` between 2019-2021.")
     st.dataframe(be.get_ranking_df(var))
 
 with tab3:
-    st.write("All data comes from the American Community Survey (ACS) 1-year estimates.")
+    text = open('about.md').read()
+    st.write(text)
 
 st.write("Created by [Ari Lamstein](https://www.arilamstein.com). View the code [here](https://github.com/arilamstein/censusdis-streamlit).")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -28,4 +28,7 @@ with col2:
     df['Percent Change'] = df[var].pct_change() * 100
     st.pyplot(df.plot(kind='bar', x='YEAR', y='Percent Change').figure)
 
+st.write("Here's how all the counties ranked")
+st.dataframe(be.get_ranking_df(var))
+
 st.write("Created by [Ari Lamstein](https://www.arilamstein.com). View the code [here](https://github.com/arilamstein/censusdis-streamlit).")


### PR DESCRIPTION
- Add a tabset: 
  - "County Details" (what was originally there)
  - "County Rankings" (a df that shows rankings for the metric as a % change between 2019-2021)
  - "About" that has what's written in the README of the repo
- Minor changes to the select UI.	