### PR TITLE
Bug fix: when splicing the two columns which make up work from home I

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -48,7 +48,6 @@ def get_ranking_df(column):
         df2
         .loc[df['YEAR'] == 2021]
         [['STATE_NAME', 'COUNTY_NAME', column, 'Percent Change']]
-        .replace([np.inf, -np.inf], np.nan) # Happens when we divide by 0 
         .dropna()
         .sort_values('Percent Change', ascending=False)
     )

--- a/county_data.csv
+++ b/county_data.csv
@@ -1,122 +1,122 @@
 STATE_NAME,COUNTY_NAME,YEAR,Total Population,Worked from Home,Median Household Income,Median Rent
-Alabama,Baldwin County,2005,160354,0.0,42119,555
-Alabama,Baldwin County,2006,169162,0.0,44878,641
-Alabama,Baldwin County,2007,171769,0.0,49119,653
-Alabama,Baldwin County,2008,174439,0.0,52320,644
-Alabama,Baldwin County,2009,179878,0.0,48487,634
-Alabama,Baldwin County,2010,183195,0.0,47502,678
-Alabama,Baldwin County,2011,186717,0.0,50900,679
-Alabama,Baldwin County,2012,190790,0.0,48378,710
-Alabama,Baldwin County,2013,195540,0.0,44874,671
-Alabama,Baldwin County,2014,200111,0.0,48461,648
-Alabama,Baldwin County,2015,203709,0.0,52003,728
-Alabama,Baldwin County,2016,208563,0.0,56732,814
-Alabama,Baldwin County,2017,212628,0.0,55342,785
-Alabama,Baldwin County,2018,218022,0.0,56813,831
-Alabama,Baldwin County,2019,223234,0.0,56439,898
-Alabama,Baldwin County,2021,239294,0.0,63866,917
-Alabama,Baldwin County,2022,246435,0.0,69914,892
-Alabama,Calhoun County,2005,109762,0.0,36243,372
-Alabama,Calhoun County,2006,112903,0.0,36241,379
-Alabama,Calhoun County,2007,113103,0.0,37074,398
-Alabama,Calhoun County,2008,113419,0.0,40056,376
-Alabama,Calhoun County,2009,114081,0.0,36527,391
-Alabama,Calhoun County,2010,118510,0.0,36675,411
-Alabama,Calhoun County,2011,117797,0.0,39037,416
-Alabama,Calhoun County,2012,117296,0.0,39169,452
-Alabama,Calhoun County,2013,116736,0.0,36205,428
-Alabama,Calhoun County,2014,115916,0.0,41428,428
-Alabama,Calhoun County,2015,115620,0.0,42346,496
-Alabama,Calhoun County,2016,114611,0.0,41687,468
-Alabama,Calhoun County,2017,114728,0.0,46763,477
-Alabama,Calhoun County,2018,114277,0.0,45818,534
-Alabama,Calhoun County,2019,113605,0.0,48156,529
-Alabama,Calhoun County,2021,115972,0.0,46524,503
-Alabama,Calhoun County,2022,115788,0.0,52819,505
-Alabama,Cullman County,2005,78888,0.0,37153,378
-Alabama,Cullman County,2006,80187,0.0,33959,339
-Alabama,Cullman County,2007,80554,0.0,39095,384
-Alabama,Cullman County,2008,81324,0.0,39229,404
-Alabama,Cullman County,2009,81778,0.0,36628,363
-Alabama,Cullman County,2010,80459,0.0,35786,414
-Alabama,Cullman County,2011,80536,0.0,40054,410
-Alabama,Cullman County,2012,80440,0.0,37287,385
-Alabama,Cullman County,2013,80811,0.0,39936,424
-Alabama,Cullman County,2014,81289,0.0,38261,428
-Alabama,Cullman County,2015,82005,0.0,37862,451
-Alabama,Cullman County,2016,82471,0.0,39411,461
-Alabama,Cullman County,2017,82755,0.0,45044,460
-Alabama,Cullman County,2018,83442,0.0,44612,433
-Alabama,Cullman County,2019,83768,0.0,50906,531
-Alabama,Cullman County,2021,89496,0.0,55517,592
-Alabama,Cullman County,2022,90665,0.0,63229,501
-Alabama,DeKalb County,2005,66407,0.0,29053,317
-Alabama,DeKalb County,2006,68014,0.0,30470,324
-Alabama,DeKalb County,2007,68016,0.0,35680,319
-Alabama,DeKalb County,2008,68515,0.0,34357,338
-Alabama,DeKalb County,2009,69380,0.0,33057,291
-Alabama,DeKalb County,2010,71151,0.0,35967,334
-Alabama,DeKalb County,2011,71375,0.0,36541,361
-Alabama,DeKalb County,2012,71080,0.0,38445,363
-Alabama,DeKalb County,2013,71013,0.0,40876,392
-Alabama,DeKalb County,2014,71065,0.0,35023,342
-Alabama,DeKalb County,2015,71130,0.0,36559,372
-Alabama,DeKalb County,2016,70900,0.0,35963,412
-Alabama,DeKalb County,2017,71617,0.0,39373,406
-Alabama,DeKalb County,2018,71385,0.0,36998,435
-Alabama,DeKalb County,2019,71513,0.0,44208,373
-Alabama,DeKalb County,2021,71813,0.0,41800,448
-Alabama,DeKalb County,2022,71998,0.0,49663,437
-Alabama,Elmore County,2005,68057,0.0,45802,390
-Alabama,Elmore County,2006,75688,0.0,52278,482
-Alabama,Elmore County,2007,77525,0.0,49495,478
-Alabama,Elmore County,2008,78106,0.0,54601,457
-Alabama,Elmore County,2009,79233,0.0,51142,509
-Alabama,Elmore County,2010,79549,0.0,52222,665
-Alabama,Elmore County,2011,80162,0.0,57405,479
-Alabama,Elmore County,2012,80629,0.0,53328,525
-Alabama,Elmore County,2013,80902,0.0,50699,584
-Alabama,Elmore County,2014,80977,0.0,55530,535
-Alabama,Elmore County,2015,81468,0.0,52502,589
-Alabama,Elmore County,2016,81799,0.0,52579,621
-Alabama,Elmore County,2017,81677,0.0,60558,638
-Alabama,Elmore County,2018,81887,0.0,60796,621
-Alabama,Elmore County,2019,81209,0.0,61854,669
-Alabama,Elmore County,2021,89304,0.0,59032,649
-Alabama,Elmore County,2022,89563,0.0,71651,796
-Alabama,Etowah County,2005,101151,0.0,32507,345
-Alabama,Etowah County,2006,103362,0.0,31562,345
-Alabama,Etowah County,2007,103217,0.0,34637,349
-Alabama,Etowah County,2008,103303,0.0,37642,388
-Alabama,Etowah County,2009,103645,0.0,39118,408
-Alabama,Etowah County,2010,104462,0.0,35897,402
-Alabama,Etowah County,2011,104303,0.0,33313,399
-Alabama,Etowah County,2012,104392,0.0,34264,398
-Alabama,Etowah County,2013,103931,0.0,39459,422
-Alabama,Etowah County,2014,103531,0.0,40529,452
-Alabama,Etowah County,2015,103057,0.0,43346,469
-Alabama,Etowah County,2016,102564,0.0,41152,437
-Alabama,Etowah County,2017,102755,0.0,41576,463
-Alabama,Etowah County,2018,102501,0.0,45868,492
-Alabama,Etowah County,2019,102268,0.0,41447,471
-Alabama,Etowah County,2021,103162,0.0,45298,528
-Alabama,Etowah County,2022,103088,0.0,57098,557
-Alabama,Houston County,2005,93101,0.0,38063,377
+Alabama,Baldwin County,2005,160354,,42119,555
+Alabama,Baldwin County,2006,169162,,44878,641
+Alabama,Baldwin County,2007,171769,,49119,653
+Alabama,Baldwin County,2008,174439,,52320,644
+Alabama,Baldwin County,2009,179878,,48487,634
+Alabama,Baldwin County,2010,183195,,47502,678
+Alabama,Baldwin County,2011,186717,,50900,679
+Alabama,Baldwin County,2012,190790,,48378,710
+Alabama,Baldwin County,2013,195540,,44874,671
+Alabama,Baldwin County,2014,200111,,48461,648
+Alabama,Baldwin County,2015,203709,,52003,728
+Alabama,Baldwin County,2016,208563,,56732,814
+Alabama,Baldwin County,2017,212628,,55342,785
+Alabama,Baldwin County,2018,218022,,56813,831
+Alabama,Baldwin County,2019,223234,,56439,898
+Alabama,Baldwin County,2021,239294,,63866,917
+Alabama,Baldwin County,2022,246435,,69914,892
+Alabama,Calhoun County,2005,109762,,36243,372
+Alabama,Calhoun County,2006,112903,,36241,379
+Alabama,Calhoun County,2007,113103,,37074,398
+Alabama,Calhoun County,2008,113419,,40056,376
+Alabama,Calhoun County,2009,114081,,36527,391
+Alabama,Calhoun County,2010,118510,,36675,411
+Alabama,Calhoun County,2011,117797,,39037,416
+Alabama,Calhoun County,2012,117296,,39169,452
+Alabama,Calhoun County,2013,116736,,36205,428
+Alabama,Calhoun County,2014,115916,,41428,428
+Alabama,Calhoun County,2015,115620,,42346,496
+Alabama,Calhoun County,2016,114611,,41687,468
+Alabama,Calhoun County,2017,114728,,46763,477
+Alabama,Calhoun County,2018,114277,,45818,534
+Alabama,Calhoun County,2019,113605,,48156,529
+Alabama,Calhoun County,2021,115972,,46524,503
+Alabama,Calhoun County,2022,115788,,52819,505
+Alabama,Cullman County,2005,78888,,37153,378
+Alabama,Cullman County,2006,80187,,33959,339
+Alabama,Cullman County,2007,80554,,39095,384
+Alabama,Cullman County,2008,81324,,39229,404
+Alabama,Cullman County,2009,81778,,36628,363
+Alabama,Cullman County,2010,80459,,35786,414
+Alabama,Cullman County,2011,80536,,40054,410
+Alabama,Cullman County,2012,80440,,37287,385
+Alabama,Cullman County,2013,80811,,39936,424
+Alabama,Cullman County,2014,81289,,38261,428
+Alabama,Cullman County,2015,82005,,37862,451
+Alabama,Cullman County,2016,82471,,39411,461
+Alabama,Cullman County,2017,82755,,45044,460
+Alabama,Cullman County,2018,83442,,44612,433
+Alabama,Cullman County,2019,83768,,50906,531
+Alabama,Cullman County,2021,89496,,55517,592
+Alabama,Cullman County,2022,90665,,63229,501
+Alabama,DeKalb County,2005,66407,,29053,317
+Alabama,DeKalb County,2006,68014,,30470,324
+Alabama,DeKalb County,2007,68016,,35680,319
+Alabama,DeKalb County,2008,68515,,34357,338
+Alabama,DeKalb County,2009,69380,,33057,291
+Alabama,DeKalb County,2010,71151,,35967,334
+Alabama,DeKalb County,2011,71375,,36541,361
+Alabama,DeKalb County,2012,71080,,38445,363
+Alabama,DeKalb County,2013,71013,,40876,392
+Alabama,DeKalb County,2014,71065,,35023,342
+Alabama,DeKalb County,2015,71130,,36559,372
+Alabama,DeKalb County,2016,70900,,35963,412
+Alabama,DeKalb County,2017,71617,,39373,406
+Alabama,DeKalb County,2018,71385,,36998,435
+Alabama,DeKalb County,2019,71513,,44208,373
+Alabama,DeKalb County,2021,71813,,41800,448
+Alabama,DeKalb County,2022,71998,,49663,437
+Alabama,Elmore County,2005,68057,,45802,390
+Alabama,Elmore County,2006,75688,,52278,482
+Alabama,Elmore County,2007,77525,,49495,478
+Alabama,Elmore County,2008,78106,,54601,457
+Alabama,Elmore County,2009,79233,,51142,509
+Alabama,Elmore County,2010,79549,,52222,665
+Alabama,Elmore County,2011,80162,,57405,479
+Alabama,Elmore County,2012,80629,,53328,525
+Alabama,Elmore County,2013,80902,,50699,584
+Alabama,Elmore County,2014,80977,,55530,535
+Alabama,Elmore County,2015,81468,,52502,589
+Alabama,Elmore County,2016,81799,,52579,621
+Alabama,Elmore County,2017,81677,,60558,638
+Alabama,Elmore County,2018,81887,,60796,621
+Alabama,Elmore County,2019,81209,,61854,669
+Alabama,Elmore County,2021,89304,,59032,649
+Alabama,Elmore County,2022,89563,,71651,796
+Alabama,Etowah County,2005,101151,,32507,345
+Alabama,Etowah County,2006,103362,,31562,345
+Alabama,Etowah County,2007,103217,,34637,349
+Alabama,Etowah County,2008,103303,,37642,388
+Alabama,Etowah County,2009,103645,,39118,408
+Alabama,Etowah County,2010,104462,,35897,402
+Alabama,Etowah County,2011,104303,,33313,399
+Alabama,Etowah County,2012,104392,,34264,398
+Alabama,Etowah County,2013,103931,,39459,422
+Alabama,Etowah County,2014,103531,,40529,452
+Alabama,Etowah County,2015,103057,,43346,469
+Alabama,Etowah County,2016,102564,,41152,437
+Alabama,Etowah County,2017,102755,,41576,463
+Alabama,Etowah County,2018,102501,,45868,492
+Alabama,Etowah County,2019,102268,,41447,471
+Alabama,Etowah County,2021,103162,,45298,528
+Alabama,Etowah County,2022,103088,,57098,557
+Alabama,Houston County,2005,93101,,38063,377
 Alabama,Houston County,2006,95660,910.0,36599,400
 Alabama,Houston County,2007,97171,643.0,40261,414
-Alabama,Houston County,2008,98488,0.0,42646,428
+Alabama,Houston County,2008,98488,,42646,428
 Alabama,Houston County,2009,100085,576.0,38342,437
-Alabama,Houston County,2010,101888,0.0,38579,452
+Alabama,Houston County,2010,101888,,38579,452
 Alabama,Houston County,2011,102369,745.0,40336,463
 Alabama,Houston County,2012,103402,607.0,40409,502
-Alabama,Houston County,2013,103668,0.0,39006,493
+Alabama,Houston County,2013,103668,,39006,493
 Alabama,Houston County,2014,104193,996.0,39543,512
 Alabama,Houston County,2015,104173,1256.0,43553,520
 Alabama,Houston County,2016,104056,926.0,42321,533
 Alabama,Houston County,2017,104346,824.0,44529,551
 Alabama,Houston County,2018,104722,1438.0,48105,555
-Alabama,Houston County,2019,105882,0.0,50103,533
-Alabama,Houston County,2021,107458,0.0,46931,609
+Alabama,Houston County,2019,105882,,50103,533
+Alabama,Houston County,2021,107458,,46931,609
 Alabama,Houston County,2022,108079,2338.0,56705,613
 Alabama,Jefferson County,2005,641690,7366.0,42013,496
 Alabama,Jefferson County,2006,656700,7661.0,41691,506
@@ -135,60 +135,60 @@ Alabama,Jefferson County,2018,659300,12469.0,55206,687
 Alabama,Jefferson County,2019,658573,11152.0,53944,689
 Alabama,Jefferson County,2021,667820,40032.0,55006,770
 Alabama,Jefferson County,2022,665409,33709.0,61968,845
-Alabama,Lauderdale County,2005,85898,0.0,32081,320
-Alabama,Lauderdale County,2006,87891,0.0,37644,339
-Alabama,Lauderdale County,2007,88561,0.0,36899,359
-Alabama,Lauderdale County,2008,89128,0.0,36762,355
-Alabama,Lauderdale County,2009,89599,0.0,38798,374
-Alabama,Lauderdale County,2010,92679,0.0,38661,386
-Alabama,Lauderdale County,2011,92781,0.0,40121,385
-Alabama,Lauderdale County,2012,92542,0.0,41908,397
-Alabama,Lauderdale County,2013,92797,0.0,43891,408
-Alabama,Lauderdale County,2014,93096,0.0,40309,446
-Alabama,Lauderdale County,2015,92596,0.0,42577,485
-Alabama,Lauderdale County,2016,92318,0.0,43427,457
-Alabama,Lauderdale County,2017,92538,0.0,45352,490
-Alabama,Lauderdale County,2018,92387,0.0,49014,435
-Alabama,Lauderdale County,2019,92729,0.0,46632,461
-Alabama,Lauderdale County,2021,94043,0.0,50218,586
-Alabama,Lauderdale County,2022,95878,0.0,59461,583
-Alabama,Lee County,2005,118664,0.0,35203,437
+Alabama,Lauderdale County,2005,85898,,32081,320
+Alabama,Lauderdale County,2006,87891,,37644,339
+Alabama,Lauderdale County,2007,88561,,36899,359
+Alabama,Lauderdale County,2008,89128,,36762,355
+Alabama,Lauderdale County,2009,89599,,38798,374
+Alabama,Lauderdale County,2010,92679,,38661,386
+Alabama,Lauderdale County,2011,92781,,40121,385
+Alabama,Lauderdale County,2012,92542,,41908,397
+Alabama,Lauderdale County,2013,92797,,43891,408
+Alabama,Lauderdale County,2014,93096,,40309,446
+Alabama,Lauderdale County,2015,92596,,42577,485
+Alabama,Lauderdale County,2016,92318,,43427,457
+Alabama,Lauderdale County,2017,92538,,45352,490
+Alabama,Lauderdale County,2018,92387,,49014,435
+Alabama,Lauderdale County,2019,92729,,46632,461
+Alabama,Lauderdale County,2021,94043,,50218,586
+Alabama,Lauderdale County,2022,95878,,59461,583
+Alabama,Lee County,2005,118664,,35203,437
 Alabama,Lee County,2006,125781,1399.0,38398,454
 Alabama,Lee County,2007,130516,2181.0,39355,477
 Alabama,Lee County,2008,133010,2023.0,41787,505
 Alabama,Lee County,2009,135883,1251.0,36925,511
 Alabama,Lee County,2010,140780,1592.0,39381,534
-Alabama,Lee County,2011,143468,0.0,42965,559
-Alabama,Lee County,2012,147257,0.0,45043,631
-Alabama,Lee County,2013,150933,0.0,46068,617
-Alabama,Lee County,2014,154255,0.0,39932,591
-Alabama,Lee County,2015,156993,0.0,46589,621
-Alabama,Lee County,2016,158991,0.0,48056,636
-Alabama,Lee County,2017,161604,0.0,52943,666
-Alabama,Lee County,2018,163941,0.0,46456,645
-Alabama,Lee County,2019,164542,0.0,53712,655
-Alabama,Lee County,2021,177218,0.0,52424,759
-Alabama,Lee County,2022,180773,0.0,58549,791
-Alabama,Limestone County,2005,67771,0.0,38562,351
-Alabama,Limestone County,2006,72446,0.0,44201,400
-Alabama,Limestone County,2007,73898,0.0,46583,354
-Alabama,Limestone County,2008,76135,0.0,45309,410
-Alabama,Limestone County,2009,78572,0.0,46065,414
-Alabama,Limestone County,2010,83193,0.0,50325,422
-Alabama,Limestone County,2011,85369,0.0,46339,421
-Alabama,Limestone County,2012,87654,0.0,47999,445
-Alabama,Limestone County,2013,88845,0.0,48639,422
-Alabama,Limestone County,2014,90787,0.0,49672,424
-Alabama,Limestone County,2015,91663,0.0,55009,445
-Alabama,Limestone County,2016,92753,0.0,50872,469
-Alabama,Limestone County,2017,94402,0.0,55817,446
-Alabama,Limestone County,2018,96174,0.0,67000,502
-Alabama,Limestone County,2019,98915,0.0,63695,543
-Alabama,Limestone County,2021,107517,0.0,66796,613
-Alabama,Limestone County,2022,110900,0.0,84220,779
-Alabama,Madison County,2005,290875,0.0,50504,474
+Alabama,Lee County,2011,143468,,42965,559
+Alabama,Lee County,2012,147257,,45043,631
+Alabama,Lee County,2013,150933,,46068,617
+Alabama,Lee County,2014,154255,,39932,591
+Alabama,Lee County,2015,156993,,46589,621
+Alabama,Lee County,2016,158991,,48056,636
+Alabama,Lee County,2017,161604,,52943,666
+Alabama,Lee County,2018,163941,,46456,645
+Alabama,Lee County,2019,164542,,53712,655
+Alabama,Lee County,2021,177218,,52424,759
+Alabama,Lee County,2022,180773,,58549,791
+Alabama,Limestone County,2005,67771,,38562,351
+Alabama,Limestone County,2006,72446,,44201,400
+Alabama,Limestone County,2007,73898,,46583,354
+Alabama,Limestone County,2008,76135,,45309,410
+Alabama,Limestone County,2009,78572,,46065,414
+Alabama,Limestone County,2010,83193,,50325,422
+Alabama,Limestone County,2011,85369,,46339,421
+Alabama,Limestone County,2012,87654,,47999,445
+Alabama,Limestone County,2013,88845,,48639,422
+Alabama,Limestone County,2014,90787,,49672,424
+Alabama,Limestone County,2015,91663,,55009,445
+Alabama,Limestone County,2016,92753,,50872,469
+Alabama,Limestone County,2017,94402,,55817,446
+Alabama,Limestone County,2018,96174,,67000,502
+Alabama,Limestone County,2019,98915,,63695,543
+Alabama,Limestone County,2021,107517,,66796,613
+Alabama,Limestone County,2022,110900,,84220,779
+Alabama,Madison County,2005,290875,,50504,474
 Alabama,Madison County,2006,304307,3828.0,51359,462
-Alabama,Madison County,2007,312734,0.0,51931,523
+Alabama,Madison County,2007,312734,,51931,523
 Alabama,Madison County,2008,319510,3532.0,55096,499
 Alabama,Madison County,2009,327744,3801.0,57617,542
 Alabama,Madison County,2010,335988,6101.0,53539,525
@@ -201,26 +201,26 @@ Alabama,Madison County,2016,356967,6223.0,60503,658
 Alabama,Madison County,2017,361046,6161.0,62312,657
 Alabama,Madison County,2018,366519,7672.0,63111,706
 Alabama,Madison County,2019,372909,10163.0,67930,720
-Alabama,Madison County,2021,395211,0.0,78525,846
+Alabama,Madison County,2021,395211,,78525,846
 Alabama,Madison County,2022,403565,29935.0,80123,914
-Alabama,Marshall County,2005,84662,0.0,33722,325
-Alabama,Marshall County,2006,87185,0.0,37030,334
-Alabama,Marshall County,2007,87644,0.0,34153,347
-Alabama,Marshall County,2008,88484,0.0,35205,433
-Alabama,Marshall County,2009,90399,0.0,37284,408
-Alabama,Marshall County,2010,93235,0.0,39343,402
-Alabama,Marshall County,2011,94166,0.0,39245,422
-Alabama,Marshall County,2012,94776,0.0,36197,410
-Alabama,Marshall County,2013,94760,0.0,38116,422
-Alabama,Marshall County,2014,94636,0.0,33446,410
-Alabama,Marshall County,2015,94725,0.0,40525,444
-Alabama,Marshall County,2016,95157,0.0,42362,450
-Alabama,Marshall County,2017,95548,0.0,41476,437
-Alabama,Marshall County,2018,96109,0.0,47528,507
-Alabama,Marshall County,2019,96774,0.0,49467,443
-Alabama,Marshall County,2021,98228,0.0,50191,507
-Alabama,Marshall County,2022,99423,0.0,52678,512
-Alabama,Mobile County,2005,393585,0.0,36402,427
+Alabama,Marshall County,2005,84662,,33722,325
+Alabama,Marshall County,2006,87185,,37030,334
+Alabama,Marshall County,2007,87644,,34153,347
+Alabama,Marshall County,2008,88484,,35205,433
+Alabama,Marshall County,2009,90399,,37284,408
+Alabama,Marshall County,2010,93235,,39343,402
+Alabama,Marshall County,2011,94166,,39245,422
+Alabama,Marshall County,2012,94776,,36197,410
+Alabama,Marshall County,2013,94760,,38116,422
+Alabama,Marshall County,2014,94636,,33446,410
+Alabama,Marshall County,2015,94725,,40525,444
+Alabama,Marshall County,2016,95157,,42362,450
+Alabama,Marshall County,2017,95548,,41476,437
+Alabama,Marshall County,2018,96109,,47528,507
+Alabama,Marshall County,2019,96774,,49467,443
+Alabama,Marshall County,2021,98228,,50191,507
+Alabama,Marshall County,2022,99423,,52678,512
+Alabama,Mobile County,2005,393585,,36402,427
 Alabama,Mobile County,2006,404157,3403.0,38686,468
 Alabama,Mobile County,2007,404406,5428.0,37391,479
 Alabama,Mobile County,2008,406309,3621.0,41065,506
@@ -236,109 +236,109 @@ Alabama,Mobile County,2017,413955,7647.0,46023,633
 Alabama,Mobile County,2018,413757,6604.0,43061,633
 Alabama,Mobile County,2019,413210,8011.0,49639,639
 Alabama,Mobile County,2021,413073,13651.0,49721,700
-Alabama,Mobile County,2022,411411,0.0,54300,738
-Alabama,Montgomery County,2005,209374,0.0,40401,462
-Alabama,Montgomery County,2006,223571,0.0,41340,492
+Alabama,Mobile County,2022,411411,,54300,738
+Alabama,Montgomery County,2005,209374,,40401,462
+Alabama,Montgomery County,2006,223571,,41340,492
 Alabama,Montgomery County,2007,225791,3528.0,41143,511
 Alabama,Montgomery County,2008,224810,2918.0,43557,553
 Alabama,Montgomery County,2009,224119,1819.0,41452,567
 Alabama,Montgomery County,2010,229844,2521.0,41946,568
-Alabama,Montgomery County,2011,232032,0.0,44185,543
+Alabama,Montgomery County,2011,232032,,44185,543
 Alabama,Montgomery County,2012,230149,2881.0,41807,588
 Alabama,Montgomery County,2013,226659,2338.0,44675,595
 Alabama,Montgomery County,2014,226189,3947.0,43346,616
-Alabama,Montgomery County,2015,226519,0.0,42477,643
+Alabama,Montgomery County,2015,226519,,42477,643
 Alabama,Montgomery County,2016,226349,3724.0,45395,634
 Alabama,Montgomery County,2017,226646,3730.0,45724,632
 Alabama,Montgomery County,2018,225763,3032.0,49989,661
 Alabama,Montgomery County,2019,226486,3998.0,53117,682
-Alabama,Montgomery County,2021,227434,0.0,50385,711
-Alabama,Montgomery County,2022,226361,0.0,57509,738
-Alabama,Morgan County,2005,112005,0.0,41144,405
-Alabama,Morgan County,2006,115237,0.0,38276,402
-Alabama,Morgan County,2007,115050,0.0,42990,382
-Alabama,Morgan County,2008,115959,0.0,46363,431
-Alabama,Morgan County,2009,117293,0.0,38890,421
-Alabama,Morgan County,2010,119626,0.0,45513,434
-Alabama,Morgan County,2011,119953,0.0,43590,416
-Alabama,Morgan County,2012,120395,0.0,45051,430
-Alabama,Morgan County,2013,119787,0.0,43169,463
-Alabama,Morgan County,2014,119607,0.0,44708,460
-Alabama,Morgan County,2015,119565,0.0,47229,452
-Alabama,Morgan County,2016,119012,0.0,44378,472
-Alabama,Morgan County,2017,118818,0.0,48563,443
-Alabama,Morgan County,2018,119089,0.0,53260,536
-Alabama,Morgan County,2019,119679,0.0,54338,518
-Alabama,Morgan County,2021,123668,0.0,55286,500
-Alabama,Morgan County,2022,124211,0.0,62201,673
-Alabama,St. Clair County,2005,72100,0.0,48349,364
-Alabama,St. Clair County,2006,65096,0.0,47274,482
-Alabama,St. Clair County,2007,76609,0.0,50829,422
-Alabama,St. Clair County,2008,79577,0.0,48143,443
-Alabama,St. Clair County,2009,81895,0.0,42327,455
-Alabama,St. Clair County,2010,83761,0.0,48316,503
-Alabama,St. Clair County,2011,84398,0.0,47500,456
-Alabama,St. Clair County,2012,85237,0.0,51859,553
-Alabama,St. Clair County,2013,86308,0.0,53803,532
-Alabama,St. Clair County,2014,86697,0.0,50146,513
-Alabama,St. Clair County,2015,87074,0.0,54484,534
-Alabama,St. Clair County,2016,88019,0.0,60158,546
-Alabama,St. Clair County,2017,88199,0.0,50934,531
-Alabama,St. Clair County,2018,88690,0.0,56602,634
-Alabama,St. Clair County,2019,89512,0.0,67487,797
-Alabama,St. Clair County,2021,92748,0.0,60433,602
-Alabama,St. Clair County,2022,93932,0.0,70301,612
-Alabama,Shelby County,2005,169822,0.0,60964,594
-Alabama,Shelby County,2006,178182,0.0,66300,622
-Alabama,Shelby County,2007,182113,0.0,66391,601
-Alabama,Shelby County,2008,187784,0.0,71675,671
-Alabama,Shelby County,2009,192503,0.0,64371,675
-Alabama,Shelby County,2010,195828,0.0,65673,696
-Alabama,Shelby County,2011,197936,0.0,65815,740
-Alabama,Shelby County,2012,200941,0.0,65728,750
-Alabama,Shelby County,2013,204180,0.0,67800,767
-Alabama,Shelby County,2014,206655,0.0,67754,765
-Alabama,Shelby County,2015,208713,0.0,70192,746
-Alabama,Shelby County,2016,210622,0.0,73647,804
-Alabama,Shelby County,2017,213605,0.0,73031,818
-Alabama,Shelby County,2018,215707,0.0,71230,884
-Alabama,Shelby County,2019,217702,0.0,75614,911
-Alabama,Shelby County,2021,226902,0.0,84260,1035
-Alabama,Shelby County,2022,230115,0.0,98212,1107
-Alabama,Talladega County,2005,76962,0.0,31505,289
-Alabama,Talladega County,2006,80271,0.0,33639,319
-Alabama,Talladega County,2007,80255,0.0,39297,313
-Alabama,Talladega County,2008,80279,0.0,33838,346
-Alabama,Talladega County,2009,80242,0.0,36526,344
-Alabama,Talladega County,2010,82110,0.0,34488,383
-Alabama,Talladega County,2011,81664,0.0,30367,352
-Alabama,Talladega County,2012,81762,0.0,31547,362
-Alabama,Talladega County,2013,81096,0.0,37719,379
-Alabama,Talladega County,2014,81322,0.0,39971,377
-Alabama,Talladega County,2015,80862,0.0,34451,356
-Alabama,Talladega County,2016,80103,0.0,39393,496
-Alabama,Talladega County,2017,80065,0.0,39731,388
-Alabama,Talladega County,2018,79828,0.0,40315,385
-Alabama,Talladega County,2019,79978,0.0,50147,429
-Alabama,Talladega County,2021,81524,0.0,45063,533
-Alabama,Talladega County,2022,80704,0.0,56876,514
-Alabama,Tuscaloosa County,2005,160947,0.0,32991,461
+Alabama,Montgomery County,2021,227434,,50385,711
+Alabama,Montgomery County,2022,226361,,57509,738
+Alabama,Morgan County,2005,112005,,41144,405
+Alabama,Morgan County,2006,115237,,38276,402
+Alabama,Morgan County,2007,115050,,42990,382
+Alabama,Morgan County,2008,115959,,46363,431
+Alabama,Morgan County,2009,117293,,38890,421
+Alabama,Morgan County,2010,119626,,45513,434
+Alabama,Morgan County,2011,119953,,43590,416
+Alabama,Morgan County,2012,120395,,45051,430
+Alabama,Morgan County,2013,119787,,43169,463
+Alabama,Morgan County,2014,119607,,44708,460
+Alabama,Morgan County,2015,119565,,47229,452
+Alabama,Morgan County,2016,119012,,44378,472
+Alabama,Morgan County,2017,118818,,48563,443
+Alabama,Morgan County,2018,119089,,53260,536
+Alabama,Morgan County,2019,119679,,54338,518
+Alabama,Morgan County,2021,123668,,55286,500
+Alabama,Morgan County,2022,124211,,62201,673
+Alabama,St. Clair County,2005,72100,,48349,364
+Alabama,St. Clair County,2006,65096,,47274,482
+Alabama,St. Clair County,2007,76609,,50829,422
+Alabama,St. Clair County,2008,79577,,48143,443
+Alabama,St. Clair County,2009,81895,,42327,455
+Alabama,St. Clair County,2010,83761,,48316,503
+Alabama,St. Clair County,2011,84398,,47500,456
+Alabama,St. Clair County,2012,85237,,51859,553
+Alabama,St. Clair County,2013,86308,,53803,532
+Alabama,St. Clair County,2014,86697,,50146,513
+Alabama,St. Clair County,2015,87074,,54484,534
+Alabama,St. Clair County,2016,88019,,60158,546
+Alabama,St. Clair County,2017,88199,,50934,531
+Alabama,St. Clair County,2018,88690,,56602,634
+Alabama,St. Clair County,2019,89512,,67487,797
+Alabama,St. Clair County,2021,92748,,60433,602
+Alabama,St. Clair County,2022,93932,,70301,612
+Alabama,Shelby County,2005,169822,,60964,594
+Alabama,Shelby County,2006,178182,,66300,622
+Alabama,Shelby County,2007,182113,,66391,601
+Alabama,Shelby County,2008,187784,,71675,671
+Alabama,Shelby County,2009,192503,,64371,675
+Alabama,Shelby County,2010,195828,,65673,696
+Alabama,Shelby County,2011,197936,,65815,740
+Alabama,Shelby County,2012,200941,,65728,750
+Alabama,Shelby County,2013,204180,,67800,767
+Alabama,Shelby County,2014,206655,,67754,765
+Alabama,Shelby County,2015,208713,,70192,746
+Alabama,Shelby County,2016,210622,,73647,804
+Alabama,Shelby County,2017,213605,,73031,818
+Alabama,Shelby County,2018,215707,,71230,884
+Alabama,Shelby County,2019,217702,,75614,911
+Alabama,Shelby County,2021,226902,,84260,1035
+Alabama,Shelby County,2022,230115,,98212,1107
+Alabama,Talladega County,2005,76962,,31505,289
+Alabama,Talladega County,2006,80271,,33639,319
+Alabama,Talladega County,2007,80255,,39297,313
+Alabama,Talladega County,2008,80279,,33838,346
+Alabama,Talladega County,2009,80242,,36526,344
+Alabama,Talladega County,2010,82110,,34488,383
+Alabama,Talladega County,2011,81664,,30367,352
+Alabama,Talladega County,2012,81762,,31547,362
+Alabama,Talladega County,2013,81096,,37719,379
+Alabama,Talladega County,2014,81322,,39971,377
+Alabama,Talladega County,2015,80862,,34451,356
+Alabama,Talladega County,2016,80103,,39393,496
+Alabama,Talladega County,2017,80065,,39731,388
+Alabama,Talladega County,2018,79828,,40315,385
+Alabama,Talladega County,2019,79978,,50147,429
+Alabama,Talladega County,2021,81524,,45063,533
+Alabama,Talladega County,2022,80704,,56876,514
+Alabama,Tuscaloosa County,2005,160947,,32991,461
 Alabama,Tuscaloosa County,2006,171159,2278.0,37020,452
 Alabama,Tuscaloosa County,2007,177906,1808.0,40943,508
 Alabama,Tuscaloosa County,2008,179448,958.0,43645,545
 Alabama,Tuscaloosa County,2009,184035,1596.0,41743,528
 Alabama,Tuscaloosa County,2010,195036,1982.0,43450,567
-Alabama,Tuscaloosa County,2011,197211,0.0,42056,573
+Alabama,Tuscaloosa County,2011,197211,,42056,573
 Alabama,Tuscaloosa County,2012,198596,2024.0,41139,541
 Alabama,Tuscaloosa County,2013,200821,2426.0,46538,565
 Alabama,Tuscaloosa County,2014,202212,2227.0,47531,625
-Alabama,Tuscaloosa County,2015,203976,0.0,49067,588
-Alabama,Tuscaloosa County,2016,206102,0.0,47787,627
-Alabama,Tuscaloosa County,2017,207811,0.0,52313,647
-Alabama,Tuscaloosa County,2018,208911,0.0,54459,653
-Alabama,Tuscaloosa County,2019,209355,0.0,52243,691
-Alabama,Tuscaloosa County,2021,227007,0.0,56559,728
-Alabama,Tuscaloosa County,2022,236780,0.0,61097,772
+Alabama,Tuscaloosa County,2015,203976,,49067,588
+Alabama,Tuscaloosa County,2016,206102,,47787,627
+Alabama,Tuscaloosa County,2017,207811,,52313,647
+Alabama,Tuscaloosa County,2018,208911,,54459,653
+Alabama,Tuscaloosa County,2019,209355,,52243,691
+Alabama,Tuscaloosa County,2021,227007,,56559,728
+Alabama,Tuscaloosa County,2022,236780,,61097,772
 Alaska,Anchorage Municipality,2005,266281,5638.0,61217,810
 Alaska,Anchorage Municipality,2006,278700,5599.0,63656,864
 Alaska,Anchorage Municipality,2007,279671,6152.0,68726,910
@@ -356,24 +356,24 @@ Alaska,Anchorage Municipality,2018,291538,6555.0,83648,1138
 Alaska,Anchorage Municipality,2019,288000,5189.0,82716,1156
 Alaska,Anchorage Municipality,2021,288121,18335.0,86654,1189
 Alaska,Anchorage Municipality,2022,287145,17867.0,100751,1274
-Alaska,Fairbanks North Star Borough,2005,83656,0.0,56560,758
-Alaska,Fairbanks North Star Borough,2006,86754,0.0,58833,790
+Alaska,Fairbanks North Star Borough,2005,83656,,56560,758
+Alaska,Fairbanks North Star Borough,2006,86754,,58833,790
 Alaska,Fairbanks North Star Borough,2007,97484,4214.0,65327,846
-Alaska,Fairbanks North Star Borough,2008,97970,0.0,69103,876
-Alaska,Fairbanks North Star Borough,2009,98660,0.0,70610,873
-Alaska,Fairbanks North Star Borough,2010,98314,0.0,60785,1000
+Alaska,Fairbanks North Star Borough,2008,97970,,69103,876
+Alaska,Fairbanks North Star Borough,2009,98660,,70610,873
+Alaska,Fairbanks North Star Borough,2010,98314,,60785,1000
 Alaska,Fairbanks North Star Borough,2011,99192,2449.0,65920,1058
-Alaska,Fairbanks North Star Borough,2012,100272,0.0,66539,1077
-Alaska,Fairbanks North Star Borough,2013,100436,0.0,69113,1061
-Alaska,Fairbanks North Star Borough,2014,99357,0.0,69820,1128
+Alaska,Fairbanks North Star Borough,2012,100272,,66539,1077
+Alaska,Fairbanks North Star Borough,2013,100436,,69113,1061
+Alaska,Fairbanks North Star Borough,2014,99357,,69820,1128
 Alaska,Fairbanks North Star Borough,2015,99631,1340.0,72975,1112
-Alaska,Fairbanks North Star Borough,2016,100605,0.0,77328,1189
-Alaska,Fairbanks North Star Borough,2017,99703,0.0,76747,1113
+Alaska,Fairbanks North Star Borough,2016,100605,,77328,1189
+Alaska,Fairbanks North Star Borough,2017,99703,,76747,1113
 Alaska,Fairbanks North Star Borough,2018,98971,3161.0,75448,1183
-Alaska,Fairbanks North Star Borough,2019,96849,0.0,72065,1173
-Alaska,Fairbanks North Star Borough,2021,95593,0.0,72149,1136
+Alaska,Fairbanks North Star Borough,2019,96849,,72065,1173
+Alaska,Fairbanks North Star Borough,2021,95593,,72149,1136
 Alaska,Fairbanks North Star Borough,2022,95356,1779.0,83519,1200
-Alaska,Matanuska-Susitna Borough,2005,75001,0.0,56857,758
+Alaska,Matanuska-Susitna Borough,2005,75001,,56857,758
 Alaska,Matanuska-Susitna Borough,2006,80480,2141.0,58321,738
 Alaska,Matanuska-Susitna Borough,2007,82669,2210.0,65321,777
 Alaska,Matanuska-Susitna Borough,2008,85458,2432.0,72966,829
@@ -388,43 +388,43 @@ Alaska,Matanuska-Susitna Borough,2016,104365,3210.0,69332,961
 Alaska,Matanuska-Susitna Borough,2017,106532,2874.0,69121,978
 Alaska,Matanuska-Susitna Borough,2018,107610,3143.0,72667,948
 Alaska,Matanuska-Susitna Borough,2019,108317,2885.0,74709,975
-Alaska,Matanuska-Susitna Borough,2021,110686,0.0,78856,1036
+Alaska,Matanuska-Susitna Borough,2021,110686,,78856,1036
 Alaska,Matanuska-Susitna Borough,2022,113325,5945.0,84636,1152
-Arizona,Apache County,2005,68070,0.0,23545,242
-Arizona,Apache County,2006,71118,0.0,26502,353
-Arizona,Apache County,2007,69980,0.0,30534,320
-Arizona,Apache County,2008,70207,0.0,30653,215
-Arizona,Apache County,2009,70591,0.0,26396,254
-Arizona,Apache County,2010,71676,0.0,30744,376
-Arizona,Apache County,2011,72401,0.0,31123,348
-Arizona,Apache County,2012,73195,0.0,33867,323
-Arizona,Apache County,2013,71934,0.0,29180,347
-Arizona,Apache County,2014,71828,0.0,33076,330
-Arizona,Apache County,2015,71474,0.0,29417,365
-Arizona,Apache County,2016,73112,0.0,34685,311
-Arizona,Apache County,2017,71606,0.0,31671,328
-Arizona,Apache County,2018,71818,0.0,30207,343
-Arizona,Apache County,2019,71887,0.0,30480,330
-Arizona,Apache County,2021,65623,0.0,40628,454
-Arizona,Apache County,2022,65432,0.0,37663,402
-Arizona,Cochise County,2005,120439,0.0,36027,474
+Arizona,Apache County,2005,68070,,23545,242
+Arizona,Apache County,2006,71118,,26502,353
+Arizona,Apache County,2007,69980,,30534,320
+Arizona,Apache County,2008,70207,,30653,215
+Arizona,Apache County,2009,70591,,26396,254
+Arizona,Apache County,2010,71676,,30744,376
+Arizona,Apache County,2011,72401,,31123,348
+Arizona,Apache County,2012,73195,,33867,323
+Arizona,Apache County,2013,71934,,29180,347
+Arizona,Apache County,2014,71828,,33076,330
+Arizona,Apache County,2015,71474,,29417,365
+Arizona,Apache County,2016,73112,,34685,311
+Arizona,Apache County,2017,71606,,31671,328
+Arizona,Apache County,2018,71818,,30207,343
+Arizona,Apache County,2019,71887,,30480,330
+Arizona,Apache County,2021,65623,,40628,454
+Arizona,Apache County,2022,65432,,37663,402
+Arizona,Cochise County,2005,120439,,36027,474
 Arizona,Cochise County,2006,127757,2668.0,38427,525
-Arizona,Cochise County,2007,127866,0.0,44499,566
-Arizona,Cochise County,2008,129006,0.0,44549,550
-Arizona,Cochise County,2009,129518,0.0,45706,587
-Arizona,Cochise County,2010,131789,0.0,45213,583
-Arizona,Cochise County,2011,133289,0.0,40903,610
+Arizona,Cochise County,2007,127866,,44499,566
+Arizona,Cochise County,2008,129006,,44549,550
+Arizona,Cochise County,2009,129518,,45706,587
+Arizona,Cochise County,2010,131789,,45213,583
+Arizona,Cochise County,2011,133289,,40903,610
 Arizona,Cochise County,2012,132088,2694.0,43252,605
 Arizona,Cochise County,2013,129473,1583.0,46647,636
 Arizona,Cochise County,2014,127448,2829.0,45688,660
 Arizona,Cochise County,2015,126427,1929.0,43291,606
-Arizona,Cochise County,2016,125770,0.0,45508,642
+Arizona,Cochise County,2016,125770,,45508,642
 Arizona,Cochise County,2017,124756,2075.0,51816,642
 Arizona,Cochise County,2018,126770,1943.0,50495,635
 Arizona,Cochise County,2019,125922,3164.0,48484,628
-Arizona,Cochise County,2021,126050,0.0,56600,686
+Arizona,Cochise County,2021,126050,,56600,686
 Arizona,Cochise County,2022,125663,6417.0,55031,748
-Arizona,Coconino County,2005,120776,0.0,41184,672
+Arizona,Coconino County,2005,120776,,41184,672
 Arizona,Coconino County,2006,124953,2934.0,43510,638
 Arizona,Coconino County,2007,127450,4507.0,49633,758
 Arizona,Coconino County,2008,128558,3842.0,47408,776
@@ -458,40 +458,40 @@ Arizona,Maricopa County,2018,4410824,156187.0,65252,961
 Arizona,Maricopa County,2019,4485414,172100.0,68649,1031
 Arizona,Maricopa County,2021,4496588,512937.0,76247,1228
 Arizona,Maricopa County,2022,4551524,499811.0,83747,1458
-Arizona,Mohave County,2005,185969,0.0,35477,604
+Arizona,Mohave County,2005,185969,,35477,604
 Arizona,Mohave County,2006,193035,2945.0,36097,580
-Arizona,Mohave County,2007,194944,0.0,39991,674
-Arizona,Mohave County,2008,196281,0.0,38305,672
+Arizona,Mohave County,2007,194944,,39991,674
+Arizona,Mohave County,2008,196281,,38305,672
 Arizona,Mohave County,2009,194825,2267.0,40946,633
-Arizona,Mohave County,2010,200181,0.0,36456,614
-Arizona,Mohave County,2011,202351,0.0,35983,616
+Arizona,Mohave County,2010,200181,,36456,614
+Arizona,Mohave County,2011,202351,,35983,616
 Arizona,Mohave County,2012,203334,2392.0,34445,653
-Arizona,Mohave County,2013,203030,0.0,39058,597
+Arizona,Mohave County,2013,203030,,39058,597
 Arizona,Mohave County,2014,203361,1358.0,37674,616
 Arizona,Mohave County,2015,204737,1645.0,40908,611
-Arizona,Mohave County,2016,205249,0.0,42423,655
-Arizona,Mohave County,2017,207200,0.0,42311,648
+Arizona,Mohave County,2016,205249,,42423,655
+Arizona,Mohave County,2017,207200,,42311,648
 Arizona,Mohave County,2018,209550,4239.0,46060,669
-Arizona,Mohave County,2019,212181,0.0,50179,728
-Arizona,Mohave County,2021,217692,0.0,46616,787
-Arizona,Mohave County,2022,220816,0.0,54786,883
-Arizona,Navajo County,2005,106192,0.0,31272,345
-Arizona,Navajo County,2006,111399,0.0,36651,465
-Arizona,Navajo County,2007,111273,0.0,40190,424
-Arizona,Navajo County,2008,112757,0.0,41090,469
-Arizona,Navajo County,2009,112975,0.0,34547,520
-Arizona,Navajo County,2010,107551,0.0,40623,474
+Arizona,Mohave County,2019,212181,,50179,728
+Arizona,Mohave County,2021,217692,,46616,787
+Arizona,Mohave County,2022,220816,,54786,883
+Arizona,Navajo County,2005,106192,,31272,345
+Arizona,Navajo County,2006,111399,,36651,465
+Arizona,Navajo County,2007,111273,,40190,424
+Arizona,Navajo County,2008,112757,,41090,469
+Arizona,Navajo County,2009,112975,,34547,520
+Arizona,Navajo County,2010,107551,,40623,474
 Arizona,Navajo County,2011,107398,2818.0,30937,467
 Arizona,Navajo County,2012,107094,2049.0,34298,507
 Arizona,Navajo County,2013,107322,1616.0,38400,503
 Arizona,Navajo County,2014,108101,1592.0,34600,445
-Arizona,Navajo County,2015,108277,0.0,37833,521
-Arizona,Navajo County,2016,110026,0.0,36998,531
+Arizona,Navajo County,2015,108277,,37833,521
+Arizona,Navajo County,2016,110026,,36998,531
 Arizona,Navajo County,2017,108956,2498.0,41295,551
-Arizona,Navajo County,2018,110445,0.0,40463,524
-Arizona,Navajo County,2019,110924,0.0,38897,518
-Arizona,Navajo County,2021,108147,0.0,49449,521
-Arizona,Navajo County,2022,108650,0.0,49487,669
+Arizona,Navajo County,2018,110445,,40463,524
+Arizona,Navajo County,2019,110924,,38897,518
+Arizona,Navajo County,2021,108147,,49449,521
+Arizona,Navajo County,2022,108650,,49487,669
 Arizona,Pima County,2005,902720,15542.0,41521,547
 Arizona,Pima County,2006,946362,18989.0,42984,568
 Arizona,Pima County,2007,967089,19500.0,43546,610
@@ -509,8 +509,8 @@ Arizona,Pima County,2018,1039073,24877.0,53464,758
 Arizona,Pima County,2019,1047279,31777.0,56169,772
 Arizona,Pima County,2021,1052030,84488.0,60667,867
 Arizona,Pima County,2022,1057597,69188.0,64014,974
-Arizona,Pinal County,2005,214319,0.0,41164,512
-Arizona,Pinal County,2006,271059,0.0,43142,536
+Arizona,Pinal County,2005,214319,,41164,512
+Arizona,Pinal County,2006,271059,,43142,536
 Arizona,Pinal County,2007,299246,5091.0,50228,632
 Arizona,Pinal County,2008,327301,7841.0,49530,642
 Arizona,Pinal County,2009,340962,6894.0,48851,763
@@ -526,24 +526,24 @@ Arizona,Pinal County,2018,447138,10674.0,59058,836
 Arizona,Pinal County,2019,462789,12972.0,62057,870
 Arizona,Pinal County,2021,449557,32359.0,70993,991
 Arizona,Pinal County,2022,464154,31560.0,76377,1340
-Arizona,Yavapai County,2005,194928,0.0,40746,627
-Arizona,Yavapai County,2006,208014,0.0,40649,672
-Arizona,Yavapai County,2007,212635,0.0,44408,691
+Arizona,Yavapai County,2005,194928,,40746,627
+Arizona,Yavapai County,2006,208014,,40649,672
+Arizona,Yavapai County,2007,212635,,44408,691
 Arizona,Yavapai County,2008,215503,8987.0,41804,682
-Arizona,Yavapai County,2009,215686,0.0,40402,678
-Arizona,Yavapai County,2010,211061,0.0,40274,658
-Arizona,Yavapai County,2011,211888,0.0,41719,642
+Arizona,Yavapai County,2009,215686,,40402,678
+Arizona,Yavapai County,2010,211061,,40274,658
+Arizona,Yavapai County,2011,211888,,41719,642
 Arizona,Yavapai County,2012,212637,4645.0,44035,690
 Arizona,Yavapai County,2013,215133,6386.0,39895,725
 Arizona,Yavapai County,2014,218844,6277.0,44255,725
 Arizona,Yavapai County,2015,222255,5882.0,48105,733
-Arizona,Yavapai County,2016,225562,0.0,50420,788
-Arizona,Yavapai County,2017,228168,0.0,50041,790
-Arizona,Yavapai County,2018,231993,0.0,48148,738
-Arizona,Yavapai County,2019,235099,0.0,53816,863
+Arizona,Yavapai County,2016,225562,,50420,788
+Arizona,Yavapai County,2017,228168,,50041,790
+Arizona,Yavapai County,2018,231993,,48148,738
+Arizona,Yavapai County,2019,235099,,53816,863
 Arizona,Yavapai County,2021,242253,14340.0,57230,941
 Arizona,Yavapai County,2022,246191,13876.0,63936,1019
-Arizona,Yuma County,2005,175793,0.0,35956,526
+Arizona,Yuma County,2005,175793,,35956,526
 Arizona,Yuma County,2006,187555,1711.0,37457,496
 Arizona,Yuma County,2007,190557,2269.0,40733,569
 Arizona,Yuma County,2008,194322,1858.0,38930,587
@@ -558,108 +558,108 @@ Arizona,Yuma County,2016,205631,2038.0,43518,616
 Arizona,Yuma County,2017,207534,2303.0,46798,682
 Arizona,Yuma County,2018,212128,1482.0,43403,692
 Arizona,Yuma County,2019,213787,2395.0,46419,665
-Arizona,Yuma County,2021,206990,0.0,57304,770
-Arizona,Yuma County,2022,207842,0.0,53994,757
-Arkansas,Benton County,2005,184692,0.0,48863,506
+Arizona,Yuma County,2021,206990,,57304,770
+Arizona,Yuma County,2022,207842,,53994,757
+Arkansas,Benton County,2005,184692,,48863,506
 Arkansas,Benton County,2006,196045,3806.0,45543,516
 Arkansas,Benton County,2007,203107,3071.0,48373,542
-Arkansas,Benton County,2008,209791,0.0,50463,568
+Arkansas,Benton County,2008,209791,,50463,568
 Arkansas,Benton County,2009,225504,6250.0,48764,551
 Arkansas,Benton County,2010,222894,3455.0,52368,536
-Arkansas,Benton County,2011,227556,0.0,52341,593
+Arkansas,Benton County,2011,227556,,52341,593
 Arkansas,Benton County,2012,232268,5564.0,52294,590
 Arkansas,Benton County,2013,237297,4100.0,56570,621
 Arkansas,Benton County,2014,242321,4536.0,56981,607
 Arkansas,Benton County,2015,249672,4638.0,58770,652
-Arkansas,Benton County,2016,258291,0.0,63631,655
+Arkansas,Benton County,2016,258291,,63631,655
 Arkansas,Benton County,2017,266300,4150.0,63746,700
 Arkansas,Benton County,2018,272608,5720.0,67164,711
 Arkansas,Benton County,2019,279141,7160.0,69130,729
 Arkansas,Benton County,2021,293692,31343.0,78691,860
 Arkansas,Benton County,2022,302863,25199.0,85917,953
-Arkansas,Craighead County,2005,84288,0.0,32770,442
-Arkansas,Craighead County,2006,88244,0.0,39464,427
-Arkansas,Craighead County,2007,91552,0.0,40873,439
-Arkansas,Craighead County,2008,92640,0.0,39747,466
-Arkansas,Craighead County,2009,95457,0.0,40028,490
-Arkansas,Craighead County,2010,96771,0.0,36320,478
-Arkansas,Craighead County,2011,98315,0.0,37390,511
-Arkansas,Craighead County,2012,99735,0.0,44111,556
-Arkansas,Craighead County,2013,101488,0.0,41134,519
-Arkansas,Craighead County,2014,102518,0.0,42691,590
-Arkansas,Craighead County,2015,104354,0.0,40085,575
-Arkansas,Craighead County,2016,105835,0.0,43678,614
-Arkansas,Craighead County,2017,107115,0.0,50422,627
-Arkansas,Craighead County,2018,108558,0.0,44810,614
-Arkansas,Craighead County,2019,110332,0.0,45610,634
-Arkansas,Craighead County,2021,112218,0.0,50186,678
-Arkansas,Craighead County,2022,113017,0.0,61871,702
-Arkansas,Faulkner County,2005,91784,0.0,42646,471
-Arkansas,Faulkner County,2006,100685,0.0,41748,474
-Arkansas,Faulkner County,2007,104865,0.0,44280,469
-Arkansas,Faulkner County,2008,106823,0.0,41170,518
-Arkansas,Faulkner County,2009,109386,0.0,49018,540
-Arkansas,Faulkner County,2010,113980,0.0,43033,528
-Arkansas,Faulkner County,2011,116342,0.0,49886,556
-Arkansas,Faulkner County,2012,118704,0.0,49752,547
-Arkansas,Faulkner County,2013,119580,0.0,49149,539
-Arkansas,Faulkner County,2014,120768,0.0,51650,591
-Arkansas,Faulkner County,2015,121552,0.0,50596,607
-Arkansas,Faulkner County,2016,122227,0.0,48506,651
-Arkansas,Faulkner County,2017,123654,0.0,47964,594
-Arkansas,Faulkner County,2018,124806,0.0,51437,652
-Arkansas,Faulkner County,2019,126007,0.0,57642,651
-Arkansas,Faulkner County,2021,125106,0.0,55635,649
-Arkansas,Faulkner County,2022,127665,0.0,62993,699
-Arkansas,Garland County,2005,91690,0.0,31986,416
-Arkansas,Garland County,2006,95164,0.0,33688,479
-Arkansas,Garland County,2007,96371,0.0,34947,473
-Arkansas,Garland County,2008,97465,0.0,36922,478
-Arkansas,Garland County,2009,98479,0.0,37678,496
-Arkansas,Garland County,2010,96145,0.0,36482,535
-Arkansas,Garland County,2011,97124,0.0,34251,528
-Arkansas,Garland County,2012,96903,0.0,40893,561
-Arkansas,Garland County,2013,97173,0.0,39589,499
-Arkansas,Garland County,2014,97322,0.0,41032,516
-Arkansas,Garland County,2015,97177,0.0,37013,560
-Arkansas,Garland County,2016,97477,0.0,42826,568
-Arkansas,Garland County,2017,98658,0.0,46101,566
-Arkansas,Garland County,2018,99154,0.0,42779,617
-Arkansas,Garland County,2019,99386,0.0,45265,591
-Arkansas,Garland County,2021,100330,0.0,47694,633
-Arkansas,Garland County,2022,100089,0.0,53145,695
-Arkansas,Jefferson County,2005,76258,0.0,31547,368
-Arkansas,Jefferson County,2006,80655,0.0,32852,389
-Arkansas,Jefferson County,2007,78986,0.0,36725,421
-Arkansas,Jefferson County,2008,78373,0.0,38922,420
-Arkansas,Jefferson County,2009,78705,0.0,33957,367
-Arkansas,Jefferson County,2010,77358,0.0,33474,451
-Arkansas,Jefferson County,2011,76246,0.0,39176,417
-Arkansas,Jefferson County,2012,74723,0.0,36275,464
-Arkansas,Jefferson County,2013,73191,0.0,34689,466
-Arkansas,Jefferson County,2014,72297,0.0,32433,438
-Arkansas,Jefferson County,2015,71565,0.0,35381,502
-Arkansas,Jefferson County,2016,70016,0.0,37712,508
-Arkansas,Jefferson County,2017,69115,0.0,37678,489
-Arkansas,Jefferson County,2018,68114,0.0,35652,534
-Arkansas,Jefferson County,2019,66824,0.0,39326,574
-Arkansas,Jefferson County,2021,65861,0.0,48499,612
-Arkansas,Jefferson County,2022,64246,0.0,44584,531
-Arkansas,Lonoke County,2008,65233,0.0,48664,475
-Arkansas,Lonoke County,2009,66677,0.0,52211,490
-Arkansas,Lonoke County,2010,68634,0.0,49367,504
-Arkansas,Lonoke County,2011,69341,0.0,48161,483
-Arkansas,Lonoke County,2012,69839,0.0,51098,498
-Arkansas,Lonoke County,2013,70753,0.0,56635,543
-Arkansas,Lonoke County,2014,71557,0.0,54545,519
-Arkansas,Lonoke County,2015,71645,0.0,56893,552
-Arkansas,Lonoke County,2016,72228,0.0,55837,654
-Arkansas,Lonoke County,2017,72898,0.0,51835,597
-Arkansas,Lonoke County,2018,73657,0.0,53782,647
-Arkansas,Lonoke County,2019,73309,0.0,62532,601
-Arkansas,Lonoke County,2021,74722,0.0,63641,745
-Arkansas,Lonoke County,2022,75225,0.0,63766,642
-Arkansas,Pulaski County,2005,358234,0.0,40421,506
+Arkansas,Craighead County,2005,84288,,32770,442
+Arkansas,Craighead County,2006,88244,,39464,427
+Arkansas,Craighead County,2007,91552,,40873,439
+Arkansas,Craighead County,2008,92640,,39747,466
+Arkansas,Craighead County,2009,95457,,40028,490
+Arkansas,Craighead County,2010,96771,,36320,478
+Arkansas,Craighead County,2011,98315,,37390,511
+Arkansas,Craighead County,2012,99735,,44111,556
+Arkansas,Craighead County,2013,101488,,41134,519
+Arkansas,Craighead County,2014,102518,,42691,590
+Arkansas,Craighead County,2015,104354,,40085,575
+Arkansas,Craighead County,2016,105835,,43678,614
+Arkansas,Craighead County,2017,107115,,50422,627
+Arkansas,Craighead County,2018,108558,,44810,614
+Arkansas,Craighead County,2019,110332,,45610,634
+Arkansas,Craighead County,2021,112218,,50186,678
+Arkansas,Craighead County,2022,113017,,61871,702
+Arkansas,Faulkner County,2005,91784,,42646,471
+Arkansas,Faulkner County,2006,100685,,41748,474
+Arkansas,Faulkner County,2007,104865,,44280,469
+Arkansas,Faulkner County,2008,106823,,41170,518
+Arkansas,Faulkner County,2009,109386,,49018,540
+Arkansas,Faulkner County,2010,113980,,43033,528
+Arkansas,Faulkner County,2011,116342,,49886,556
+Arkansas,Faulkner County,2012,118704,,49752,547
+Arkansas,Faulkner County,2013,119580,,49149,539
+Arkansas,Faulkner County,2014,120768,,51650,591
+Arkansas,Faulkner County,2015,121552,,50596,607
+Arkansas,Faulkner County,2016,122227,,48506,651
+Arkansas,Faulkner County,2017,123654,,47964,594
+Arkansas,Faulkner County,2018,124806,,51437,652
+Arkansas,Faulkner County,2019,126007,,57642,651
+Arkansas,Faulkner County,2021,125106,,55635,649
+Arkansas,Faulkner County,2022,127665,,62993,699
+Arkansas,Garland County,2005,91690,,31986,416
+Arkansas,Garland County,2006,95164,,33688,479
+Arkansas,Garland County,2007,96371,,34947,473
+Arkansas,Garland County,2008,97465,,36922,478
+Arkansas,Garland County,2009,98479,,37678,496
+Arkansas,Garland County,2010,96145,,36482,535
+Arkansas,Garland County,2011,97124,,34251,528
+Arkansas,Garland County,2012,96903,,40893,561
+Arkansas,Garland County,2013,97173,,39589,499
+Arkansas,Garland County,2014,97322,,41032,516
+Arkansas,Garland County,2015,97177,,37013,560
+Arkansas,Garland County,2016,97477,,42826,568
+Arkansas,Garland County,2017,98658,,46101,566
+Arkansas,Garland County,2018,99154,,42779,617
+Arkansas,Garland County,2019,99386,,45265,591
+Arkansas,Garland County,2021,100330,,47694,633
+Arkansas,Garland County,2022,100089,,53145,695
+Arkansas,Jefferson County,2005,76258,,31547,368
+Arkansas,Jefferson County,2006,80655,,32852,389
+Arkansas,Jefferson County,2007,78986,,36725,421
+Arkansas,Jefferson County,2008,78373,,38922,420
+Arkansas,Jefferson County,2009,78705,,33957,367
+Arkansas,Jefferson County,2010,77358,,33474,451
+Arkansas,Jefferson County,2011,76246,,39176,417
+Arkansas,Jefferson County,2012,74723,,36275,464
+Arkansas,Jefferson County,2013,73191,,34689,466
+Arkansas,Jefferson County,2014,72297,,32433,438
+Arkansas,Jefferson County,2015,71565,,35381,502
+Arkansas,Jefferson County,2016,70016,,37712,508
+Arkansas,Jefferson County,2017,69115,,37678,489
+Arkansas,Jefferson County,2018,68114,,35652,534
+Arkansas,Jefferson County,2019,66824,,39326,574
+Arkansas,Jefferson County,2021,65861,,48499,612
+Arkansas,Jefferson County,2022,64246,,44584,531
+Arkansas,Lonoke County,2008,65233,,48664,475
+Arkansas,Lonoke County,2009,66677,,52211,490
+Arkansas,Lonoke County,2010,68634,,49367,504
+Arkansas,Lonoke County,2011,69341,,48161,483
+Arkansas,Lonoke County,2012,69839,,51098,498
+Arkansas,Lonoke County,2013,70753,,56635,543
+Arkansas,Lonoke County,2014,71557,,54545,519
+Arkansas,Lonoke County,2015,71645,,56893,552
+Arkansas,Lonoke County,2016,72228,,55837,654
+Arkansas,Lonoke County,2017,72898,,51835,597
+Arkansas,Lonoke County,2018,73657,,53782,647
+Arkansas,Lonoke County,2019,73309,,62532,601
+Arkansas,Lonoke County,2021,74722,,63641,745
+Arkansas,Lonoke County,2022,75225,,63766,642
+Arkansas,Pulaski County,2005,358234,,40421,506
 Arkansas,Pulaski County,2006,367319,4984.0,43308,515
 Arkansas,Pulaski County,2007,373911,5575.0,44754,526
 Arkansas,Pulaski County,2008,376797,6095.0,44967,555
@@ -676,45 +676,45 @@ Arkansas,Pulaski County,2018,392680,7124.0,49613,668
 Arkansas,Pulaski County,2019,391911,6783.0,52043,669
 Arkansas,Pulaski County,2021,397821,25182.0,52479,749
 Arkansas,Pulaski County,2022,399145,20717.0,56308,760
-Arkansas,Saline County,2005,89380,0.0,48627,488
-Arkansas,Saline County,2006,94024,0.0,47404,498
-Arkansas,Saline County,2007,96212,0.0,50094,513
-Arkansas,Saline County,2008,98209,0.0,48038,500
-Arkansas,Saline County,2009,99449,0.0,51394,549
-Arkansas,Saline County,2010,107532,0.0,52664,551
-Arkansas,Saline County,2011,109526,0.0,53557,582
-Arkansas,Saline County,2012,111845,0.0,58009,600
-Arkansas,Saline County,2013,114404,0.0,53107,575
-Arkansas,Saline County,2014,115719,0.0,53926,597
-Arkansas,Saline County,2015,117460,0.0,55051,595
-Arkansas,Saline County,2016,118703,0.0,64932,620
-Arkansas,Saline County,2017,119323,0.0,59633,644
-Arkansas,Saline County,2018,121421,0.0,63084,641
-Arkansas,Saline County,2019,122437,0.0,66327,694
-Arkansas,Saline County,2021,125233,0.0,67345,779
-Arkansas,Saline County,2022,127357,0.0,67632,730
-Arkansas,Sebastian County,2005,116426,0.0,33932,373
-Arkansas,Sebastian County,2006,120322,0.0,35917,410
-Arkansas,Sebastian County,2007,121766,0.0,39919,410
-Arkansas,Sebastian County,2008,122274,0.0,38824,423
-Arkansas,Sebastian County,2009,123597,0.0,38838,434
-Arkansas,Sebastian County,2010,125920,0.0,38093,469
-Arkansas,Sebastian County,2011,127127,0.0,35703,471
-Arkansas,Sebastian County,2012,127304,0.0,37330,472
-Arkansas,Sebastian County,2013,127342,0.0,41056,500
-Arkansas,Sebastian County,2014,126776,0.0,38418,508
-Arkansas,Sebastian County,2015,127780,0.0,40448,468
-Arkansas,Sebastian County,2016,127793,0.0,42053,526
-Arkansas,Sebastian County,2017,128107,0.0,41917,467
-Arkansas,Sebastian County,2018,127753,0.0,46826,528
-Arkansas,Sebastian County,2019,127827,0.0,48839,543
-Arkansas,Sebastian County,2021,128400,0.0,47874,559
-Arkansas,Sebastian County,2022,129059,0.0,51491,591
-Arkansas,Washington County,2005,173713,0.0,39861,494
+Arkansas,Saline County,2005,89380,,48627,488
+Arkansas,Saline County,2006,94024,,47404,498
+Arkansas,Saline County,2007,96212,,50094,513
+Arkansas,Saline County,2008,98209,,48038,500
+Arkansas,Saline County,2009,99449,,51394,549
+Arkansas,Saline County,2010,107532,,52664,551
+Arkansas,Saline County,2011,109526,,53557,582
+Arkansas,Saline County,2012,111845,,58009,600
+Arkansas,Saline County,2013,114404,,53107,575
+Arkansas,Saline County,2014,115719,,53926,597
+Arkansas,Saline County,2015,117460,,55051,595
+Arkansas,Saline County,2016,118703,,64932,620
+Arkansas,Saline County,2017,119323,,59633,644
+Arkansas,Saline County,2018,121421,,63084,641
+Arkansas,Saline County,2019,122437,,66327,694
+Arkansas,Saline County,2021,125233,,67345,779
+Arkansas,Saline County,2022,127357,,67632,730
+Arkansas,Sebastian County,2005,116426,,33932,373
+Arkansas,Sebastian County,2006,120322,,35917,410
+Arkansas,Sebastian County,2007,121766,,39919,410
+Arkansas,Sebastian County,2008,122274,,38824,423
+Arkansas,Sebastian County,2009,123597,,38838,434
+Arkansas,Sebastian County,2010,125920,,38093,469
+Arkansas,Sebastian County,2011,127127,,35703,471
+Arkansas,Sebastian County,2012,127304,,37330,472
+Arkansas,Sebastian County,2013,127342,,41056,500
+Arkansas,Sebastian County,2014,126776,,38418,508
+Arkansas,Sebastian County,2015,127780,,40448,468
+Arkansas,Sebastian County,2016,127793,,42053,526
+Arkansas,Sebastian County,2017,128107,,41917,467
+Arkansas,Sebastian County,2018,127753,,46826,528
+Arkansas,Sebastian County,2019,127827,,48839,543
+Arkansas,Sebastian County,2021,128400,,47874,559
+Arkansas,Sebastian County,2022,129059,,51491,591
+Arkansas,Washington County,2005,173713,,39861,494
 Arkansas,Washington County,2006,186521,2949.0,41471,510
-Arkansas,Washington County,2007,194292,0.0,42689,510
-Arkansas,Washington County,2008,195803,0.0,41911,503
-Arkansas,Washington County,2009,200181,0.0,40532,530
+Arkansas,Washington County,2007,194292,,42689,510
+Arkansas,Washington County,2008,195803,,41911,503
+Arkansas,Washington County,2009,200181,,40532,530
 Arkansas,Washington County,2010,204123,2908.0,38278,538
 Arkansas,Washington County,2011,207521,6516.0,37449,499
 Arkansas,Washington County,2012,211411,6278.0,41225,552
@@ -727,23 +727,23 @@ Arkansas,Washington County,2018,236961,8594.0,50342,661
 Arkansas,Washington County,2019,239187,4377.0,50798,687
 Arkansas,Washington County,2021,250057,14259.0,65125,771
 Arkansas,Washington County,2022,256054,13461.0,61194,761
-Arkansas,White County,2005,67705,0.0,36551,356
-Arkansas,White County,2006,72560,0.0,36259,356
-Arkansas,White County,2007,73441,0.0,36859,417
-Arkansas,White County,2008,74845,0.0,39047,418
-Arkansas,White County,2009,76338,0.0,38161,424
-Arkansas,White County,2010,77350,0.0,38326,467
-Arkansas,White County,2011,78167,0.0,44626,435
-Arkansas,White County,2012,78493,0.0,38853,458
-Arkansas,White County,2013,78483,0.0,43643,452
-Arkansas,White County,2014,78592,0.0,39340,446
-Arkansas,White County,2015,79161,0.0,38986,490
-Arkansas,White County,2016,79263,0.0,42844,510
-Arkansas,White County,2017,79016,0.0,42443,531
-Arkansas,White County,2018,78727,0.0,42270,521
-Arkansas,White County,2019,78753,0.0,43399,483
-Arkansas,White County,2021,77207,0.0,51402,543
-Arkansas,White County,2022,77755,0.0,57015,606
+Arkansas,White County,2005,67705,,36551,356
+Arkansas,White County,2006,72560,,36259,356
+Arkansas,White County,2007,73441,,36859,417
+Arkansas,White County,2008,74845,,39047,418
+Arkansas,White County,2009,76338,,38161,424
+Arkansas,White County,2010,77350,,38326,467
+Arkansas,White County,2011,78167,,44626,435
+Arkansas,White County,2012,78493,,38853,458
+Arkansas,White County,2013,78483,,43643,452
+Arkansas,White County,2014,78592,,39340,446
+Arkansas,White County,2015,79161,,38986,490
+Arkansas,White County,2016,79263,,42844,510
+Arkansas,White County,2017,79016,,42443,531
+Arkansas,White County,2018,78727,,42270,521
+Arkansas,White County,2019,78753,,43399,483
+Arkansas,White County,2021,77207,,51402,543
+Arkansas,White County,2022,77755,,57015,606
 California,Alameda County,2005,1421308,23566.0,61014,987
 California,Alameda County,2006,1457426,35228.0,64424,1015
 California,Alameda County,2007,1464202,33904.0,68740,1038
@@ -761,7 +761,7 @@ California,Alameda County,2018,1666753,55046.0,102125,1791
 California,Alameda County,2019,1671329,53235.0,108322,1879
 California,Alameda County,2021,1648556,287142.0,109729,1917
 California,Alameda County,2022,1628997,234028.0,122159,2046
-California,Butte County,2005,207937,0.0,36602,660
+California,Butte County,2005,207937,,36602,660
 California,Butte County,2006,215881,4501.0,40897,694
 California,Butte County,2007,218779,4022.0,39529,691
 California,Butte County,2008,220337,4006.0,40101,726
@@ -795,13 +795,13 @@ California,Contra Costa County,2018,1150215,37975.0,101618,1721
 California,Contra Costa County,2019,1153526,38974.0,107135,1798
 California,Contra Costa County,2021,1161413,152844.0,111080,1908
 California,Contra Costa County,2022,1156966,115159.0,120061,1971
-California,El Dorado County,2005,175790,0.0,63147,854
+California,El Dorado County,2005,175790,,63147,854
 California,El Dorado County,2006,178066,5827.0,70516,855
 California,El Dorado County,2007,175689,6257.0,64188,850
 California,El Dorado County,2008,176075,5698.0,67660,931
-California,El Dorado County,2009,178447,0.0,70449,990
+California,El Dorado County,2009,178447,,70449,990
 California,El Dorado County,2010,181194,4787.0,66129,981
-California,El Dorado County,2011,180938,0.0,61084,871
+California,El Dorado County,2011,180938,,61084,871
 California,El Dorado County,2012,180561,6492.0,69973,945
 California,El Dorado County,2013,181737,5997.0,61365,866
 California,El Dorado County,2014,183087,5755.0,71113,905
@@ -811,7 +811,7 @@ California,El Dorado County,2017,188987,8420.0,79414,1121
 California,El Dorado County,2018,190678,11837.0,82742,1163
 California,El Dorado County,2019,192843,7232.0,87059,1153
 California,El Dorado County,2021,193221,22047.0,87491,1394
-California,El Dorado County,2022,192646,0.0,105982,1394
+California,El Dorado County,2022,192646,,105982,1394
 California,Fresno County,2005,858948,13696.0,41899,602
 California,Fresno County,2006,891756,11719.0,42732,626
 California,Fresno County,2007,899348,12617.0,47298,679
@@ -829,39 +829,39 @@ California,Fresno County,2018,994400,16028.0,52629,835
 California,Fresno County,2019,999101,21483.0,57518,859
 California,Fresno County,2021,1013581,45810.0,63656,962
 California,Fresno County,2022,1015190,49340.0,69571,1054
-California,Humboldt County,2005,124031,0.0,33093,561
+California,Humboldt County,2005,124031,,33093,561
 California,Humboldt County,2006,128330,3773.0,40749,643
 California,Humboldt County,2007,128864,3887.0,36870,685
-California,Humboldt County,2008,129000,0.0,39750,659
+California,Humboldt County,2008,129000,,39750,659
 California,Humboldt County,2009,129623,3810.0,35745,722
 California,Humboldt County,2010,134794,3183.0,38492,721
 California,Humboldt County,2011,134761,3553.0,41187,757
 California,Humboldt County,2012,134827,3638.0,40682,738
 California,Humboldt County,2013,134493,3487.0,42092,797
 California,Humboldt County,2014,134809,3985.0,40598,799
-California,Humboldt County,2015,135727,0.0,40484,805
+California,Humboldt County,2015,135727,,40484,805
 California,Humboldt County,2016,136646,3971.0,43130,811
 California,Humboldt County,2017,136754,5045.0,46494,800
-California,Humboldt County,2018,136373,0.0,50294,865
+California,Humboldt County,2018,136373,,50294,865
 California,Humboldt County,2019,135558,4778.0,51662,895
-California,Humboldt County,2021,136310,0.0,54752,989
-California,Humboldt County,2022,135010,0.0,57883,1045
-California,Imperial County,2005,144523,0.0,35533,475
-California,Imperial County,2006,160301,0.0,37086,518
+California,Humboldt County,2021,136310,,54752,989
+California,Humboldt County,2022,135010,,57883,1045
+California,Imperial County,2005,144523,,35533,475
+California,Imperial County,2006,160301,,37086,518
 California,Imperial County,2007,161867,1823.0,31912,499
 California,Imperial County,2008,163972,2068.0,37936,545
 California,Imperial County,2009,166874,2917.0,38594,547
-California,Imperial County,2010,175234,0.0,41802,615
+California,Imperial County,2010,175234,,41802,615
 California,Imperial County,2011,177057,2401.0,37843,592
 California,Imperial County,2012,176948,2707.0,40200,595
 California,Imperial County,2013,176584,2417.0,43310,639
 California,Imperial County,2014,179091,1960.0,39290,658
-California,Imperial County,2015,180191,0.0,40852,636
+California,Imperial County,2015,180191,,40852,636
 California,Imperial County,2016,180883,2807.0,49095,652
 California,Imperial County,2017,182830,3603.0,47211,675
-California,Imperial County,2018,181827,0.0,48984,638
-California,Imperial County,2019,181215,0.0,48472,677
-California,Imperial County,2021,179851,0.0,51809,751
+California,Imperial County,2018,181827,,48984,638
+California,Imperial County,2019,181215,,48472,677
+California,Imperial County,2021,179851,,51809,751
 California,Imperial County,2022,178713,2823.0,57310,804
 California,Kern County,2005,724206,7503.0,40224,555
 California,Kern County,2006,780117,8545.0,43106,604
@@ -880,40 +880,40 @@ California,Kern County,2018,896764,13353.0,51579,809
 California,Kern County,2019,900202,12286.0,53067,803
 California,Kern County,2021,917673,31307.0,58217,887
 California,Kern County,2022,916108,25409.0,66234,958
-California,Kings County,2005,121418,0.0,41095,564
+California,Kings County,2005,121418,,41095,564
 California,Kings County,2006,146153,2017.0,43178,559
 California,Kings County,2007,148875,1952.0,46756,595
 California,Kings County,2008,149518,1987.0,50962,750
 California,Kings County,2009,148764,1968.0,44506,690
 California,Kings County,2010,153174,1538.0,44609,692
-California,Kings County,2011,153765,0.0,50345,769
-California,Kings County,2012,151364,0.0,45935,691
+California,Kings County,2011,153765,,50345,769
+California,Kings County,2012,151364,,45935,691
 California,Kings County,2013,150960,1698.0,45774,694
 California,Kings County,2014,150269,2729.0,42784,712
-California,Kings County,2015,150965,0.0,45746,776
+California,Kings County,2015,150965,,45746,776
 California,Kings County,2016,149785,3166.0,53234,754
 California,Kings County,2017,150101,4252.0,57555,735
-California,Kings County,2018,151366,0.0,61663,851
-California,Kings County,2019,152940,0.0,58453,763
-California,Kings County,2021,153443,0.0,62155,927
+California,Kings County,2018,151366,,61663,851
+California,Kings County,2019,152940,,58453,763
+California,Kings County,2021,153443,,62155,927
 California,Kings County,2022,152981,2782.0,64368,1055
-California,Lake County,2005,63962,0.0,40067,589
-California,Lake County,2006,65933,0.0,37628,629
-California,Lake County,2007,64664,0.0,40946,739
-California,Lake County,2008,64866,0.0,40538,665
-California,Lake County,2009,65279,0.0,39343,695
-California,Lake County,2010,64771,0.0,34910,649
-California,Lake County,2011,64323,0.0,35991,791
-California,Lake County,2012,63983,0.0,33219,644
-California,Lake County,2013,63860,0.0,37079,764
-California,Lake County,2014,64184,0.0,34529,759
-California,Lake County,2015,64591,0.0,37294,639
-California,Lake County,2016,64116,0.0,42029,714
-California,Lake County,2017,64246,0.0,48930,767
-California,Lake County,2018,64382,0.0,48554,891
-California,Lake County,2019,64386,0.0,47138,831
-California,Lake County,2021,68766,0.0,61221,920
-California,Lake County,2022,68191,0.0,51259,892
+California,Lake County,2005,63962,,40067,589
+California,Lake County,2006,65933,,37628,629
+California,Lake County,2007,64664,,40946,739
+California,Lake County,2008,64866,,40538,665
+California,Lake County,2009,65279,,39343,695
+California,Lake County,2010,64771,,34910,649
+California,Lake County,2011,64323,,35991,791
+California,Lake County,2012,63983,,33219,644
+California,Lake County,2013,63860,,37079,764
+California,Lake County,2014,64184,,34529,759
+California,Lake County,2015,64591,,37294,639
+California,Lake County,2016,64116,,42029,714
+California,Lake County,2017,64246,,48930,767
+California,Lake County,2018,64382,,48554,891
+California,Lake County,2019,64386,,47138,831
+California,Lake County,2021,68766,,61221,920
+California,Lake County,2022,68191,,51259,892
 California,Los Angeles County,2005,9758886,168484.0,48248,852
 California,Los Angeles County,2006,9948081,185965.0,51315,905
 California,Los Angeles County,2007,9878554,189537.0,53573,957
@@ -931,23 +931,23 @@ California,Los Angeles County,2018,10105518,271838.0,68093,1376
 California,Los Angeles County,2019,10039107,289663.0,72797,1471
 California,Los Angeles County,2021,9829544,946616.0,77456,1595
 California,Los Angeles County,2022,9721138,810443.0,82516,1675
-California,Madera County,2005,134159,0.0,46787,549
-California,Madera County,2006,146345,0.0,39068,667
-California,Madera County,2007,146513,0.0,44975,656
-California,Madera County,2008,148333,0.0,47394,798
-California,Madera County,2009,148632,0.0,44135,721
-California,Madera County,2010,151408,0.0,48268,788
-California,Madera County,2011,152925,0.0,46570,671
-California,Madera County,2012,152218,0.0,42039,780
-California,Madera County,2013,152389,0.0,39758,826
+California,Madera County,2005,134159,,46787,549
+California,Madera County,2006,146345,,39068,667
+California,Madera County,2007,146513,,44975,656
+California,Madera County,2008,148333,,47394,798
+California,Madera County,2009,148632,,44135,721
+California,Madera County,2010,151408,,48268,788
+California,Madera County,2011,152925,,46570,671
+California,Madera County,2012,152218,,42039,780
+California,Madera County,2013,152389,,39758,826
 California,Madera County,2014,154548,1942.0,42433,786
-California,Madera County,2015,154998,0.0,47150,800
+California,Madera County,2015,154998,,47150,800
 California,Madera County,2016,154697,1263.0,51657,819
 California,Madera County,2017,156890,3013.0,51283,819
-California,Madera County,2018,157672,0.0,56305,792
-California,Madera County,2019,157327,0.0,64827,832
-California,Madera County,2021,159410,0.0,63454,873
-California,Madera County,2022,160256,0.0,76920,993
+California,Madera County,2018,157672,,56305,792
+California,Madera County,2019,157327,,64827,832
+California,Madera County,2021,159410,,63454,873
+California,Madera County,2022,160256,,76920,993
 California,Marin County,2005,235609,12073.0,78919,1323
 California,Marin County,2006,248742,11830.0,81761,1383
 California,Marin County,2007,248096,12438.0,83870,1363
@@ -965,24 +965,24 @@ California,Marin County,2018,259666,20469.0,126373,2072
 California,Marin County,2019,258826,17884.0,110843,2011
 California,Marin County,2021,260206,44360.0,118209,2243
 California,Marin County,2022,256018,40124.0,136214,2257
-California,Mendocino County,2005,86011,0.0,41734,649
-California,Mendocino County,2006,88109,0.0,39705,750
-California,Mendocino County,2007,86273,0.0,42941,727
-California,Mendocino County,2008,86221,0.0,43205,727
-California,Mendocino County,2009,86040,0.0,41867,728
-California,Mendocino County,2010,87828,0.0,40536,845
-California,Mendocino County,2011,87553,0.0,42431,857
-California,Mendocino County,2012,87428,0.0,41369,740
-California,Mendocino County,2013,87192,0.0,42042,785
-California,Mendocino County,2014,87869,0.0,42660,818
-California,Mendocino County,2015,87649,0.0,41896,873
-California,Mendocino County,2016,87628,0.0,43809,881
-California,Mendocino County,2017,88018,0.0,53024,958
-California,Mendocino County,2018,87606,0.0,51830,939
-California,Mendocino County,2019,86749,0.0,51744,995
-California,Mendocino County,2021,91305,0.0,59444,985
-California,Mendocino County,2022,89783,0.0,65520,1078
-California,Merced County,2005,237278,0.0,40281,612
+California,Mendocino County,2005,86011,,41734,649
+California,Mendocino County,2006,88109,,39705,750
+California,Mendocino County,2007,86273,,42941,727
+California,Mendocino County,2008,86221,,43205,727
+California,Mendocino County,2009,86040,,41867,728
+California,Mendocino County,2010,87828,,40536,845
+California,Mendocino County,2011,87553,,42431,857
+California,Mendocino County,2012,87428,,41369,740
+California,Mendocino County,2013,87192,,42042,785
+California,Mendocino County,2014,87869,,42660,818
+California,Mendocino County,2015,87649,,41896,873
+California,Mendocino County,2016,87628,,43809,881
+California,Mendocino County,2017,88018,,53024,958
+California,Mendocino County,2018,87606,,51830,939
+California,Mendocino County,2019,86749,,51744,995
+California,Mendocino County,2021,91305,,59444,985
+California,Mendocino County,2022,89783,,65520,1078
+California,Merced County,2005,237278,,40281,612
 California,Merced County,2006,245658,4903.0,40447,658
 California,Merced County,2007,245514,2874.0,44410,662
 California,Merced County,2008,246117,3770.0,42303,619
@@ -1016,7 +1016,7 @@ California,Monterey County,2018,435594,9288.0,70681,1403
 California,Monterey County,2019,434061,9514.0,77514,1523
 California,Monterey County,2021,437325,20522.0,82163,1674
 California,Monterey County,2022,432858,22115.0,92840,1757
-California,Napa County,2005,127445,0.0,65260,992
+California,Napa County,2005,127445,,65260,992
 California,Napa County,2006,133522,4410.0,66645,998
 California,Napa County,2007,132565,3934.0,62081,1074
 California,Napa County,2008,133433,2720.0,65158,1056
@@ -1033,22 +1033,22 @@ California,Napa County,2018,139417,4302.0,87025,1587
 California,Napa County,2019,137744,4241.0,92769,1701
 California,Napa County,2021,136207,12963.0,97213,1721
 California,Napa County,2022,134300,7540.0,100318,1863
-California,Nevada County,2005,97572,0.0,51615,851
-California,Nevada County,2006,98764,0.0,50675,966
-California,Nevada County,2007,97027,0.0,59150,875
-California,Nevada County,2008,97118,0.0,53195,877
-California,Nevada County,2009,97751,0.0,57884,1042
-California,Nevada County,2010,98794,0.0,54456,878
-California,Nevada County,2011,98612,0.0,54080,1009
-California,Nevada County,2012,98292,0.0,53768,1048
-California,Nevada County,2013,98200,0.0,54851,1071
-California,Nevada County,2014,98893,0.0,56917,981
-California,Nevada County,2015,98877,0.0,54177,994
-California,Nevada County,2016,99107,0.0,59022,1082
-California,Nevada County,2017,99814,0.0,65385,1040
-California,Nevada County,2018,99696,0.0,66299,1030
-California,Nevada County,2019,99755,0.0,68818,1213
-California,Nevada County,2021,103487,0.0,79519,1287
+California,Nevada County,2005,97572,,51615,851
+California,Nevada County,2006,98764,,50675,966
+California,Nevada County,2007,97027,,59150,875
+California,Nevada County,2008,97118,,53195,877
+California,Nevada County,2009,97751,,57884,1042
+California,Nevada County,2010,98794,,54456,878
+California,Nevada County,2011,98612,,54080,1009
+California,Nevada County,2012,98292,,53768,1048
+California,Nevada County,2013,98200,,54851,1071
+California,Nevada County,2014,98893,,56917,981
+California,Nevada County,2015,98877,,54177,994
+California,Nevada County,2016,99107,,59022,1082
+California,Nevada County,2017,99814,,65385,1040
+California,Nevada County,2018,99696,,66299,1030
+California,Nevada County,2019,99755,,68818,1213
+California,Nevada County,2021,103487,,79519,1287
 California,Nevada County,2022,102293,9825.0,78401,1335
 California,Orange County,2005,2944537,63312.0,65953,1161
 California,Orange County,2006,3002048,60187.0,70232,1228
@@ -1067,7 +1067,7 @@ California,Orange County,2018,3185968,106014.0,89759,1790
 California,Orange County,2019,3175692,121272.0,95934,1841
 California,Orange County,2021,3167809,338620.0,100559,1958
 California,Orange County,2022,3151184,282211.0,106209,2125
-California,Placer County,2005,314135,0.0,62080,935
+California,Placer County,2005,314135,,62080,935
 California,Placer County,2006,326242,11895.0,70013,939
 California,Placer County,2007,332920,10910.0,69076,959
 California,Placer County,2008,341945,10899.0,75183,1056
@@ -1118,8 +1118,8 @@ California,Sacramento County,2018,1540975,46043.0,69767,1152
 California,Sacramento County,2019,1552058,52374.0,72017,1224
 California,Sacramento County,2021,1588921,162644.0,80063,1355
 California,Sacramento County,2022,1584169,144719.0,84211,1485
-California,San Benito County,2021,66677,0.0,101923,1488
-California,San Benito County,2022,67579,0.0,111544,1448
+California,San Benito County,2021,66677,,101923,1488
+California,San Benito County,2022,67579,,111544,1448
 California,San Bernardino County,2005,1916665,26612.0,49026,817
 California,San Bernardino County,2006,1999332,31800.0,52941,855
 California,San Bernardino County,2007,2007800,34340.0,56428,919
@@ -1203,7 +1203,7 @@ California,San Luis Obispo County,2016,282887,8158.0,70564,1218
 California,San Luis Obispo County,2017,283405,10147.0,71880,1312
 California,San Luis Obispo County,2018,284010,9205.0,71148,1291
 California,San Luis Obispo County,2019,283111,11756.0,77265,1533
-California,San Luis Obispo County,2021,283159,0.0,80615,1600
+California,San Luis Obispo County,2021,283159,,80615,1600
 California,San Luis Obispo County,2022,282013,21445.0,90216,1712
 California,San Mateo County,2005,689271,17688.0,74546,1199
 California,San Mateo County,2006,705499,15867.0,77914,1251
@@ -1273,13 +1273,13 @@ California,Santa Cruz County,2018,274255,10142.0,86941,1610
 California,Santa Cruz County,2019,273213,11389.0,89269,1694
 California,Santa Cruz County,2021,267792,30366.0,93933,1865
 California,Santa Cruz County,2022,264370,25256.0,102146,1920
-California,Shasta County,2005,176570,0.0,42227,610
+California,Shasta County,2005,176570,,42227,610
 California,Shasta County,2006,179951,2720.0,44120,598
 California,Shasta County,2007,179427,3219.0,41901,651
 California,Shasta County,2008,180214,3728.0,42065,687
 California,Shasta County,2009,181099,4389.0,42889,686
 California,Shasta County,2010,177291,4352.0,41023,736
-California,Shasta County,2011,177774,0.0,42062,728
+California,Shasta County,2011,177774,,42062,728
 California,Shasta County,2012,178586,2509.0,45442,754
 California,Shasta County,2013,178980,3814.0,40332,713
 California,Shasta County,2014,179804,3319.0,43706,738
@@ -1288,7 +1288,7 @@ California,Shasta County,2016,179631,4007.0,46724,788
 California,Shasta County,2017,179921,5666.0,52439,805
 California,Shasta County,2018,180040,3119.0,56280,823
 California,Shasta County,2019,180080,4305.0,63091,868
-California,Shasta County,2021,182139,0.0,61125,874
+California,Shasta County,2021,182139,,61125,874
 California,Shasta County,2022,180930,6403.0,68276,900
 California,Solano County,2005,395426,6117.0,62213,989
 California,Solano County,2006,411680,6781.0,61533,965
@@ -1341,26 +1341,26 @@ California,Stanislaus County,2018,549815,12041.0,60321,983
 California,Stanislaus County,2019,550660,9064.0,63037,1046
 California,Stanislaus County,2021,552999,19999.0,73982,1136
 California,Stanislaus County,2022,551275,16921.0,75886,1220
-California,Sutter County,2005,87444,0.0,49913,668
-California,Sutter County,2006,91410,0.0,51688,665
-California,Sutter County,2007,92040,0.0,51382,678
-California,Sutter County,2008,92207,0.0,50021,681
-California,Sutter County,2009,92614,0.0,50333,704
-California,Sutter County,2010,94806,0.0,46521,713
+California,Sutter County,2005,87444,,49913,668
+California,Sutter County,2006,91410,,51688,665
+California,Sutter County,2007,92040,,51382,678
+California,Sutter County,2008,92207,,50021,681
+California,Sutter County,2009,92614,,50333,704
+California,Sutter County,2010,94806,,46521,713
 California,Sutter County,2011,94919,2048.0,49533,715
-California,Sutter County,2012,95022,0.0,47081,744
+California,Sutter County,2012,95022,,47081,744
 California,Sutter County,2013,95350,1543.0,49139,835
-California,Sutter County,2014,95847,0.0,54433,817
-California,Sutter County,2015,96463,0.0,52277,760
-California,Sutter County,2016,96651,0.0,51397,787
-California,Sutter County,2017,96648,0.0,55062,874
-California,Sutter County,2018,96807,0.0,59121,842
-California,Sutter County,2019,96971,0.0,62777,972
-California,Sutter County,2021,99063,0.0,64251,1020
-California,Sutter County,2022,98503,0.0,65018,1168
-California,Tehama County,2019,65084,0.0,53475,824
-California,Tehama County,2021,65498,0.0,48810,806
-California,Tehama County,2022,65245,0.0,58884,839
+California,Sutter County,2014,95847,,54433,817
+California,Sutter County,2015,96463,,52277,760
+California,Sutter County,2016,96651,,51397,787
+California,Sutter County,2017,96648,,55062,874
+California,Sutter County,2018,96807,,59121,842
+California,Sutter County,2019,96971,,62777,972
+California,Sutter County,2021,99063,,64251,1020
+California,Sutter County,2022,98503,,65018,1168
+California,Tehama County,2019,65084,,53475,824
+California,Tehama County,2021,65498,,48810,806
+California,Tehama County,2022,65245,,58884,839
 California,Tulare County,2005,404909,4426.0,38722,508
 California,Tulare County,2006,419909,5691.0,41933,536
 California,Tulare County,2007,421553,4822.0,40595,576
@@ -1412,24 +1412,24 @@ California,Yolo County,2018,220408,7022.0,68670,1185
 California,Yolo County,2019,220500,6481.0,71417,1318
 California,Yolo County,2021,216986,22446.0,78146,1456
 California,Yolo County,2022,222115,16518.0,83875,1613
-California,Yuba County,2005,65818,0.0,37695,586
-California,Yuba County,2006,70396,0.0,38006,602
-California,Yuba County,2007,72098,0.0,42712,624
-California,Yuba County,2008,73067,0.0,51844,713
-California,Yuba County,2009,72925,0.0,45117,688
-California,Yuba County,2010,72388,0.0,45755,707
-California,Yuba County,2011,72578,0.0,43961,628
-California,Yuba County,2012,72926,0.0,43545,760
-California,Yuba County,2013,73340,0.0,43801,768
-California,Yuba County,2014,73966,0.0,42143,759
-California,Yuba County,2015,74492,0.0,50451,767
-California,Yuba County,2016,75275,0.0,49259,786
-California,Yuba County,2017,77031,0.0,63120,846
-California,Yuba County,2018,78041,0.0,46574,767
-California,Yuba County,2019,78668,0.0,58765,839
-California,Yuba County,2021,83421,0.0,63303,854
-California,Yuba County,2022,84310,0.0,65052,915
-Colorado,Adams County,2005,396032,0.0,50650,696
+California,Yuba County,2005,65818,,37695,586
+California,Yuba County,2006,70396,,38006,602
+California,Yuba County,2007,72098,,42712,624
+California,Yuba County,2008,73067,,51844,713
+California,Yuba County,2009,72925,,45117,688
+California,Yuba County,2010,72388,,45755,707
+California,Yuba County,2011,72578,,43961,628
+California,Yuba County,2012,72926,,43545,760
+California,Yuba County,2013,73340,,43801,768
+California,Yuba County,2014,73966,,42143,759
+California,Yuba County,2015,74492,,50451,767
+California,Yuba County,2016,75275,,49259,786
+California,Yuba County,2017,77031,,63120,846
+California,Yuba County,2018,78041,,46574,767
+California,Yuba County,2019,78668,,58765,839
+California,Yuba County,2021,83421,,63303,854
+California,Yuba County,2022,84310,,65052,915
+Colorado,Adams County,2005,396032,,50650,696
 Colorado,Adams County,2006,414338,6621.0,50575,723
 Colorado,Adams County,2007,422495,8238.0,52110,717
 Colorado,Adams County,2008,430836,6629.0,56529,757
@@ -1463,7 +1463,7 @@ Colorado,Arapahoe County,2018,651215,27231.0,76768,1275
 Colorado,Arapahoe County,2019,656590,28705.0,82710,1365
 Colorado,Arapahoe County,2021,654900,89095.0,84386,1456
 Colorado,Arapahoe County,2022,655808,70357.0,93784,1642
-Colorado,Boulder County,2005,271934,0.0,57502,870
+Colorado,Boulder County,2005,271934,,57502,870
 Colorado,Boulder County,2006,282304,12692.0,61748,836
 Colorado,Boulder County,2007,290262,12757.0,63257,832
 Colorado,Boulder County,2008,293161,16242.0,66463,877
@@ -1480,13 +1480,13 @@ Colorado,Boulder County,2018,326078,21481.0,83755,1418
 Colorado,Boulder County,2019,326196,24461.0,88535,1512
 Colorado,Boulder County,2021,329543,62668.0,90168,1667
 Colorado,Boulder County,2022,327468,57679.0,96079,1699
-Colorado,Broomfield County,2015,65065,0.0,84921,1343
-Colorado,Broomfield County,2016,66529,0.0,84349,1405
-Colorado,Broomfield County,2017,68341,0.0,90939,1483
-Colorado,Broomfield County,2018,69267,0.0,95800,1516
-Colorado,Broomfield County,2019,70465,0.0,111400,1723
-Colorado,Broomfield County,2021,75325,0.0,107638,1818
-Colorado,Broomfield County,2022,76121,0.0,115833,1846
+Colorado,Broomfield County,2015,65065,,84921,1343
+Colorado,Broomfield County,2016,66529,,84349,1405
+Colorado,Broomfield County,2017,68341,,90939,1483
+Colorado,Broomfield County,2018,69267,,95800,1516
+Colorado,Broomfield County,2019,70465,,111400,1723
+Colorado,Broomfield County,2021,75325,,107638,1818
+Colorado,Broomfield County,2022,76121,,115833,1846
 Colorado,Denver County,2005,545198,12702.0,42370,629
 Colorado,Denver County,2006,566974,13692.0,40900,639
 Colorado,Denver County,2007,588349,14732.0,44444,654
@@ -1555,7 +1555,7 @@ Colorado,Jefferson County,2018,580233,30032.0,85890,1288
 Colorado,Jefferson County,2019,582881,33837.0,90040,1361
 Colorado,Jefferson County,2021,579581,86886.0,94549,1480
 Colorado,Jefferson County,2022,576143,80736.0,102731,1630
-Colorado,Larimer County,2005,264807,0.0,48686,692
+Colorado,Larimer County,2005,264807,,48686,692
 Colorado,Larimer County,2006,276253,8667.0,53745,669
 Colorado,Larimer County,2007,287574,10000.0,52046,690
 Colorado,Larimer County,2008,292825,11263.0,56331,733
@@ -1572,26 +1572,26 @@ Colorado,Larimer County,2018,350518,18866.0,71091,1254
 Colorado,Larimer County,2019,356899,19155.0,75186,1259
 Colorado,Larimer County,2021,362533,46082.0,78109,1343
 Colorado,Larimer County,2022,366778,37152.0,88403,1471
-Colorado,Mesa County,2005,126588,0.0,39487,562
+Colorado,Mesa County,2005,126588,,39487,562
 Colorado,Mesa County,2006,134189,2842.0,42596,541
 Colorado,Mesa County,2007,139082,3524.0,50954,654
 Colorado,Mesa County,2008,143171,3507.0,55738,744
 Colorado,Mesa County,2009,146093,2673.0,52882,671
-Colorado,Mesa County,2010,146313,0.0,46231,712
+Colorado,Mesa County,2010,146313,,46231,712
 Colorado,Mesa County,2011,147083,2784.0,47664,711
 Colorado,Mesa County,2012,147848,3170.0,45892,666
 Colorado,Mesa County,2013,147554,3842.0,46723,749
-Colorado,Mesa County,2014,148255,0.0,50174,717
+Colorado,Mesa County,2014,148255,,50174,717
 Colorado,Mesa County,2015,148513,3567.0,51465,774
 Colorado,Mesa County,2016,150083,4199.0,48846,807
-Colorado,Mesa County,2017,151616,0.0,52742,798
+Colorado,Mesa County,2017,151616,,52742,798
 Colorado,Mesa County,2018,153207,5733.0,49848,762
-Colorado,Mesa County,2019,154210,0.0,60500,868
+Colorado,Mesa County,2019,154210,,60500,868
 Colorado,Mesa County,2021,157335,11002.0,64055,830
 Colorado,Mesa County,2022,158636,12601.0,70711,1094
-Colorado,Pueblo County,2005,147187,0.0,37305,482
+Colorado,Pueblo County,2005,147187,,37305,482
 Colorado,Pueblo County,2006,152912,2493.0,36834,509
-Colorado,Pueblo County,2007,154538,0.0,41564,500
+Colorado,Pueblo County,2007,154538,,41564,500
 Colorado,Pueblo County,2008,156737,1972.0,42628,526
 Colorado,Pueblo County,2009,157224,2547.0,38780,544
 Colorado,Pueblo County,2010,159477,2028.0,38326,548
@@ -1601,12 +1601,12 @@ Colorado,Pueblo County,2013,161451,2073.0,41218,598
 Colorado,Pueblo County,2014,161875,1255.0,41047,592
 Colorado,Pueblo County,2015,163591,1811.0,40050,605
 Colorado,Pueblo County,2016,165123,1840.0,44677,661
-Colorado,Pueblo County,2017,166475,0.0,43148,646
-Colorado,Pueblo County,2018,167529,0.0,48468,642
+Colorado,Pueblo County,2017,166475,,43148,646
+Colorado,Pueblo County,2018,167529,,48468,642
 Colorado,Pueblo County,2019,168424,2182.0,51276,697
-Colorado,Pueblo County,2021,169622,0.0,56689,789
-Colorado,Pueblo County,2022,169544,0.0,58723,841
-Colorado,Weld County,2005,223966,0.0,48763,591
+Colorado,Pueblo County,2021,169622,,56689,789
+Colorado,Pueblo County,2022,169544,,58723,841
+Colorado,Weld County,2005,223966,,48763,591
 Colorado,Weld County,2006,236857,7387.0,52543,594
 Colorado,Weld County,2007,243750,4752.0,52133,620
 Colorado,Weld County,2008,249775,5756.0,56065,649
@@ -1627,27 +1627,27 @@ Connecticut,Capitol Planning Region,2022,981447,82906.0,84504,1094
 Connecticut,Greater Bridgeport Planning Region,2022,327286,24825.0,81143,1238
 Connecticut,Lower Connecticut River Valley Planning Region,2022,176622,17087.0,99438,1192
 Connecticut,Naugatuck Valley Planning Region,2022,454083,28017.0,81925,962
-Connecticut,Northeastern Connecticut Planning Region,2022,96196,0.0,80701,813
+Connecticut,Northeastern Connecticut Planning Region,2022,96196,,80701,813
 Connecticut,Northwest Hills Planning Region,2022,113234,8644.0,86555,892
 Connecticut,South Central Connecticut Planning Region,2022,573244,39394.0,85026,1201
 Connecticut,Southeastern Connecticut Planning Region,2022,280403,15649.0,80113,1040
 Connecticut,Western Connecticut Planning Region,2022,623690,68154.0,122234,1770
-Delaware,Kent County,2005,140205,0.0,48282,557
-Delaware,Kent County,2006,147601,0.0,47722,640
+Delaware,Kent County,2005,140205,,48282,557
+Delaware,Kent County,2006,147601,,47722,640
 Delaware,Kent County,2007,152255,1219.0,46788,743
 Delaware,Kent County,2008,155415,1771.0,56039,737
 Delaware,Kent County,2009,157741,2198.0,51485,690
-Delaware,Kent County,2010,162912,0.0,54617,804
+Delaware,Kent County,2010,162912,,54617,804
 Delaware,Kent County,2011,164834,2058.0,52512,729
 Delaware,Kent County,2012,167626,2163.0,52894,763
 Delaware,Kent County,2013,169416,3356.0,54794,745
 Delaware,Kent County,2014,171987,2349.0,55227,843
-Delaware,Kent County,2015,173533,0.0,56778,797
-Delaware,Kent County,2016,174827,0.0,54140,809
-Delaware,Kent County,2017,176824,0.0,57608,840
+Delaware,Kent County,2015,173533,,56778,797
+Delaware,Kent County,2016,174827,,54140,809
+Delaware,Kent County,2017,176824,,57608,840
 Delaware,Kent County,2018,178550,3188.0,54419,826
 Delaware,Kent County,2019,180786,3573.0,58001,953
-Delaware,Kent County,2021,184149,0.0,64308,1015
+Delaware,Kent County,2021,184149,,64308,1015
 Delaware,Kent County,2022,186946,6153.0,72675,1063
 Delaware,New Castle County,2005,505271,8159.0,59270,726
 Delaware,New Castle County,2006,525587,6493.0,58043,739
@@ -1666,7 +1666,7 @@ Delaware,New Castle County,2018,559335,13880.0,69479,995
 Delaware,New Castle County,2019,558753,13796.0,76328,985
 Delaware,New Castle County,2021,571708,65129.0,73854,1097
 Delaware,New Castle County,2022,575494,52678.0,86020,1161
-Delaware,Sussex County,2005,173111,0.0,44942,525
+Delaware,Sussex County,2005,173111,,44942,525
 Delaware,Sussex County,2006,180288,2660.0,45876,611
 Delaware,Sussex County,2007,184291,2661.0,50976,598
 Delaware,Sussex County,2008,188036,2065.0,47426,656
@@ -1680,7 +1680,7 @@ Delaware,Sussex County,2015,215622,6747.0,55065,767
 Delaware,Sussex County,2016,220251,5654.0,57734,728
 Delaware,Sussex County,2017,225322,6570.0,61985,803
 Delaware,Sussex County,2018,229286,8671.0,60277,820
-Delaware,Sussex County,2019,234225,0.0,65155,779
+Delaware,Sussex County,2019,234225,,65155,779
 Delaware,Sussex County,2021,247527,12907.0,70556,904
 Delaware,Sussex County,2022,255956,15222.0,81792,897
 District of Columbia,District of Columbia,2005,515118,11110.0,47221,768
@@ -1717,22 +1717,22 @@ Florida,Alachua County,2018,269956,7530.0,51241,851
 Florida,Alachua County,2019,269043,6431.0,49534,838
 Florida,Alachua County,2021,279238,21326.0,56445,957
 Florida,Alachua County,2022,284030,19167.0,58354,1105
-Florida,Bay County,2005,158141,0.0,40701,573
-Florida,Bay County,2006,163505,0.0,45098,616
+Florida,Bay County,2005,158141,,40701,573
+Florida,Bay County,2006,163505,,45098,616
 Florida,Bay County,2007,163984,2052.0,48985,733
-Florida,Bay County,2008,163946,0.0,45736,700
-Florida,Bay County,2009,164767,0.0,44357,716
-Florida,Bay County,2010,169272,0.0,44881,738
-Florida,Bay County,2011,169856,0.0,44310,713
-Florida,Bay County,2012,171903,0.0,46005,730
+Florida,Bay County,2008,163946,,45736,700
+Florida,Bay County,2009,164767,,44357,716
+Florida,Bay County,2010,169272,,44881,738
+Florida,Bay County,2011,169856,,44310,713
+Florida,Bay County,2012,171903,,46005,730
 Florida,Bay County,2013,174987,1430.0,45594,745
 Florida,Bay County,2014,178985,1983.0,44775,728
 Florida,Bay County,2015,181635,3535.0,48259,802
 Florida,Bay County,2016,183974,3015.0,49157,779
-Florida,Bay County,2017,183563,0.0,52415,838
+Florida,Bay County,2017,183563,,52415,838
 Florida,Bay County,2018,185287,3200.0,52107,881
-Florida,Bay County,2019,174705,0.0,59450,1007
-Florida,Bay County,2021,179168,0.0,60557,1072
+Florida,Bay County,2019,174705,,59450,1007
+Florida,Bay County,2021,179168,,60557,1072
 Florida,Bay County,2022,185134,10781.0,66245,1102
 Florida,Brevard County,2005,521226,5760.0,43281,643
 Florida,Brevard County,2006,534359,7668.0,46335,703
@@ -1768,58 +1768,58 @@ Florida,Broward County,2018,1951260,49426.0,57278,1234
 Florida,Broward County,2019,1952778,59582.0,61502,1321
 Florida,Broward County,2021,1930983,161208.0,65747,1379
 Florida,Broward County,2022,1947026,141983.0,70978,1613
-Florida,Charlotte County,2005,154716,0.0,39091,695
-Florida,Charlotte County,2006,154438,0.0,44166,789
-Florida,Charlotte County,2007,152814,0.0,46707,811
-Florida,Charlotte County,2008,150060,0.0,46404,729
-Florida,Charlotte County,2009,156952,0.0,40362,697
-Florida,Charlotte County,2010,159990,0.0,42031,740
-Florida,Charlotte County,2011,160511,0.0,41190,721
-Florida,Charlotte County,2012,162449,0.0,45247,718
-Florida,Charlotte County,2013,164736,0.0,43698,755
-Florida,Charlotte County,2014,168474,0.0,43039,733
-Florida,Charlotte County,2015,173115,0.0,45492,789
-Florida,Charlotte County,2016,178465,0.0,44200,837
-Florida,Charlotte County,2017,182033,0.0,52070,840
-Florida,Charlotte County,2018,184998,0.0,52927,883
-Florida,Charlotte County,2019,188910,0.0,54652,900
-Florida,Charlotte County,2021,194843,0.0,59285,1039
-Florida,Charlotte County,2022,202661,0.0,64860,1118
-Florida,Citrus County,2005,132209,0.0,34084,529
-Florida,Citrus County,2006,138143,0.0,34973,530
-Florida,Citrus County,2007,140169,0.0,35810,589
-Florida,Citrus County,2008,141416,0.0,38137,545
-Florida,Citrus County,2009,140357,0.0,38128,618
-Florida,Citrus County,2010,141129,0.0,35459,620
-Florida,Citrus County,2011,140031,0.0,33764,603
-Florida,Citrus County,2012,139360,0.0,39322,674
-Florida,Citrus County,2013,139271,0.0,40015,623
-Florida,Citrus County,2014,139377,0.0,35671,593
-Florida,Citrus County,2015,141058,0.0,40294,595
-Florida,Citrus County,2016,143621,0.0,39206,659
-Florida,Citrus County,2017,145647,0.0,43548,634
-Florida,Citrus County,2018,147929,0.0,39964,732
-Florida,Citrus County,2019,149657,0.0,50751,739
-Florida,Citrus County,2021,158083,0.0,47197,843
-Florida,Citrus County,2022,162529,0.0,51532,798
-Florida,Clay County,2005,169528,0.0,54055,753
-Florida,Clay County,2006,178899,0.0,60450,742
-Florida,Clay County,2007,182023,0.0,58555,788
+Florida,Charlotte County,2005,154716,,39091,695
+Florida,Charlotte County,2006,154438,,44166,789
+Florida,Charlotte County,2007,152814,,46707,811
+Florida,Charlotte County,2008,150060,,46404,729
+Florida,Charlotte County,2009,156952,,40362,697
+Florida,Charlotte County,2010,159990,,42031,740
+Florida,Charlotte County,2011,160511,,41190,721
+Florida,Charlotte County,2012,162449,,45247,718
+Florida,Charlotte County,2013,164736,,43698,755
+Florida,Charlotte County,2014,168474,,43039,733
+Florida,Charlotte County,2015,173115,,45492,789
+Florida,Charlotte County,2016,178465,,44200,837
+Florida,Charlotte County,2017,182033,,52070,840
+Florida,Charlotte County,2018,184998,,52927,883
+Florida,Charlotte County,2019,188910,,54652,900
+Florida,Charlotte County,2021,194843,,59285,1039
+Florida,Charlotte County,2022,202661,,64860,1118
+Florida,Citrus County,2005,132209,,34084,529
+Florida,Citrus County,2006,138143,,34973,530
+Florida,Citrus County,2007,140169,,35810,589
+Florida,Citrus County,2008,141416,,38137,545
+Florida,Citrus County,2009,140357,,38128,618
+Florida,Citrus County,2010,141129,,35459,620
+Florida,Citrus County,2011,140031,,33764,603
+Florida,Citrus County,2012,139360,,39322,674
+Florida,Citrus County,2013,139271,,40015,623
+Florida,Citrus County,2014,139377,,35671,593
+Florida,Citrus County,2015,141058,,40294,595
+Florida,Citrus County,2016,143621,,39206,659
+Florida,Citrus County,2017,145647,,43548,634
+Florida,Citrus County,2018,147929,,39964,732
+Florida,Citrus County,2019,149657,,50751,739
+Florida,Citrus County,2021,158083,,47197,843
+Florida,Citrus County,2022,162529,,51532,798
+Florida,Clay County,2005,169528,,54055,753
+Florida,Clay County,2006,178899,,60450,742
+Florida,Clay County,2007,182023,,58555,788
 Florida,Clay County,2008,184727,3625.0,61130,787
-Florida,Clay County,2009,186756,0.0,57783,760
-Florida,Clay County,2010,191395,0.0,58263,778
-Florida,Clay County,2011,192370,0.0,54389,826
-Florida,Clay County,2012,194345,0.0,54827,788
-Florida,Clay County,2013,196399,0.0,57757,796
-Florida,Clay County,2014,199798,0.0,58153,816
-Florida,Clay County,2015,203967,0.0,58676,833
-Florida,Clay County,2016,208311,0.0,56315,870
-Florida,Clay County,2017,212230,0.0,65247,943
-Florida,Clay County,2018,216072,0.0,61825,921
+Florida,Clay County,2009,186756,,57783,760
+Florida,Clay County,2010,191395,,58263,778
+Florida,Clay County,2011,192370,,54389,826
+Florida,Clay County,2012,194345,,54827,788
+Florida,Clay County,2013,196399,,57757,796
+Florida,Clay County,2014,199798,,58153,816
+Florida,Clay County,2015,203967,,58676,833
+Florida,Clay County,2016,208311,,56315,870
+Florida,Clay County,2017,212230,,65247,943
+Florida,Clay County,2018,216072,,61825,921
 Florida,Clay County,2019,219252,6420.0,76687,935
-Florida,Clay County,2021,222361,0.0,76679,1144
-Florida,Clay County,2022,226589,0.0,85594,1366
-Florida,Collier County,2005,302514,0.0,52179,876
+Florida,Clay County,2021,222361,,76679,1144
+Florida,Clay County,2022,226589,,85594,1366
+Florida,Collier County,2005,302514,,52179,876
 Florida,Collier County,2006,314649,6701.0,55888,915
 Florida,Collier County,2007,315839,8355.0,57653,922
 Florida,Collier County,2008,315258,9775.0,61165,955
@@ -1836,22 +1836,22 @@ Florida,Collier County,2018,378488,13359.0,69867,1137
 Florida,Collier County,2019,384902,11489.0,76025,1246
 Florida,Collier County,2021,385980,21864.0,74215,1405
 Florida,Collier County,2022,397994,26502.0,80815,1575
-Florida,Columbia County,2006,76170,0.0,40834,459
-Florida,Columbia County,2007,76552,0.0,41321,497
-Florida,Columbia County,2008,72124,0.0,38788,481
-Florida,Columbia County,2009,69263,0.0,37321,615
-Florida,Columbia County,2010,67597,0.0,32488,540
-Florida,Columbia County,2011,67485,0.0,35008,581
-Florida,Columbia County,2012,67966,0.0,36542,602
-Florida,Columbia County,2013,67543,0.0,45220,594
-Florida,Columbia County,2014,67857,0.0,38520,574
-Florida,Columbia County,2015,68348,0.0,47808,599
-Florida,Columbia County,2016,69299,0.0,42019,637
-Florida,Columbia County,2017,69612,0.0,40811,625
-Florida,Columbia County,2018,70503,0.0,48848,682
-Florida,Columbia County,2019,71686,0.0,47094,611
-Florida,Columbia County,2021,70385,0.0,54077,625
-Florida,Columbia County,2022,71908,0.0,53985,753
+Florida,Columbia County,2006,76170,,40834,459
+Florida,Columbia County,2007,76552,,41321,497
+Florida,Columbia County,2008,72124,,38788,481
+Florida,Columbia County,2009,69263,,37321,615
+Florida,Columbia County,2010,67597,,32488,540
+Florida,Columbia County,2011,67485,,35008,581
+Florida,Columbia County,2012,67966,,36542,602
+Florida,Columbia County,2013,67543,,45220,594
+Florida,Columbia County,2014,67857,,38520,574
+Florida,Columbia County,2015,68348,,47808,599
+Florida,Columbia County,2016,69299,,42019,637
+Florida,Columbia County,2017,69612,,40811,625
+Florida,Columbia County,2018,70503,,48848,682
+Florida,Columbia County,2019,71686,,47094,611
+Florida,Columbia County,2021,70385,,54077,625
+Florida,Columbia County,2022,71908,,53985,753
 Florida,Duval County,2005,810698,9346.0,44740,637
 Florida,Duval County,2006,837964,15353.0,45756,643
 Florida,Duval County,2007,849159,10769.0,49230,704
@@ -1869,7 +1869,7 @@ Florida,Duval County,2018,950181,24318.0,55832,912
 Florida,Duval County,2019,957755,29135.0,58415,948
 Florida,Duval County,2021,999935,80071.0,59980,1047
 Florida,Duval County,2022,1016536,90822.0,70533,1237
-Florida,Escambia County,2005,274663,0.0,40384,521
+Florida,Escambia County,2005,274663,,40384,521
 Florida,Escambia County,2006,295426,9099.0,42535,582
 Florida,Escambia County,2007,306407,7669.0,41894,608
 Florida,Escambia County,2008,302939,8121.0,41474,647
@@ -1886,56 +1886,56 @@ Florida,Escambia County,2018,315534,12392.0,51050,742
 Florida,Escambia County,2019,318316,13391.0,53136,800
 Florida,Escambia County,2021,322390,20299.0,54228,873
 Florida,Escambia County,2022,324878,22838.0,61924,1013
-Florida,Flagler County,2005,75757,0.0,44971,815
-Florida,Flagler County,2006,83084,0.0,44461,763
-Florida,Flagler County,2007,88397,0.0,41830,850
-Florida,Flagler County,2008,91247,0.0,46609,824
-Florida,Flagler County,2009,91622,0.0,50180,870
-Florida,Flagler County,2010,95928,0.0,43993,831
-Florida,Flagler County,2011,97376,0.0,46232,856
-Florida,Flagler County,2012,98359,0.0,42856,824
-Florida,Flagler County,2013,99956,0.0,46055,864
-Florida,Flagler County,2014,102408,0.0,51622,850
-Florida,Flagler County,2015,105392,0.0,48864,923
-Florida,Flagler County,2016,108310,0.0,49395,993
-Florida,Flagler County,2017,110510,0.0,49652,1055
-Florida,Flagler County,2018,112067,0.0,58963,1025
-Florida,Flagler County,2019,115081,0.0,60204,1194
-Florida,Flagler County,2021,120932,0.0,62618,1181
-Florida,Flagler County,2022,126705,0.0,71211,1380
-Florida,Hernando County,2005,156325,0.0,38257,573
-Florida,Hernando County,2006,165409,0.0,40347,671
-Florida,Hernando County,2007,169070,0.0,44172,704
-Florida,Hernando County,2008,171689,0.0,38771,679
-Florida,Hernando County,2009,171233,0.0,40728,710
-Florida,Hernando County,2010,173008,0.0,37459,732
-Florida,Hernando County,2011,173094,0.0,41150,675
-Florida,Hernando County,2012,173422,0.0,36515,684
-Florida,Hernando County,2013,174441,0.0,39193,720
-Florida,Hernando County,2014,175855,0.0,40255,724
-Florida,Hernando County,2015,178439,0.0,43590,741
-Florida,Hernando County,2016,182835,0.0,47253,762
-Florida,Hernando County,2017,186553,0.0,44892,790
-Florida,Hernando County,2018,190865,0.0,45977,807
-Florida,Hernando County,2019,193920,0.0,51031,800
-Florida,Hernando County,2021,200638,0.0,56868,876
-Florida,Hernando County,2022,206896,0.0,61462,986
-Florida,Highlands County,2005,94177,0.0,30309,444
-Florida,Highlands County,2006,97987,0.0,32894,545
-Florida,Highlands County,2007,99349,0.0,33047,532
-Florida,Highlands County,2008,100011,0.0,31971,538
-Florida,Highlands County,2009,98704,0.0,33225,556
-Florida,Highlands County,2010,98700,0.0,34561,567
-Florida,Highlands County,2011,98630,0.0,33652,558
-Florida,Highlands County,2012,98128,0.0,34733,629
-Florida,Highlands County,2013,97616,0.0,33811,535
-Florida,Highlands County,2014,98236,0.0,36120,499
-Florida,Highlands County,2015,99491,0.0,34242,590
-Florida,Highlands County,2016,100917,0.0,36490,604
-Florida,Highlands County,2017,102883,0.0,35543,630
-Florida,Highlands County,2018,105424,0.0,39796,642
-Florida,Highlands County,2019,106221,0.0,48698,644
-Florida,Highlands County,2021,103296,0.0,48564,714
+Florida,Flagler County,2005,75757,,44971,815
+Florida,Flagler County,2006,83084,,44461,763
+Florida,Flagler County,2007,88397,,41830,850
+Florida,Flagler County,2008,91247,,46609,824
+Florida,Flagler County,2009,91622,,50180,870
+Florida,Flagler County,2010,95928,,43993,831
+Florida,Flagler County,2011,97376,,46232,856
+Florida,Flagler County,2012,98359,,42856,824
+Florida,Flagler County,2013,99956,,46055,864
+Florida,Flagler County,2014,102408,,51622,850
+Florida,Flagler County,2015,105392,,48864,923
+Florida,Flagler County,2016,108310,,49395,993
+Florida,Flagler County,2017,110510,,49652,1055
+Florida,Flagler County,2018,112067,,58963,1025
+Florida,Flagler County,2019,115081,,60204,1194
+Florida,Flagler County,2021,120932,,62618,1181
+Florida,Flagler County,2022,126705,,71211,1380
+Florida,Hernando County,2005,156325,,38257,573
+Florida,Hernando County,2006,165409,,40347,671
+Florida,Hernando County,2007,169070,,44172,704
+Florida,Hernando County,2008,171689,,38771,679
+Florida,Hernando County,2009,171233,,40728,710
+Florida,Hernando County,2010,173008,,37459,732
+Florida,Hernando County,2011,173094,,41150,675
+Florida,Hernando County,2012,173422,,36515,684
+Florida,Hernando County,2013,174441,,39193,720
+Florida,Hernando County,2014,175855,,40255,724
+Florida,Hernando County,2015,178439,,43590,741
+Florida,Hernando County,2016,182835,,47253,762
+Florida,Hernando County,2017,186553,,44892,790
+Florida,Hernando County,2018,190865,,45977,807
+Florida,Hernando County,2019,193920,,51031,800
+Florida,Hernando County,2021,200638,,56868,876
+Florida,Hernando County,2022,206896,,61462,986
+Florida,Highlands County,2005,94177,,30309,444
+Florida,Highlands County,2006,97987,,32894,545
+Florida,Highlands County,2007,99349,,33047,532
+Florida,Highlands County,2008,100011,,31971,538
+Florida,Highlands County,2009,98704,,33225,556
+Florida,Highlands County,2010,98700,,34561,567
+Florida,Highlands County,2011,98630,,33652,558
+Florida,Highlands County,2012,98128,,34733,629
+Florida,Highlands County,2013,97616,,33811,535
+Florida,Highlands County,2014,98236,,36120,499
+Florida,Highlands County,2015,99491,,34242,590
+Florida,Highlands County,2016,100917,,36490,604
+Florida,Highlands County,2017,102883,,35543,630
+Florida,Highlands County,2018,105424,,39796,642
+Florida,Highlands County,2019,106221,,48698,644
+Florida,Highlands County,2021,103296,,48564,714
 Florida,Highlands County,2022,105618,2571.0,52799,801
 Florida,Hillsborough County,2005,1111717,22276.0,45129,659
 Florida,Hillsborough County,2006,1157738,21477.0,46766,698
@@ -1954,40 +1954,40 @@ Florida,Hillsborough County,2018,1436888,51084.0,58480,1021
 Florida,Hillsborough County,2019,1471968,59777.0,61154,1046
 Florida,Hillsborough County,2021,1478194,161989.0,65905,1198
 Florida,Hillsborough County,2022,1513301,163974.0,74308,1378
-Florida,Indian River County,2005,126258,0.0,45040,737
+Florida,Indian River County,2005,126258,,45040,737
 Florida,Indian River County,2006,130100,2606.0,43685,708
-Florida,Indian River County,2007,131837,0.0,46081,760
-Florida,Indian River County,2008,132315,0.0,46410,735
-Florida,Indian River County,2009,135167,0.0,42712,721
-Florida,Indian River County,2010,138268,0.0,47335,770
+Florida,Indian River County,2007,131837,,46081,760
+Florida,Indian River County,2008,132315,,46410,735
+Florida,Indian River County,2009,135167,,42712,721
+Florida,Indian River County,2010,138268,,47335,770
 Florida,Indian River County,2011,138894,2129.0,39767,635
-Florida,Indian River County,2012,140567,0.0,40413,659
-Florida,Indian River County,2013,141994,0.0,42401,736
-Florida,Indian River County,2014,144755,0.0,46238,755
-Florida,Indian River County,2015,147919,0.0,49379,765
-Florida,Indian River County,2016,151563,0.0,49072,782
-Florida,Indian River County,2017,154383,0.0,49177,777
-Florida,Indian River County,2018,157413,0.0,57508,824
-Florida,Indian River County,2019,159923,0.0,59782,877
-Florida,Indian River County,2021,163662,0.0,58972,985
+Florida,Indian River County,2012,140567,,40413,659
+Florida,Indian River County,2013,141994,,42401,736
+Florida,Indian River County,2014,144755,,46238,755
+Florida,Indian River County,2015,147919,,49379,765
+Florida,Indian River County,2016,151563,,49072,782
+Florida,Indian River County,2017,154383,,49177,777
+Florida,Indian River County,2018,157413,,57508,824
+Florida,Indian River County,2019,159923,,59782,877
+Florida,Indian River County,2021,163662,,58972,985
 Florida,Indian River County,2022,167352,10326.0,67407,1150
-Florida,Lake County,2005,273277,0.0,39698,618
+Florida,Lake County,2005,273277,,39698,618
 Florida,Lake County,2006,290435,4532.0,41871,614
-Florida,Lake County,2007,301059,0.0,46797,687
+Florida,Lake County,2007,301059,,46797,687
 Florida,Lake County,2008,307243,5176.0,45020,718
 Florida,Lake County,2009,312119,6412.0,42081,723
 Florida,Lake County,2010,297950,4880.0,42033,765
 Florida,Lake County,2011,301019,4962.0,45454,772
 Florida,Lake County,2012,303186,5036.0,41083,771
-Florida,Lake County,2013,308034,0.0,44026,693
+Florida,Lake County,2013,308034,,44026,693
 Florida,Lake County,2014,315690,8346.0,47191,780
-Florida,Lake County,2015,325875,0.0,50305,824
+Florida,Lake County,2015,325875,,50305,824
 Florida,Lake County,2016,335396,8136.0,50226,819
-Florida,Lake County,2017,346017,0.0,51383,852
-Florida,Lake County,2018,356495,0.0,52096,845
-Florida,Lake County,2019,367118,0.0,57588,929
+Florida,Lake County,2017,346017,,51383,852
+Florida,Lake County,2018,356495,,52096,845
+Florida,Lake County,2019,367118,,57588,929
 Florida,Lake County,2021,395804,23661.0,64795,1197
-Florida,Lake County,2022,410139,0.0,67559,1196
+Florida,Lake County,2022,410139,,67559,1196
 Florida,Lee County,2005,539097,8419.0,46053,744
 Florida,Lee County,2006,571344,12456.0,48553,820
 Florida,Lee County,2007,590564,11940.0,50699,866
@@ -2005,7 +2005,7 @@ Florida,Lee County,2018,754610,18474.0,56129,1061
 Florida,Lee County,2019,770577,26326.0,62240,1075
 Florida,Lee County,2021,787976,50828.0,66256,1180
 Florida,Lee County,2022,822453,53495.0,71072,1441
-Florida,Leon County,2005,233649,0.0,43180,575
+Florida,Leon County,2005,233649,,43180,575
 Florida,Leon County,2006,245625,2426.0,41516,631
 Florida,Leon County,2007,260945,3024.0,49234,658
 Florida,Leon County,2008,264063,3605.0,47000,670
@@ -2039,12 +2039,12 @@ Florida,Manatee County,2018,394855,13692.0,59956,1019
 Florida,Manatee County,2019,403253,14593.0,64499,1096
 Florida,Manatee County,2021,412703,28860.0,68172,1190
 Florida,Manatee County,2022,429125,30741.0,72108,1335
-Florida,Marion County,2005,295555,0.0,36116,516
+Florida,Marion County,2005,295555,,36116,516
 Florida,Marion County,2006,316183,5406.0,40062,588
 Florida,Marion County,2007,324857,6329.0,39294,580
 Florida,Marion County,2008,329628,4454.0,40170,693
 Florida,Marion County,2009,328547,5075.0,39035,611
-Florida,Marion County,2010,331290,0.0,37044,639
+Florida,Marion County,2010,331290,,37044,639
 Florida,Marion County,2011,332529,5717.0,36255,602
 Florida,Marion County,2012,335125,5459.0,37098,607
 Florida,Marion County,2013,337362,8346.0,38695,623
@@ -2052,27 +2052,27 @@ Florida,Marion County,2014,339167,6498.0,39958,629
 Florida,Marion County,2015,343254,6548.0,40050,618
 Florida,Marion County,2016,349020,8331.0,39383,682
 Florida,Marion County,2017,354353,7090.0,43910,692
-Florida,Marion County,2018,359977,0.0,44576,713
-Florida,Marion County,2019,365579,0.0,49576,804
+Florida,Marion County,2018,359977,,44576,713
+Florida,Marion County,2019,365579,,49576,804
 Florida,Marion County,2021,385915,14365.0,55161,860
 Florida,Marion County,2022,396415,18504.0,54190,911
-Florida,Martin County,2005,136138,0.0,45511,759
-Florida,Martin County,2006,139393,0.0,50939,860
+Florida,Martin County,2005,136138,,45511,759
+Florida,Martin County,2006,139393,,50939,860
 Florida,Martin County,2007,139182,2223.0,55472,858
-Florida,Martin County,2008,138660,0.0,51930,889
-Florida,Martin County,2009,139794,0.0,49530,874
-Florida,Martin County,2010,146393,0.0,48311,777
-Florida,Martin County,2011,147495,0.0,50022,784
+Florida,Martin County,2008,138660,,51930,889
+Florida,Martin County,2009,139794,,49530,874
+Florida,Martin County,2010,146393,,48311,777
+Florida,Martin County,2011,147495,,50022,784
 Florida,Martin County,2012,148817,2988.0,44821,796
-Florida,Martin County,2013,151263,0.0,49444,813
-Florida,Martin County,2014,153392,0.0,55866,927
-Florida,Martin County,2015,156283,0.0,51622,886
-Florida,Martin County,2016,158701,0.0,54620,887
-Florida,Martin County,2017,159923,0.0,54681,959
-Florida,Martin County,2018,160912,0.0,59978,1008
-Florida,Martin County,2019,161000,0.0,70842,1043
-Florida,Martin County,2021,159942,0.0,64625,1122
-Florida,Martin County,2022,162006,0.0,80024,1480
+Florida,Martin County,2013,151263,,49444,813
+Florida,Martin County,2014,153392,,55866,927
+Florida,Martin County,2015,156283,,51622,886
+Florida,Martin County,2016,158701,,54620,887
+Florida,Martin County,2017,159923,,54681,959
+Florida,Martin County,2018,160912,,59978,1008
+Florida,Martin County,2019,161000,,70842,1043
+Florida,Martin County,2021,159942,,64625,1122
+Florida,Martin County,2022,162006,,80024,1480
 Florida,Miami-Dade County,2005,2329187,25716.0,37148,723
 Florida,Miami-Dade County,2006,2402208,36033.0,41237,781
 Florida,Miami-Dade County,2007,2387170,38030.0,43650,854
@@ -2090,51 +2090,51 @@ Florida,Miami-Dade County,2018,2761581,72028.0,52205,1211
 Florida,Miami-Dade County,2019,2716940,75504.0,55171,1284
 Florida,Miami-Dade County,2021,2662777,193449.0,59044,1389
 Florida,Miami-Dade County,2022,2673837,202679.0,67263,1527
-Florida,Monroe County,2005,75074,0.0,49040,1001
+Florida,Monroe County,2005,75074,,49040,1001
 Florida,Monroe County,2006,74737,2625.0,52069,1084
-Florida,Monroe County,2007,73223,0.0,60642,1012
-Florida,Monroe County,2008,72243,0.0,52443,1051
-Florida,Monroe County,2009,73165,0.0,49721,1094
-Florida,Monroe County,2010,73269,0.0,50619,1174
-Florida,Monroe County,2011,73873,0.0,51524,1083
+Florida,Monroe County,2007,73223,,60642,1012
+Florida,Monroe County,2008,72243,,52443,1051
+Florida,Monroe County,2009,73165,,49721,1094
+Florida,Monroe County,2010,73269,,50619,1174
+Florida,Monroe County,2011,73873,,51524,1083
 Florida,Monroe County,2012,74809,1665.0,53637,1176
-Florida,Monroe County,2013,76351,0.0,50838,1096
-Florida,Monroe County,2014,77136,0.0,59388,1266
+Florida,Monroe County,2013,76351,,50838,1096
+Florida,Monroe County,2014,77136,,59388,1266
 Florida,Monroe County,2015,77482,1888.0,61020,1219
 Florida,Monroe County,2016,79077,2846.0,65717,1470
-Florida,Monroe County,2017,77013,0.0,65747,1508
+Florida,Monroe County,2017,77013,,65747,1508
 Florida,Monroe County,2018,75027,1814.0,71973,1551
-Florida,Monroe County,2019,74228,0.0,68589,1443
-Florida,Monroe County,2021,82170,0.0,68563,1623
+Florida,Monroe County,2019,74228,,68589,1443
+Florida,Monroe County,2021,82170,,68563,1623
 Florida,Monroe County,2022,81708,5721.0,79420,1467
-Florida,Nassau County,2006,66707,0.0,55925,705
-Florida,Nassau County,2007,68450,0.0,55978,695
-Florida,Nassau County,2008,69835,0.0,59634,698
-Florida,Nassau County,2009,70576,0.0,49830,709
-Florida,Nassau County,2010,73473,0.0,60729,719
-Florida,Nassau County,2011,74195,0.0,52466,914
-Florida,Nassau County,2012,74629,0.0,53230,810
-Florida,Nassau County,2013,75710,0.0,54330,846
-Florida,Nassau County,2014,76619,0.0,52249,896
-Florida,Nassau County,2015,78444,0.0,52005,847
-Florida,Nassau County,2016,80622,0.0,71515,918
-Florida,Nassau County,2017,82721,0.0,71489,883
-Florida,Nassau County,2018,85832,0.0,63913,766
-Florida,Nassau County,2019,88625,0.0,70939,1015
-Florida,Nassau County,2021,94189,0.0,75981,1206
-Florida,Nassau County,2022,97899,0.0,90883,1461
-Florida,Okaloosa County,2005,177284,0.0,50899,627
+Florida,Nassau County,2006,66707,,55925,705
+Florida,Nassau County,2007,68450,,55978,695
+Florida,Nassau County,2008,69835,,59634,698
+Florida,Nassau County,2009,70576,,49830,709
+Florida,Nassau County,2010,73473,,60729,719
+Florida,Nassau County,2011,74195,,52466,914
+Florida,Nassau County,2012,74629,,53230,810
+Florida,Nassau County,2013,75710,,54330,846
+Florida,Nassau County,2014,76619,,52249,896
+Florida,Nassau County,2015,78444,,52005,847
+Florida,Nassau County,2016,80622,,71515,918
+Florida,Nassau County,2017,82721,,71489,883
+Florida,Nassau County,2018,85832,,63913,766
+Florida,Nassau County,2019,88625,,70939,1015
+Florida,Nassau County,2021,94189,,75981,1206
+Florida,Nassau County,2022,97899,,90883,1461
+Florida,Okaloosa County,2005,177284,,50899,627
 Florida,Okaloosa County,2006,180291,2402.0,54422,727
 Florida,Okaloosa County,2007,181499,3198.0,55543,809
-Florida,Okaloosa County,2008,179693,0.0,56088,796
+Florida,Okaloosa County,2008,179693,,56088,796
 Florida,Okaloosa County,2009,178473,3342.0,49207,755
-Florida,Okaloosa County,2010,180728,0.0,51529,779
+Florida,Okaloosa County,2010,180728,,51529,779
 Florida,Okaloosa County,2011,183482,2447.0,49158,750
 Florida,Okaloosa County,2012,190083,1833.0,52787,795
 Florida,Okaloosa County,2013,193811,2304.0,55139,814
-Florida,Okaloosa County,2014,196512,0.0,57640,845
-Florida,Okaloosa County,2015,198664,0.0,55659,849
-Florida,Okaloosa County,2016,201170,0.0,60026,844
+Florida,Okaloosa County,2014,196512,,57640,845
+Florida,Okaloosa County,2015,198664,,55659,849
+Florida,Okaloosa County,2016,201170,,60026,844
 Florida,Okaloosa County,2017,202970,3100.0,61866,882
 Florida,Okaloosa County,2018,207269,5220.0,63997,933
 Florida,Okaloosa County,2019,210738,5032.0,64222,981
@@ -2157,7 +2157,7 @@ Florida,Orange County,2018,1380645,30860.0,58588,1075
 Florida,Orange County,2019,1393452,47839.0,63461,1175
 Florida,Orange County,2021,1422746,132738.0,64833,1275
 Florida,Orange County,2022,1452726,145731.0,72324,1455
-Florida,Osceola County,2005,229134,0.0,41035,733
+Florida,Osceola County,2005,229134,,41035,733
 Florida,Osceola County,2006,244045,3440.0,44951,775
 Florida,Osceola County,2007,255815,3733.0,48332,855
 Florida,Osceola County,2008,263676,5737.0,45972,848
@@ -2168,7 +2168,7 @@ Florida,Osceola County,2012,287416,4041.0,42915,800
 Florida,Osceola County,2013,298504,4004.0,41361,835
 Florida,Osceola County,2014,310211,6361.0,42899,887
 Florida,Osceola County,2015,323993,5709.0,45244,913
-Florida,Osceola County,2016,336015,0.0,51436,927
+Florida,Osceola County,2016,336015,,51436,927
 Florida,Osceola County,2017,352180,6522.0,49762,1015
 Florida,Osceola County,2018,367990,7440.0,50546,1096
 Florida,Osceola County,2019,375751,11719.0,51760,1176
@@ -2242,75 +2242,75 @@ Florida,Polk County,2018,708009,12425.0,51670,786
 Florida,Polk County,2019,724777,11957.0,51833,823
 Florida,Polk County,2021,753520,39739.0,56379,920
 Florida,Polk County,2022,787404,42260.0,62051,1030
-Florida,Putnam County,2005,72148,0.0,31260,416
-Florida,Putnam County,2006,74083,0.0,30771,423
-Florida,Putnam County,2007,73821,0.0,32621,413
-Florida,Putnam County,2008,73459,0.0,36162,419
-Florida,Putnam County,2009,72893,0.0,30278,455
-Florida,Putnam County,2010,74262,0.0,33842,481
-Florida,Putnam County,2011,74041,0.0,30440,511
-Florida,Putnam County,2012,73263,0.0,34025,526
-Florida,Putnam County,2013,72577,0.0,32295,478
-Florida,Putnam County,2014,72143,0.0,30765,559
-Florida,Putnam County,2015,72023,0.0,31483,520
-Florida,Putnam County,2016,72277,0.0,38239,610
-Florida,Putnam County,2017,73464,0.0,33790,491
-Florida,Putnam County,2018,74163,0.0,41608,617
-Florida,Putnam County,2019,74521,0.0,42899,622
-Florida,Putnam County,2021,74167,0.0,33370,654
-Florida,Putnam County,2022,74731,0.0,46161,689
-Florida,St. Johns County,2005,159235,0.0,57261,697
-Florida,St. Johns County,2006,169224,0.0,55715,804
-Florida,St. Johns County,2007,175446,0.0,62677,857
-Florida,St. Johns County,2008,181540,0.0,67056,896
-Florida,St. Johns County,2009,187436,0.0,60900,816
-Florida,St. Johns County,2010,191323,0.0,58888,915
-Florida,St. Johns County,2011,195823,0.0,62510,885
+Florida,Putnam County,2005,72148,,31260,416
+Florida,Putnam County,2006,74083,,30771,423
+Florida,Putnam County,2007,73821,,32621,413
+Florida,Putnam County,2008,73459,,36162,419
+Florida,Putnam County,2009,72893,,30278,455
+Florida,Putnam County,2010,74262,,33842,481
+Florida,Putnam County,2011,74041,,30440,511
+Florida,Putnam County,2012,73263,,34025,526
+Florida,Putnam County,2013,72577,,32295,478
+Florida,Putnam County,2014,72143,,30765,559
+Florida,Putnam County,2015,72023,,31483,520
+Florida,Putnam County,2016,72277,,38239,610
+Florida,Putnam County,2017,73464,,33790,491
+Florida,Putnam County,2018,74163,,41608,617
+Florida,Putnam County,2019,74521,,42899,622
+Florida,Putnam County,2021,74167,,33370,654
+Florida,Putnam County,2022,74731,,46161,689
+Florida,St. Johns County,2005,159235,,57261,697
+Florida,St. Johns County,2006,169224,,55715,804
+Florida,St. Johns County,2007,175446,,62677,857
+Florida,St. Johns County,2008,181540,,67056,896
+Florida,St. Johns County,2009,187436,,60900,816
+Florida,St. Johns County,2010,191323,,58888,915
+Florida,St. Johns County,2011,195823,,62510,885
 Florida,St. Johns County,2012,202188,5977.0,61288,917
-Florida,St. Johns County,2013,209647,0.0,64862,931
-Florida,St. Johns County,2014,217919,0.0,65976,1038
+Florida,St. Johns County,2013,209647,,64862,931
+Florida,St. Johns County,2014,217919,,65976,1038
 Florida,St. Johns County,2015,226640,4057.0,70379,1019
 Florida,St. Johns County,2016,235087,10459.0,78581,1143
-Florida,St. Johns County,2017,243812,0.0,73836,1133
-Florida,St. Johns County,2018,254261,0.0,80712,1103
-Florida,St. Johns County,2019,264672,0.0,90356,1196
-Florida,St. Johns County,2021,292466,0.0,91602,1487
-Florida,St. Johns County,2022,306841,0.0,103017,1477
-Florida,St. Lucie County,2005,238575,0.0,42847,714
-Florida,St. Lucie County,2006,252724,0.0,44974,807
-Florida,St. Lucie County,2007,260939,0.0,46411,913
+Florida,St. Johns County,2017,243812,,73836,1133
+Florida,St. Johns County,2018,254261,,80712,1103
+Florida,St. Johns County,2019,264672,,90356,1196
+Florida,St. Johns County,2021,292466,,91602,1487
+Florida,St. Johns County,2022,306841,,103017,1477
+Florida,St. Lucie County,2005,238575,,42847,714
+Florida,St. Lucie County,2006,252724,,44974,807
+Florida,St. Lucie County,2007,260939,,46411,913
 Florida,St. Lucie County,2008,265108,3869.0,44414,844
-Florida,St. Lucie County,2009,266502,0.0,44739,840
-Florida,St. Lucie County,2010,278689,0.0,38671,751
-Florida,St. Lucie County,2011,280379,0.0,40898,742
+Florida,St. Lucie County,2009,266502,,44739,840
+Florida,St. Lucie County,2010,278689,,38671,751
+Florida,St. Lucie County,2011,280379,,40898,742
 Florida,St. Lucie County,2012,283866,7613.0,41785,760
-Florida,St. Lucie County,2013,286832,0.0,42504,813
+Florida,St. Lucie County,2013,286832,,42504,813
 Florida,St. Lucie County,2014,291028,6533.0,42359,846
 Florida,St. Lucie County,2015,298563,3823.0,45905,838
 Florida,St. Lucie County,2016,306507,5931.0,44804,980
 Florida,St. Lucie County,2017,313506,5130.0,50062,1016
 Florida,St. Lucie County,2018,321128,7998.0,54098,1149
-Florida,St. Lucie County,2019,328297,0.0,58039,1074
-Florida,St. Lucie County,2021,343579,0.0,62797,1159
+Florida,St. Lucie County,2019,328297,,58039,1074
+Florida,St. Lucie County,2021,343579,,62797,1159
 Florida,St. Lucie County,2022,358704,20095.0,62705,1180
-Florida,Santa Rosa County,2005,140650,0.0,46930,632
-Florida,Santa Rosa County,2006,144561,0.0,53086,577
+Florida,Santa Rosa County,2005,140650,,46930,632
+Florida,Santa Rosa County,2006,144561,,53086,577
 Florida,Santa Rosa County,2007,147044,2044.0,50341,582
-Florida,Santa Rosa County,2008,150053,0.0,54262,693
-Florida,Santa Rosa County,2009,151759,0.0,54201,809
-Florida,Santa Rosa County,2010,151966,0.0,50517,671
-Florida,Santa Rosa County,2011,154104,0.0,53103,821
-Florida,Santa Rosa County,2012,158512,0.0,61031,820
-Florida,Santa Rosa County,2013,161096,0.0,54843,785
-Florida,Santa Rosa County,2014,163422,0.0,60317,759
-Florida,Santa Rosa County,2015,167040,0.0,59682,809
-Florida,Santa Rosa County,2016,170497,0.0,63619,853
-Florida,Santa Rosa County,2017,174272,0.0,66059,872
-Florida,Santa Rosa County,2018,179349,0.0,70787,915
-Florida,Santa Rosa County,2019,184313,0.0,64930,967
-Florida,Santa Rosa County,2021,193998,0.0,82059,1079
-Florida,Santa Rosa County,2022,198268,0.0,83672,1201
-Florida,Sarasota County,2005,359783,0.0,44505,760
+Florida,Santa Rosa County,2008,150053,,54262,693
+Florida,Santa Rosa County,2009,151759,,54201,809
+Florida,Santa Rosa County,2010,151966,,50517,671
+Florida,Santa Rosa County,2011,154104,,53103,821
+Florida,Santa Rosa County,2012,158512,,61031,820
+Florida,Santa Rosa County,2013,161096,,54843,785
+Florida,Santa Rosa County,2014,163422,,60317,759
+Florida,Santa Rosa County,2015,167040,,59682,809
+Florida,Santa Rosa County,2016,170497,,63619,853
+Florida,Santa Rosa County,2017,174272,,66059,872
+Florida,Santa Rosa County,2018,179349,,70787,915
+Florida,Santa Rosa County,2019,184313,,64930,967
+Florida,Santa Rosa County,2021,193998,,82059,1079
+Florida,Santa Rosa County,2022,198268,,83672,1201
+Florida,Sarasota County,2005,359783,,44505,760
 Florida,Sarasota County,2006,369535,9792.0,48416,848
 Florida,Sarasota County,2007,372073,8509.0,49735,866
 Florida,Sarasota County,2008,372057,10431.0,48582,858
@@ -2344,23 +2344,23 @@ Florida,Seminole County,2018,467832,17547.0,67470,1123
 Florida,Seminole County,2019,471826,20961.0,70190,1179
 Florida,Seminole County,2021,470093,61569.0,70236,1275
 Florida,Seminole County,2022,478772,57762.0,80550,1467
-Florida,Sumter County,2006,68769,0.0,42949,415
-Florida,Sumter County,2007,72246,0.0,42020,525
-Florida,Sumter County,2008,74721,0.0,47250,520
-Florida,Sumter County,2009,77681,0.0,46520,687
-Florida,Sumter County,2010,94074,0.0,45026,508
-Florida,Sumter County,2011,97756,0.0,43996,657
-Florida,Sumter County,2012,101620,0.0,45173,623
-Florida,Sumter County,2013,107056,0.0,52891,704
-Florida,Sumter County,2014,114350,0.0,50942,603
-Florida,Sumter County,2015,118891,0.0,51335,653
-Florida,Sumter County,2016,123996,0.0,54562,774
-Florida,Sumter County,2017,125165,0.0,54057,640
-Florida,Sumter County,2018,128754,0.0,53895,755
-Florida,Sumter County,2019,132420,0.0,60287,1092
-Florida,Sumter County,2021,135638,0.0,64608,909
-Florida,Sumter County,2022,144970,0.0,73391,1353
-Florida,Volusia County,2005,475189,0.0,38462,646
+Florida,Sumter County,2006,68769,,42949,415
+Florida,Sumter County,2007,72246,,42020,525
+Florida,Sumter County,2008,74721,,47250,520
+Florida,Sumter County,2009,77681,,46520,687
+Florida,Sumter County,2010,94074,,45026,508
+Florida,Sumter County,2011,97756,,43996,657
+Florida,Sumter County,2012,101620,,45173,623
+Florida,Sumter County,2013,107056,,52891,704
+Florida,Sumter County,2014,114350,,50942,603
+Florida,Sumter County,2015,118891,,51335,653
+Florida,Sumter County,2016,123996,,54562,774
+Florida,Sumter County,2017,125165,,54057,640
+Florida,Sumter County,2018,128754,,53895,755
+Florida,Sumter County,2019,132420,,60287,1092
+Florida,Sumter County,2021,135638,,64608,909
+Florida,Sumter County,2022,144970,,73391,1353
+Florida,Volusia County,2005,475189,,38462,646
 Florida,Volusia County,2006,496575,6607.0,40881,700
 Florida,Volusia County,2007,500413,10744.0,42276,717
 Florida,Volusia County,2008,498036,10848.0,46139,750
@@ -2377,104 +2377,104 @@ Florida,Volusia County,2018,547538,20948.0,50361,889
 Florida,Volusia County,2019,553284,18636.0,53766,913
 Florida,Volusia County,2021,564412,36430.0,58380,986
 Florida,Volusia County,2022,579192,41061.0,64857,1239
-Florida,Walton County,2016,65889,0.0,56246,774
-Florida,Walton County,2017,68376,0.0,51620,671
-Florida,Walton County,2018,71375,0.0,62914,720
-Florida,Walton County,2019,74071,0.0,60457,962
-Florida,Walton County,2021,80069,0.0,61787,1362
-Florida,Walton County,2022,83304,0.0,74629,1210
-Georgia,Barrow County,2007,65955,0.0,50357,659
-Georgia,Barrow County,2008,64349,0.0,44532,557
-Georgia,Barrow County,2009,72158,0.0,46180,609
-Georgia,Barrow County,2010,69731,0.0,54230,665
-Georgia,Barrow County,2011,69912,0.0,50490,661
-Georgia,Barrow County,2012,70169,0.0,47582,632
-Georgia,Barrow County,2013,71453,0.0,56051,669
-Georgia,Barrow County,2014,73240,0.0,47834,693
-Georgia,Barrow County,2015,75370,0.0,53156,760
-Georgia,Barrow County,2016,77126,0.0,54256,726
-Georgia,Barrow County,2017,79061,0.0,59994,676
-Georgia,Barrow County,2018,80809,0.0,61225,768
-Georgia,Barrow County,2019,83240,0.0,69890,812
-Georgia,Barrow County,2021,86658,0.0,65273,884
-Georgia,Barrow County,2022,89299,0.0,78216,865
-Georgia,Bartow County,2005,88189,0.0,46964,596
-Georgia,Bartow County,2006,91266,0.0,45894,543
-Georgia,Bartow County,2007,92834,0.0,46410,553
-Georgia,Bartow County,2008,94913,0.0,52133,612
-Georgia,Bartow County,2009,96217,0.0,46202,617
-Georgia,Bartow County,2010,100195,0.0,42844,545
-Georgia,Bartow County,2011,100421,0.0,44034,566
-Georgia,Bartow County,2012,100661,0.0,46187,653
-Georgia,Bartow County,2013,101273,0.0,45191,574
-Georgia,Bartow County,2014,101736,0.0,53675,639
-Georgia,Bartow County,2015,102747,0.0,50572,660
-Georgia,Bartow County,2016,103807,0.0,51405,653
-Georgia,Bartow County,2017,105054,0.0,54218,710
-Georgia,Bartow County,2018,106408,0.0,57380,658
-Georgia,Bartow County,2019,107738,0.0,59911,785
-Georgia,Bartow County,2021,110843,0.0,71523,908
-Georgia,Bartow County,2022,112816,0.0,84590,881
-Georgia,Bibb County,2005,149248,0.0,33203,416
-Georgia,Bibb County,2006,154903,0.0,36459,468
-Georgia,Bibb County,2007,154709,0.0,35463,440
-Georgia,Bibb County,2008,155216,0.0,41581,483
-Georgia,Bibb County,2009,156060,0.0,37707,503
-Georgia,Bibb County,2010,155715,0.0,35651,516
-Georgia,Bibb County,2011,156433,0.0,33878,513
+Florida,Walton County,2016,65889,,56246,774
+Florida,Walton County,2017,68376,,51620,671
+Florida,Walton County,2018,71375,,62914,720
+Florida,Walton County,2019,74071,,60457,962
+Florida,Walton County,2021,80069,,61787,1362
+Florida,Walton County,2022,83304,,74629,1210
+Georgia,Barrow County,2007,65955,,50357,659
+Georgia,Barrow County,2008,64349,,44532,557
+Georgia,Barrow County,2009,72158,,46180,609
+Georgia,Barrow County,2010,69731,,54230,665
+Georgia,Barrow County,2011,69912,,50490,661
+Georgia,Barrow County,2012,70169,,47582,632
+Georgia,Barrow County,2013,71453,,56051,669
+Georgia,Barrow County,2014,73240,,47834,693
+Georgia,Barrow County,2015,75370,,53156,760
+Georgia,Barrow County,2016,77126,,54256,726
+Georgia,Barrow County,2017,79061,,59994,676
+Georgia,Barrow County,2018,80809,,61225,768
+Georgia,Barrow County,2019,83240,,69890,812
+Georgia,Barrow County,2021,86658,,65273,884
+Georgia,Barrow County,2022,89299,,78216,865
+Georgia,Bartow County,2005,88189,,46964,596
+Georgia,Bartow County,2006,91266,,45894,543
+Georgia,Bartow County,2007,92834,,46410,553
+Georgia,Bartow County,2008,94913,,52133,612
+Georgia,Bartow County,2009,96217,,46202,617
+Georgia,Bartow County,2010,100195,,42844,545
+Georgia,Bartow County,2011,100421,,44034,566
+Georgia,Bartow County,2012,100661,,46187,653
+Georgia,Bartow County,2013,101273,,45191,574
+Georgia,Bartow County,2014,101736,,53675,639
+Georgia,Bartow County,2015,102747,,50572,660
+Georgia,Bartow County,2016,103807,,51405,653
+Georgia,Bartow County,2017,105054,,54218,710
+Georgia,Bartow County,2018,106408,,57380,658
+Georgia,Bartow County,2019,107738,,59911,785
+Georgia,Bartow County,2021,110843,,71523,908
+Georgia,Bartow County,2022,112816,,84590,881
+Georgia,Bibb County,2005,149248,,33203,416
+Georgia,Bibb County,2006,154903,,36459,468
+Georgia,Bibb County,2007,154709,,35463,440
+Georgia,Bibb County,2008,155216,,41581,483
+Georgia,Bibb County,2009,156060,,37707,503
+Georgia,Bibb County,2010,155715,,35651,516
+Georgia,Bibb County,2011,156433,,33878,513
 Georgia,Bibb County,2012,156462,1027.0,36120,535
 Georgia,Bibb County,2013,154721,1308.0,36327,549
 Georgia,Bibb County,2014,153905,1753.0,35397,560
 Georgia,Bibb County,2015,153721,1787.0,38605,561
-Georgia,Bibb County,2016,152760,0.0,36724,572
+Georgia,Bibb County,2016,152760,,36724,572
 Georgia,Bibb County,2017,152862,1650.0,37444,619
-Georgia,Bibb County,2018,153095,0.0,40495,659
+Georgia,Bibb County,2018,153095,,40495,659
 Georgia,Bibb County,2019,153159,2536.0,42140,648
-Georgia,Bibb County,2021,156762,0.0,48176,699
-Georgia,Bibb County,2022,156197,0.0,47625,787
-Georgia,Bulloch County,2007,66176,0.0,34135,457
-Georgia,Bulloch County,2008,67761,0.0,39490,420
-Georgia,Bulloch County,2009,69213,0.0,32185,461
-Georgia,Bulloch County,2010,70729,0.0,29170,547
-Georgia,Bulloch County,2011,72881,0.0,32251,563
-Georgia,Bulloch County,2012,72694,0.0,35856,542
-Georgia,Bulloch County,2013,71214,0.0,36153,550
-Georgia,Bulloch County,2014,72087,0.0,32841,612
-Georgia,Bulloch County,2015,72651,0.0,33477,583
-Georgia,Bulloch County,2016,74722,0.0,43982,547
+Georgia,Bibb County,2021,156762,,48176,699
+Georgia,Bibb County,2022,156197,,47625,787
+Georgia,Bulloch County,2007,66176,,34135,457
+Georgia,Bulloch County,2008,67761,,39490,420
+Georgia,Bulloch County,2009,69213,,32185,461
+Georgia,Bulloch County,2010,70729,,29170,547
+Georgia,Bulloch County,2011,72881,,32251,563
+Georgia,Bulloch County,2012,72694,,35856,542
+Georgia,Bulloch County,2013,71214,,36153,550
+Georgia,Bulloch County,2014,72087,,32841,612
+Georgia,Bulloch County,2015,72651,,33477,583
+Georgia,Bulloch County,2016,74722,,43982,547
 Georgia,Bulloch County,2017,76149,1863.0,42138,640
-Georgia,Bulloch County,2018,77296,0.0,44179,594
-Georgia,Bulloch County,2019,79608,0.0,50436,620
-Georgia,Bulloch County,2021,82442,0.0,57656,726
-Georgia,Bulloch County,2022,83059,0.0,47297,723
-Georgia,Carroll County,2005,101762,0.0,44051,491
-Georgia,Carroll County,2006,107325,0.0,43138,550
-Georgia,Carroll County,2007,111954,0.0,41899,528
-Georgia,Carroll County,2008,113688,0.0,47203,513
-Georgia,Carroll County,2009,114778,0.0,45380,602
-Georgia,Carroll County,2010,110661,0.0,46032,525
-Georgia,Carroll County,2011,111159,0.0,42858,545
-Georgia,Carroll County,2012,111580,0.0,43134,611
-Georgia,Carroll County,2013,112355,0.0,45682,612
-Georgia,Carroll County,2014,114093,0.0,40744,601
-Georgia,Carroll County,2015,114545,0.0,43410,618
-Georgia,Carroll County,2016,116261,0.0,51228,617
-Georgia,Carroll County,2017,117812,0.0,50100,642
-Georgia,Carroll County,2018,118121,0.0,51545,663
-Georgia,Carroll County,2019,119992,0.0,61133,717
-Georgia,Carroll County,2021,121968,0.0,58473,739
+Georgia,Bulloch County,2018,77296,,44179,594
+Georgia,Bulloch County,2019,79608,,50436,620
+Georgia,Bulloch County,2021,82442,,57656,726
+Georgia,Bulloch County,2022,83059,,47297,723
+Georgia,Carroll County,2005,101762,,44051,491
+Georgia,Carroll County,2006,107325,,43138,550
+Georgia,Carroll County,2007,111954,,41899,528
+Georgia,Carroll County,2008,113688,,47203,513
+Georgia,Carroll County,2009,114778,,45380,602
+Georgia,Carroll County,2010,110661,,46032,525
+Georgia,Carroll County,2011,111159,,42858,545
+Georgia,Carroll County,2012,111580,,43134,611
+Georgia,Carroll County,2013,112355,,45682,612
+Georgia,Carroll County,2014,114093,,40744,601
+Georgia,Carroll County,2015,114545,,43410,618
+Georgia,Carroll County,2016,116261,,51228,617
+Georgia,Carroll County,2017,117812,,50100,642
+Georgia,Carroll County,2018,118121,,51545,663
+Georgia,Carroll County,2019,119992,,61133,717
+Georgia,Carroll County,2021,121968,,58473,739
 Georgia,Carroll County,2022,124592,6210.0,72595,862
-Georgia,Catoosa County,2012,65046,0.0,42251,496
-Georgia,Catoosa County,2013,65311,0.0,51608,618
-Georgia,Catoosa County,2014,65621,0.0,52412,623
-Georgia,Catoosa County,2015,66050,0.0,51012,549
-Georgia,Catoosa County,2016,66398,0.0,55717,570
-Georgia,Catoosa County,2017,66550,0.0,53231,591
-Georgia,Catoosa County,2018,67420,0.0,56364,621
-Georgia,Catoosa County,2019,67580,0.0,61487,642
-Georgia,Catoosa County,2021,68397,0.0,65576,701
-Georgia,Catoosa County,2022,68826,0.0,67081,823
-Georgia,Chatham County,2005,227915,0.0,42784,605
+Georgia,Catoosa County,2012,65046,,42251,496
+Georgia,Catoosa County,2013,65311,,51608,618
+Georgia,Catoosa County,2014,65621,,52412,623
+Georgia,Catoosa County,2015,66050,,51012,549
+Georgia,Catoosa County,2016,66398,,55717,570
+Georgia,Catoosa County,2017,66550,,53231,591
+Georgia,Catoosa County,2018,67420,,56364,621
+Georgia,Catoosa County,2019,67580,,61487,642
+Georgia,Catoosa County,2021,68397,,65576,701
+Georgia,Catoosa County,2022,68826,,67081,823
+Georgia,Chatham County,2005,227915,,42784,605
 Georgia,Chatham County,2006,241411,2081.0,39910,601
 Georgia,Chatham County,2007,248469,3476.0,45647,648
 Georgia,Chatham County,2008,251120,4082.0,45081,701
@@ -2491,41 +2491,41 @@ Georgia,Chatham County,2018,289195,6033.0,55308,879
 Georgia,Chatham County,2019,289430,8320.0,57611,896
 Georgia,Chatham County,2021,296329,13978.0,61843,1012
 Georgia,Chatham County,2022,301107,17291.0,64157,1151
-Georgia,Cherokee County,2005,182816,0.0,62551,732
-Georgia,Cherokee County,2006,195327,0.0,64416,734
-Georgia,Cherokee County,2007,204363,0.0,60786,744
+Georgia,Cherokee County,2005,182816,,62551,732
+Georgia,Cherokee County,2006,195327,,64416,734
+Georgia,Cherokee County,2007,204363,,60786,744
 Georgia,Cherokee County,2008,210529,11504.0,67320,766
-Georgia,Cherokee County,2009,215084,0.0,64922,817
+Georgia,Cherokee County,2009,215084,,64922,817
 Georgia,Cherokee County,2010,215129,8340.0,61834,755
-Georgia,Cherokee County,2011,218286,0.0,62515,742
-Georgia,Cherokee County,2012,221315,0.0,66993,788
-Georgia,Cherokee County,2013,225106,0.0,64705,814
-Georgia,Cherokee County,2014,230985,0.0,69711,845
-Georgia,Cherokee County,2015,235900,0.0,74104,865
+Georgia,Cherokee County,2011,218286,,62515,742
+Georgia,Cherokee County,2012,221315,,66993,788
+Georgia,Cherokee County,2013,225106,,64705,814
+Georgia,Cherokee County,2014,230985,,69711,845
+Georgia,Cherokee County,2015,235900,,74104,865
 Georgia,Cherokee County,2016,241689,10852.0,77950,943
-Georgia,Cherokee County,2017,247573,0.0,76368,1066
-Georgia,Cherokee County,2018,254149,0.0,82069,1074
-Georgia,Cherokee County,2019,258773,0.0,86404,1102
-Georgia,Cherokee County,2021,274615,0.0,96267,1264
+Georgia,Cherokee County,2017,247573,,76368,1066
+Georgia,Cherokee County,2018,254149,,82069,1074
+Georgia,Cherokee County,2019,258773,,86404,1102
+Georgia,Cherokee County,2021,274615,,96267,1264
 Georgia,Cherokee County,2022,281278,34269.0,99234,1416
-Georgia,Clarke County,2005,95217,0.0,30017,529
+Georgia,Clarke County,2005,95217,,30017,529
 Georgia,Clarke County,2006,112787,1435.0,30574,545
 Georgia,Clarke County,2007,114063,2051.0,36391,570
 Georgia,Clarke County,2008,114737,2160.0,36076,576
 Georgia,Clarke County,2009,116342,1459.0,32422,620
 Georgia,Clarke County,2010,116668,3379.0,34230,568
 Georgia,Clarke County,2011,117344,1964.0,28843,577
-Georgia,Clarke County,2012,120266,0.0,32571,605
-Georgia,Clarke County,2013,121265,0.0,31551,641
+Georgia,Clarke County,2012,120266,,32571,605
+Georgia,Clarke County,2013,121265,,31551,641
 Georgia,Clarke County,2014,120938,1593.0,29996,650
 Georgia,Clarke County,2015,123912,1802.0,31284,641
 Georgia,Clarke County,2016,124707,2925.0,34999,656
 Georgia,Clarke County,2017,127064,4913.0,39825,707
 Georgia,Clarke County,2018,127330,2787.0,42232,709
 Georgia,Clarke County,2019,128331,3644.0,39799,725
-Georgia,Clarke County,2021,128711,0.0,50447,891
+Georgia,Clarke County,2021,128711,,50447,891
 Georgia,Clarke County,2022,129875,8797.0,47171,911
-Georgia,Clayton County,2005,264231,0.0,41021,643
+Georgia,Clayton County,2005,264231,,41021,643
 Georgia,Clayton County,2006,271240,3378.0,41968,649
 Georgia,Clayton County,2007,272217,1623.0,43568,687
 Georgia,Clayton County,2008,273718,4092.0,46357,686
@@ -2540,8 +2540,8 @@ Georgia,Clayton County,2016,279462,6209.0,45252,723
 Georgia,Clayton County,2017,285153,4674.0,45172,761
 Georgia,Clayton County,2018,289615,5351.0,46646,785
 Georgia,Clayton County,2019,292256,6666.0,51093,856
-Georgia,Clayton County,2021,297100,0.0,51233,987
-Georgia,Clayton County,2022,296564,0.0,58325,1140
+Georgia,Clayton County,2021,297100,,51233,987
+Georgia,Clayton County,2022,296564,,58325,1140
 Georgia,Cobb County,2005,653715,18218.0,62423,699
 Georgia,Cobb County,2006,679325,19382.0,61682,711
 Georgia,Cobb County,2007,691905,19244.0,64817,761
@@ -2559,40 +2559,40 @@ Georgia,Cobb County,2018,756865,36438.0,78894,1065
 Georgia,Cobb County,2019,760141,41087.0,79601,1106
 Georgia,Cobb County,2021,766802,111919.0,88029,1245
 Georgia,Cobb County,2022,771952,102794.0,97084,1458
-Georgia,Columbia County,2005,103069,0.0,65507,593
-Georgia,Columbia County,2006,106887,0.0,62695,601
-Georgia,Columbia County,2007,109100,0.0,68263,659
-Georgia,Columbia County,2008,110627,0.0,64462,733
-Georgia,Columbia County,2009,112958,0.0,68851,762
-Georgia,Columbia County,2010,124815,0.0,62359,601
-Georgia,Columbia County,2011,128112,0.0,61718,838
-Georgia,Columbia County,2012,131627,0.0,68118,863
-Georgia,Columbia County,2013,135416,0.0,72167,981
-Georgia,Columbia County,2014,139257,0.0,66925,866
-Georgia,Columbia County,2015,144052,0.0,75440,955
-Georgia,Columbia County,2016,147450,0.0,72737,851
-Georgia,Columbia County,2017,151579,0.0,74164,900
-Georgia,Columbia County,2018,154291,0.0,82024,964
-Georgia,Columbia County,2019,156714,0.0,88761,928
-Georgia,Columbia County,2021,159639,0.0,84220,936
-Georgia,Columbia County,2022,162419,0.0,93307,1098
-Georgia,Coweta County,2005,109108,0.0,54811,670
-Georgia,Coweta County,2006,115291,0.0,62680,609
-Georgia,Coweta County,2007,118936,0.0,57923,652
-Georgia,Coweta County,2008,122924,0.0,60565,697
-Georgia,Coweta County,2009,127111,0.0,59341,674
-Georgia,Coweta County,2010,127955,0.0,55343,678
-Georgia,Coweta County,2011,129629,0.0,54792,667
-Georgia,Coweta County,2012,130929,0.0,61414,729
-Georgia,Coweta County,2013,133180,0.0,61351,715
+Georgia,Columbia County,2005,103069,,65507,593
+Georgia,Columbia County,2006,106887,,62695,601
+Georgia,Columbia County,2007,109100,,68263,659
+Georgia,Columbia County,2008,110627,,64462,733
+Georgia,Columbia County,2009,112958,,68851,762
+Georgia,Columbia County,2010,124815,,62359,601
+Georgia,Columbia County,2011,128112,,61718,838
+Georgia,Columbia County,2012,131627,,68118,863
+Georgia,Columbia County,2013,135416,,72167,981
+Georgia,Columbia County,2014,139257,,66925,866
+Georgia,Columbia County,2015,144052,,75440,955
+Georgia,Columbia County,2016,147450,,72737,851
+Georgia,Columbia County,2017,151579,,74164,900
+Georgia,Columbia County,2018,154291,,82024,964
+Georgia,Columbia County,2019,156714,,88761,928
+Georgia,Columbia County,2021,159639,,84220,936
+Georgia,Columbia County,2022,162419,,93307,1098
+Georgia,Coweta County,2005,109108,,54811,670
+Georgia,Coweta County,2006,115291,,62680,609
+Georgia,Coweta County,2007,118936,,57923,652
+Georgia,Coweta County,2008,122924,,60565,697
+Georgia,Coweta County,2009,127111,,59341,674
+Georgia,Coweta County,2010,127955,,55343,678
+Georgia,Coweta County,2011,129629,,54792,667
+Georgia,Coweta County,2012,130929,,61414,729
+Georgia,Coweta County,2013,133180,,61351,715
 Georgia,Coweta County,2014,135571,2808.0,59506,724
-Georgia,Coweta County,2015,138427,0.0,67351,801
-Georgia,Coweta County,2016,140526,0.0,71220,755
-Georgia,Coweta County,2017,143114,0.0,72787,849
-Georgia,Coweta County,2018,145864,0.0,69240,868
-Georgia,Coweta County,2019,148509,0.0,78423,961
-Georgia,Coweta County,2021,149956,0.0,84788,1081
-Georgia,Coweta County,2022,152882,0.0,84747,1165
+Georgia,Coweta County,2015,138427,,67351,801
+Georgia,Coweta County,2016,140526,,71220,755
+Georgia,Coweta County,2017,143114,,72787,849
+Georgia,Coweta County,2018,145864,,69240,868
+Georgia,Coweta County,2019,148509,,78423,961
+Georgia,Coweta County,2021,149956,,84788,1081
+Georgia,Coweta County,2022,152882,,84747,1165
 Georgia,DeKalb County,2005,662973,13716.0,47398,677
 Georgia,DeKalb County,2006,723602,14780.0,50373,712
 Georgia,DeKalb County,2007,737093,16058.0,51706,735
@@ -2610,92 +2610,92 @@ Georgia,DeKalb County,2018,756558,30951.0,64461,989
 Georgia,DeKalb County,2019,759297,34665.0,63652,1061
 Georgia,DeKalb County,2021,757718,101881.0,70985,1190
 Georgia,DeKalb County,2022,762820,89390.0,77169,1360
-Georgia,Dougherty County,2005,90508,0.0,39790,391
-Georgia,Dougherty County,2006,94773,0.0,31183,413
-Georgia,Dougherty County,2007,95693,0.0,32208,424
-Georgia,Dougherty County,2008,95754,0.0,36692,403
-Georgia,Dougherty County,2009,95859,0.0,33906,463
-Georgia,Dougherty County,2010,94577,0.0,28444,475
-Georgia,Dougherty County,2011,94788,0.0,28424,473
-Georgia,Dougherty County,2012,94501,0.0,30532,470
-Georgia,Dougherty County,2013,92969,0.0,30504,463
-Georgia,Dougherty County,2014,92407,0.0,31755,481
-Georgia,Dougherty County,2015,91332,0.0,35645,497
-Georgia,Dougherty County,2016,90017,0.0,37222,506
-Georgia,Dougherty County,2017,89502,0.0,38712,482
-Georgia,Dougherty County,2018,91243,0.0,39659,506
-Georgia,Dougherty County,2019,87956,0.0,35062,519
-Georgia,Dougherty County,2021,84844,0.0,42067,604
-Georgia,Dougherty County,2022,82966,0.0,41425,626
-Georgia,Douglas County,2005,111765,0.0,52916,666
-Georgia,Douglas County,2006,119557,0.0,55860,682
-Georgia,Douglas County,2007,124495,0.0,55626,717
-Georgia,Douglas County,2008,127932,0.0,58523,761
+Georgia,Dougherty County,2005,90508,,39790,391
+Georgia,Dougherty County,2006,94773,,31183,413
+Georgia,Dougherty County,2007,95693,,32208,424
+Georgia,Dougherty County,2008,95754,,36692,403
+Georgia,Dougherty County,2009,95859,,33906,463
+Georgia,Dougherty County,2010,94577,,28444,475
+Georgia,Dougherty County,2011,94788,,28424,473
+Georgia,Dougherty County,2012,94501,,30532,470
+Georgia,Dougherty County,2013,92969,,30504,463
+Georgia,Dougherty County,2014,92407,,31755,481
+Georgia,Dougherty County,2015,91332,,35645,497
+Georgia,Dougherty County,2016,90017,,37222,506
+Georgia,Dougherty County,2017,89502,,38712,482
+Georgia,Dougherty County,2018,91243,,39659,506
+Georgia,Dougherty County,2019,87956,,35062,519
+Georgia,Dougherty County,2021,84844,,42067,604
+Georgia,Dougherty County,2022,82966,,41425,626
+Georgia,Douglas County,2005,111765,,52916,666
+Georgia,Douglas County,2006,119557,,55860,682
+Georgia,Douglas County,2007,124495,,55626,717
+Georgia,Douglas County,2008,127932,,58523,761
 Georgia,Douglas County,2009,129703,2640.0,49544,693
 Georgia,Douglas County,2010,132722,2205.0,53092,732
-Georgia,Douglas County,2011,133355,0.0,49282,743
-Georgia,Douglas County,2012,133971,0.0,49981,697
-Georgia,Douglas County,2013,136379,0.0,50281,768
-Georgia,Douglas County,2014,138776,0.0,54826,778
-Georgia,Douglas County,2015,140733,0.0,59329,780
-Georgia,Douglas County,2016,142224,0.0,62445,816
-Georgia,Douglas County,2017,143882,0.0,61094,820
-Georgia,Douglas County,2018,145331,0.0,60829,883
-Georgia,Douglas County,2019,146343,0.0,62669,933
-Georgia,Douglas County,2021,145814,0.0,65046,1108
-Georgia,Douglas County,2022,147316,0.0,80933,1293
-Georgia,Effingham County,2021,66741,0.0,74460,817
-Georgia,Effingham County,2022,69041,0.0,89885,799
-Georgia,Fayette County,2005,103643,0.0,76421,740
-Georgia,Fayette County,2006,106671,0.0,79969,786
-Georgia,Fayette County,2007,106144,0.0,76789,816
-Georgia,Fayette County,2008,106465,0.0,81068,835
-Georgia,Fayette County,2009,106788,0.0,76633,853
-Georgia,Fayette County,2010,106945,0.0,79659,858
-Georgia,Fayette County,2011,107784,0.0,72962,845
-Georgia,Fayette County,2012,107524,0.0,77670,903
-Georgia,Fayette County,2013,108365,0.0,81394,840
-Georgia,Fayette County,2014,109664,0.0,77016,893
-Georgia,Fayette County,2015,110714,0.0,78557,864
-Georgia,Fayette County,2016,111627,0.0,80626,1146
-Georgia,Fayette County,2017,112549,0.0,84742,1111
-Georgia,Fayette County,2018,113459,0.0,93468,1089
-Georgia,Fayette County,2019,114421,0.0,92172,1208
-Georgia,Fayette County,2021,120574,0.0,90806,1460
-Georgia,Fayette County,2022,122030,0.0,108643,1512
-Georgia,Floyd County,2005,90124,0.0,35980,382
-Georgia,Floyd County,2006,95322,0.0,37882,447
-Georgia,Floyd County,2007,95618,0.0,42972,454
-Georgia,Floyd County,2008,95980,0.0,41618,465
-Georgia,Floyd County,2009,96250,0.0,38957,506
-Georgia,Floyd County,2010,96274,0.0,36934,472
-Georgia,Floyd County,2011,95989,0.0,40963,477
-Georgia,Floyd County,2012,96177,0.0,37841,503
-Georgia,Floyd County,2013,95821,0.0,37296,459
-Georgia,Floyd County,2014,96063,0.0,41752,476
-Georgia,Floyd County,2015,96504,0.0,40510,501
-Georgia,Floyd County,2016,96560,0.0,49865,550
-Georgia,Floyd County,2017,97613,0.0,45854,544
-Georgia,Floyd County,2018,97927,0.0,38462,536
-Georgia,Floyd County,2019,98498,0.0,50880,564
-Georgia,Floyd County,2021,98771,0.0,60825,640
-Georgia,Floyd County,2022,99443,0.0,56420,725
-Georgia,Forsyth County,2005,139501,0.0,82478,741
-Georgia,Forsyth County,2006,150968,0.0,83682,807
-Georgia,Forsyth County,2007,158914,0.0,84872,846
-Georgia,Forsyth County,2008,168060,0.0,87904,881
+Georgia,Douglas County,2011,133355,,49282,743
+Georgia,Douglas County,2012,133971,,49981,697
+Georgia,Douglas County,2013,136379,,50281,768
+Georgia,Douglas County,2014,138776,,54826,778
+Georgia,Douglas County,2015,140733,,59329,780
+Georgia,Douglas County,2016,142224,,62445,816
+Georgia,Douglas County,2017,143882,,61094,820
+Georgia,Douglas County,2018,145331,,60829,883
+Georgia,Douglas County,2019,146343,,62669,933
+Georgia,Douglas County,2021,145814,,65046,1108
+Georgia,Douglas County,2022,147316,,80933,1293
+Georgia,Effingham County,2021,66741,,74460,817
+Georgia,Effingham County,2022,69041,,89885,799
+Georgia,Fayette County,2005,103643,,76421,740
+Georgia,Fayette County,2006,106671,,79969,786
+Georgia,Fayette County,2007,106144,,76789,816
+Georgia,Fayette County,2008,106465,,81068,835
+Georgia,Fayette County,2009,106788,,76633,853
+Georgia,Fayette County,2010,106945,,79659,858
+Georgia,Fayette County,2011,107784,,72962,845
+Georgia,Fayette County,2012,107524,,77670,903
+Georgia,Fayette County,2013,108365,,81394,840
+Georgia,Fayette County,2014,109664,,77016,893
+Georgia,Fayette County,2015,110714,,78557,864
+Georgia,Fayette County,2016,111627,,80626,1146
+Georgia,Fayette County,2017,112549,,84742,1111
+Georgia,Fayette County,2018,113459,,93468,1089
+Georgia,Fayette County,2019,114421,,92172,1208
+Georgia,Fayette County,2021,120574,,90806,1460
+Georgia,Fayette County,2022,122030,,108643,1512
+Georgia,Floyd County,2005,90124,,35980,382
+Georgia,Floyd County,2006,95322,,37882,447
+Georgia,Floyd County,2007,95618,,42972,454
+Georgia,Floyd County,2008,95980,,41618,465
+Georgia,Floyd County,2009,96250,,38957,506
+Georgia,Floyd County,2010,96274,,36934,472
+Georgia,Floyd County,2011,95989,,40963,477
+Georgia,Floyd County,2012,96177,,37841,503
+Georgia,Floyd County,2013,95821,,37296,459
+Georgia,Floyd County,2014,96063,,41752,476
+Georgia,Floyd County,2015,96504,,40510,501
+Georgia,Floyd County,2016,96560,,49865,550
+Georgia,Floyd County,2017,97613,,45854,544
+Georgia,Floyd County,2018,97927,,38462,536
+Georgia,Floyd County,2019,98498,,50880,564
+Georgia,Floyd County,2021,98771,,60825,640
+Georgia,Floyd County,2022,99443,,56420,725
+Georgia,Forsyth County,2005,139501,,82478,741
+Georgia,Forsyth County,2006,150968,,83682,807
+Georgia,Forsyth County,2007,158914,,84872,846
+Georgia,Forsyth County,2008,168060,,87904,881
 Georgia,Forsyth County,2009,174520,6552.0,83000,906
-Georgia,Forsyth County,2010,176738,0.0,79825,877
-Georgia,Forsyth County,2011,181840,0.0,82209,908
-Georgia,Forsyth County,2012,187928,0.0,85494,936
-Georgia,Forsyth County,2013,195405,0.0,86052,965
+Georgia,Forsyth County,2010,176738,,79825,877
+Georgia,Forsyth County,2011,181840,,82209,908
+Georgia,Forsyth County,2012,187928,,85494,936
+Georgia,Forsyth County,2013,195405,,86052,965
 Georgia,Forsyth County,2014,204302,8168.0,85639,1004
 Georgia,Forsyth County,2015,212438,11046.0,94537,1076
 Georgia,Forsyth County,2016,221009,12627.0,100909,1070
-Georgia,Forsyth County,2017,227967,0.0,102084,1275
+Georgia,Forsyth County,2017,227967,,102084,1275
 Georgia,Forsyth County,2018,236612,13855.0,104687,1220
 Georgia,Forsyth County,2019,244252,15580.0,112108,1327
-Georgia,Forsyth County,2021,260206,0.0,118814,1705
+Georgia,Forsyth County,2021,260206,,118814,1705
 Georgia,Forsyth County,2022,267237,46216.0,129410,1689
 Georgia,Fulton County,2005,884079,24942.0,52465,685
 Georgia,Fulton County,2006,960009,28950.0,54755,713
@@ -2714,23 +2714,23 @@ Georgia,Fulton County,2018,1050114,51441.0,70930,1067
 Georgia,Fulton County,2019,1063937,58633.0,80013,1181
 Georgia,Fulton County,2021,1065334,203012.0,83192,1293
 Georgia,Fulton County,2022,1074634,169842.0,90346,1455
-Georgia,Glynn County,2005,70373,0.0,40272,468
-Georgia,Glynn County,2006,73630,0.0,51244,537
-Georgia,Glynn County,2007,74932,0.0,46459,613
-Georgia,Glynn County,2008,75884,0.0,55567,544
-Georgia,Glynn County,2009,76820,0.0,47751,588
-Georgia,Glynn County,2010,79816,0.0,41854,621
-Georgia,Glynn County,2011,80386,0.0,45726,603
-Georgia,Glynn County,2012,81022,0.0,44708,609
-Georgia,Glynn County,2013,81508,0.0,41502,666
-Georgia,Glynn County,2014,82175,0.0,47333,637
-Georgia,Glynn County,2015,83579,0.0,46125,648
-Georgia,Glynn County,2016,84502,0.0,48926,661
-Georgia,Glynn County,2017,85282,0.0,50998,696
-Georgia,Glynn County,2018,85219,0.0,55196,798
-Georgia,Glynn County,2019,85292,0.0,59004,635
-Georgia,Glynn County,2021,84739,0.0,61984,829
-Georgia,Glynn County,2022,85079,0.0,63228,874
+Georgia,Glynn County,2005,70373,,40272,468
+Georgia,Glynn County,2006,73630,,51244,537
+Georgia,Glynn County,2007,74932,,46459,613
+Georgia,Glynn County,2008,75884,,55567,544
+Georgia,Glynn County,2009,76820,,47751,588
+Georgia,Glynn County,2010,79816,,41854,621
+Georgia,Glynn County,2011,80386,,45726,603
+Georgia,Glynn County,2012,81022,,44708,609
+Georgia,Glynn County,2013,81508,,41502,666
+Georgia,Glynn County,2014,82175,,47333,637
+Georgia,Glynn County,2015,83579,,46125,648
+Georgia,Glynn County,2016,84502,,48926,661
+Georgia,Glynn County,2017,85282,,50998,696
+Georgia,Glynn County,2018,85219,,55196,798
+Georgia,Glynn County,2019,85292,,59004,635
+Georgia,Glynn County,2021,84739,,61984,829
+Georgia,Glynn County,2022,85079,,63228,874
 Georgia,Gwinnett County,2005,719398,17690.0,61365,726
 Georgia,Gwinnett County,2006,757104,21965.0,63189,747
 Georgia,Gwinnett County,2007,776380,17780.0,63818,774
@@ -2748,90 +2748,90 @@ Georgia,Gwinnett County,2018,927781,26574.0,72184,1122
 Georgia,Gwinnett County,2019,936250,37524.0,72109,1163
 Georgia,Gwinnett County,2021,964546,98692.0,74622,1279
 Georgia,Gwinnett County,2022,975353,80444.0,83901,1452
-Georgia,Hall County,2005,163204,0.0,48347,629
-Georgia,Hall County,2006,173256,0.0,44668,621
+Georgia,Hall County,2005,163204,,48347,629
+Georgia,Hall County,2006,173256,,44668,621
 Georgia,Hall County,2007,180175,2549.0,51797,643
 Georgia,Hall County,2008,184814,4315.0,52825,645
-Georgia,Hall County,2009,187743,0.0,49015,604
-Georgia,Hall County,2010,180253,0.0,47002,643
-Georgia,Hall County,2011,183052,0.0,50108,639
+Georgia,Hall County,2009,187743,,49015,604
+Georgia,Hall County,2010,180253,,47002,643
+Georgia,Hall County,2011,183052,,50108,639
 Georgia,Hall County,2012,185416,2656.0,49737,658
 Georgia,Hall County,2013,187745,4040.0,44998,650
-Georgia,Hall County,2014,190761,0.0,52519,679
+Georgia,Hall County,2014,190761,,52519,679
 Georgia,Hall County,2015,193535,3372.0,55009,690
-Georgia,Hall County,2016,196637,0.0,54917,711
+Georgia,Hall County,2016,196637,,54917,711
 Georgia,Hall County,2017,199335,4226.0,61977,733
-Georgia,Hall County,2018,202148,0.0,61699,827
-Georgia,Hall County,2019,204441,0.0,67467,788
+Georgia,Hall County,2018,202148,,61699,827
+Georgia,Hall County,2019,204441,,67467,788
 Georgia,Hall County,2021,207369,12022.0,66719,888
 Georgia,Hall County,2022,212692,11639.0,76888,1126
-Georgia,Henry County,2005,166871,0.0,58962,791
+Georgia,Henry County,2005,166871,,58962,791
 Georgia,Henry County,2006,178033,3672.0,60559,743
 Georgia,Henry County,2007,186037,3943.0,62899,733
-Georgia,Henry County,2008,191502,0.0,62354,837
+Georgia,Henry County,2008,191502,,62354,837
 Georgia,Henry County,2009,195370,4183.0,63660,811
-Georgia,Henry County,2010,205265,0.0,57341,793
-Georgia,Henry County,2011,207360,0.0,57258,812
-Georgia,Henry County,2012,209053,0.0,55695,844
-Georgia,Henry County,2013,211128,0.0,59097,796
+Georgia,Henry County,2010,205265,,57341,793
+Georgia,Henry County,2011,207360,,57258,812
+Georgia,Henry County,2012,209053,,55695,844
+Georgia,Henry County,2013,211128,,59097,796
 Georgia,Henry County,2014,213869,6965.0,58242,857
-Georgia,Henry County,2015,217739,0.0,65342,868
-Georgia,Henry County,2016,221768,0.0,66905,914
+Georgia,Henry County,2015,217739,,65342,868
+Georgia,Henry County,2016,221768,,66905,914
 Georgia,Henry County,2017,225813,10370.0,67018,935
-Georgia,Henry County,2018,230220,0.0,73541,970
-Georgia,Henry County,2019,234561,0.0,71939,998
-Georgia,Henry County,2021,245235,0.0,74614,1141
-Georgia,Henry County,2022,248364,0.0,81988,1340
-Georgia,Houston County,2005,123176,0.0,48962,545
-Georgia,Houston County,2006,127530,0.0,48604,497
-Georgia,Houston County,2007,131016,0.0,53298,554
-Georgia,Houston County,2008,133161,0.0,58578,624
-Georgia,Houston County,2009,135715,0.0,49965,599
-Georgia,Houston County,2010,140713,0.0,58401,606
-Georgia,Houston County,2011,143925,0.0,51021,583
-Georgia,Houston County,2012,146136,0.0,54457,706
-Georgia,Houston County,2013,147658,0.0,49660,682
-Georgia,Houston County,2014,149111,0.0,51054,674
-Georgia,Houston County,2015,150033,0.0,55044,691
-Georgia,Houston County,2016,152122,0.0,62493,700
-Georgia,Houston County,2017,153479,0.0,58525,723
-Georgia,Houston County,2018,155469,0.0,58965,741
-Georgia,Houston County,2019,157863,0.0,66740,743
-Georgia,Houston County,2021,166829,0.0,72848,839
-Georgia,Houston County,2022,169631,0.0,71068,852
-Georgia,Jackson County,2017,67519,0.0,66557,567
-Georgia,Jackson County,2018,70422,0.0,73150,544
-Georgia,Jackson County,2019,72977,0.0,65063,599
-Georgia,Jackson County,2021,80286,0.0,72116,731
-Georgia,Jackson County,2022,83936,0.0,83843,821
-Georgia,Liberty County,2011,65451,0.0,45485,728
-Georgia,Liberty County,2012,65471,0.0,42990,785
-Georgia,Liberty County,2013,64135,0.0,39140,789
-Georgia,Liberty County,2014,65198,0.0,41812,826
-Georgia,Liberty County,2015,62467,0.0,36573,782
-Georgia,Liberty County,2016,62570,0.0,45138,858
-Georgia,Liberty County,2021,65711,0.0,48624,938
-Georgia,Liberty County,2022,68030,0.0,61546,1078
-Georgia,Lowndes County,2005,89724,0.0,38532,456
-Georgia,Lowndes County,2006,97844,0.0,36282,465
-Georgia,Lowndes County,2007,101790,0.0,40084,532
+Georgia,Henry County,2018,230220,,73541,970
+Georgia,Henry County,2019,234561,,71939,998
+Georgia,Henry County,2021,245235,,74614,1141
+Georgia,Henry County,2022,248364,,81988,1340
+Georgia,Houston County,2005,123176,,48962,545
+Georgia,Houston County,2006,127530,,48604,497
+Georgia,Houston County,2007,131016,,53298,554
+Georgia,Houston County,2008,133161,,58578,624
+Georgia,Houston County,2009,135715,,49965,599
+Georgia,Houston County,2010,140713,,58401,606
+Georgia,Houston County,2011,143925,,51021,583
+Georgia,Houston County,2012,146136,,54457,706
+Georgia,Houston County,2013,147658,,49660,682
+Georgia,Houston County,2014,149111,,51054,674
+Georgia,Houston County,2015,150033,,55044,691
+Georgia,Houston County,2016,152122,,62493,700
+Georgia,Houston County,2017,153479,,58525,723
+Georgia,Houston County,2018,155469,,58965,741
+Georgia,Houston County,2019,157863,,66740,743
+Georgia,Houston County,2021,166829,,72848,839
+Georgia,Houston County,2022,169631,,71068,852
+Georgia,Jackson County,2017,67519,,66557,567
+Georgia,Jackson County,2018,70422,,73150,544
+Georgia,Jackson County,2019,72977,,65063,599
+Georgia,Jackson County,2021,80286,,72116,731
+Georgia,Jackson County,2022,83936,,83843,821
+Georgia,Liberty County,2011,65451,,45485,728
+Georgia,Liberty County,2012,65471,,42990,785
+Georgia,Liberty County,2013,64135,,39140,789
+Georgia,Liberty County,2014,65198,,41812,826
+Georgia,Liberty County,2015,62467,,36573,782
+Georgia,Liberty County,2016,62570,,45138,858
+Georgia,Liberty County,2021,65711,,48624,938
+Georgia,Liberty County,2022,68030,,61546,1078
+Georgia,Lowndes County,2005,89724,,38532,456
+Georgia,Lowndes County,2006,97844,,36282,465
+Georgia,Lowndes County,2007,101790,,40084,532
 Georgia,Lowndes County,2008,104583,1057.0,42834,551
-Georgia,Lowndes County,2009,106814,0.0,38422,576
-Georgia,Lowndes County,2010,109734,0.0,36132,602
-Georgia,Lowndes County,2011,111885,0.0,32898,556
-Georgia,Lowndes County,2012,114552,0.0,37165,618
-Georgia,Lowndes County,2013,112916,0.0,35317,565
-Georgia,Lowndes County,2014,113523,0.0,38733,571
-Georgia,Lowndes County,2015,112865,0.0,34455,568
-Georgia,Lowndes County,2016,114628,0.0,41449,577
-Georgia,Lowndes County,2017,115489,0.0,41156,633
-Georgia,Lowndes County,2018,116321,0.0,34886,582
-Georgia,Lowndes County,2019,117406,0.0,45683,651
-Georgia,Lowndes County,2021,119276,0.0,42242,670
-Georgia,Lowndes County,2022,119739,0.0,52307,817
-Georgia,Muscogee County,2005,175930,0.0,34040,475
+Georgia,Lowndes County,2009,106814,,38422,576
+Georgia,Lowndes County,2010,109734,,36132,602
+Georgia,Lowndes County,2011,111885,,32898,556
+Georgia,Lowndes County,2012,114552,,37165,618
+Georgia,Lowndes County,2013,112916,,35317,565
+Georgia,Lowndes County,2014,113523,,38733,571
+Georgia,Lowndes County,2015,112865,,34455,568
+Georgia,Lowndes County,2016,114628,,41449,577
+Georgia,Lowndes County,2017,115489,,41156,633
+Georgia,Lowndes County,2018,116321,,34886,582
+Georgia,Lowndes County,2019,117406,,45683,651
+Georgia,Lowndes County,2021,119276,,42242,670
+Georgia,Lowndes County,2022,119739,,52307,817
+Georgia,Muscogee County,2005,175930,,34040,475
 Georgia,Muscogee County,2006,188660,15558.0,41164,526
-Georgia,Muscogee County,2007,187046,0.0,41514,524
+Georgia,Muscogee County,2007,187046,,41514,524
 Georgia,Muscogee County,2008,186984,11464.0,40223,494
 Georgia,Muscogee County,2009,190414,17873.0,39438,563
 Georgia,Muscogee County,2010,190417,8848.0,35384,544
@@ -2844,139 +2844,139 @@ Georgia,Muscogee County,2016,197485,6871.0,40060,652
 Georgia,Muscogee County,2017,194058,6001.0,42107,656
 Georgia,Muscogee County,2018,194160,2346.0,47288,676
 Georgia,Muscogee County,2019,195769,3222.0,46934,729
-Georgia,Muscogee County,2021,205617,0.0,52734,726
-Georgia,Muscogee County,2022,202616,0.0,53750,807
-Georgia,Newton County,2005,85474,0.0,49343,585
-Georgia,Newton County,2006,91451,0.0,49616,593
-Georgia,Newton County,2007,96019,0.0,49157,646
-Georgia,Newton County,2008,98542,0.0,55506,741
-Georgia,Newton County,2009,99944,0.0,50207,683
-Georgia,Newton County,2010,100086,0.0,49397,720
-Georgia,Newton County,2011,100814,0.0,40932,626
-Georgia,Newton County,2012,101505,0.0,48974,694
-Georgia,Newton County,2013,102446,0.0,54107,796
-Georgia,Newton County,2014,103675,0.0,46790,733
-Georgia,Newton County,2015,105473,0.0,50806,684
-Georgia,Newton County,2016,106999,0.0,48628,688
-Georgia,Newton County,2017,108078,0.0,57337,744
-Georgia,Newton County,2018,109541,0.0,57344,851
-Georgia,Newton County,2019,111744,0.0,57254,834
-Georgia,Newton County,2021,115355,0.0,75589,993
-Georgia,Newton County,2022,117621,0.0,73579,1041
-Georgia,Paulding County,2005,111654,0.0,55528,656
-Georgia,Paulding County,2006,121530,0.0,59009,704
-Georgia,Paulding County,2007,127906,0.0,57028,667
-Georgia,Paulding County,2008,133135,0.0,57464,650
-Georgia,Paulding County,2009,136655,0.0,62302,773
-Georgia,Paulding County,2010,142741,0.0,60169,766
-Georgia,Paulding County,2011,143542,0.0,57764,720
-Georgia,Paulding County,2012,144800,0.0,57332,761
-Georgia,Paulding County,2013,146950,0.0,56307,858
-Georgia,Paulding County,2014,148987,0.0,62453,796
-Georgia,Paulding County,2015,152238,0.0,60214,866
-Georgia,Paulding County,2016,155825,0.0,60856,880
-Georgia,Paulding County,2017,159445,0.0,66482,927
-Georgia,Paulding County,2018,164044,0.0,73084,991
-Georgia,Paulding County,2019,168667,0.0,75800,1031
-Georgia,Paulding County,2021,173780,0.0,93815,1304
-Georgia,Paulding County,2022,178421,0.0,86847,1169
-Georgia,Richmond County,2005,185150,0.0,37541,486
+Georgia,Muscogee County,2021,205617,,52734,726
+Georgia,Muscogee County,2022,202616,,53750,807
+Georgia,Newton County,2005,85474,,49343,585
+Georgia,Newton County,2006,91451,,49616,593
+Georgia,Newton County,2007,96019,,49157,646
+Georgia,Newton County,2008,98542,,55506,741
+Georgia,Newton County,2009,99944,,50207,683
+Georgia,Newton County,2010,100086,,49397,720
+Georgia,Newton County,2011,100814,,40932,626
+Georgia,Newton County,2012,101505,,48974,694
+Georgia,Newton County,2013,102446,,54107,796
+Georgia,Newton County,2014,103675,,46790,733
+Georgia,Newton County,2015,105473,,50806,684
+Georgia,Newton County,2016,106999,,48628,688
+Georgia,Newton County,2017,108078,,57337,744
+Georgia,Newton County,2018,109541,,57344,851
+Georgia,Newton County,2019,111744,,57254,834
+Georgia,Newton County,2021,115355,,75589,993
+Georgia,Newton County,2022,117621,,73579,1041
+Georgia,Paulding County,2005,111654,,55528,656
+Georgia,Paulding County,2006,121530,,59009,704
+Georgia,Paulding County,2007,127906,,57028,667
+Georgia,Paulding County,2008,133135,,57464,650
+Georgia,Paulding County,2009,136655,,62302,773
+Georgia,Paulding County,2010,142741,,60169,766
+Georgia,Paulding County,2011,143542,,57764,720
+Georgia,Paulding County,2012,144800,,57332,761
+Georgia,Paulding County,2013,146950,,56307,858
+Georgia,Paulding County,2014,148987,,62453,796
+Georgia,Paulding County,2015,152238,,60214,866
+Georgia,Paulding County,2016,155825,,60856,880
+Georgia,Paulding County,2017,159445,,66482,927
+Georgia,Paulding County,2018,164044,,73084,991
+Georgia,Paulding County,2019,168667,,75800,1031
+Georgia,Paulding County,2021,173780,,93815,1304
+Georgia,Paulding County,2022,178421,,86847,1169
+Georgia,Richmond County,2005,185150,,37541,486
 Georgia,Richmond County,2006,194398,2646.0,35062,490
 Georgia,Richmond County,2007,197372,2739.0,37075,524
 Georgia,Richmond County,2008,199486,2194.0,37796,490
-Georgia,Richmond County,2009,199768,0.0,34398,523
+Georgia,Richmond County,2009,199768,,34398,523
 Georgia,Richmond County,2010,201005,1824.0,39152,547
 Georgia,Richmond County,2011,201217,1522.0,38928,595
 Georgia,Richmond County,2012,202587,782.0,37154,582
 Georgia,Richmond County,2013,202003,1228.0,35649,611
-Georgia,Richmond County,2014,201368,0.0,35793,585
+Georgia,Richmond County,2014,201368,,35793,585
 Georgia,Richmond County,2015,201793,1594.0,41672,611
 Georgia,Richmond County,2016,201647,1304.0,41419,646
 Georgia,Richmond County,2017,201800,2530.0,37324,673
 Georgia,Richmond County,2018,201554,2734.0,39413,678
 Georgia,Richmond County,2019,202518,3365.0,44973,719
-Georgia,Richmond County,2021,205673,0.0,48048,770
+Georgia,Richmond County,2021,205673,,48048,770
 Georgia,Richmond County,2022,206640,7698.0,49915,786
-Georgia,Rockdale County,2005,77375,0.0,50544,721
-Georgia,Rockdale County,2006,80332,0.0,54579,692
-Georgia,Rockdale County,2007,82052,0.0,55247,674
-Georgia,Rockdale County,2008,83222,0.0,58742,760
-Georgia,Rockdale County,2009,84569,0.0,49447,761
-Georgia,Rockdale County,2010,85434,0.0,57266,750
-Georgia,Rockdale County,2011,85765,0.0,51067,738
-Georgia,Rockdale County,2012,85820,0.0,50200,675
-Georgia,Rockdale County,2013,86919,0.0,49767,721
-Georgia,Rockdale County,2014,87754,0.0,46524,701
-Georgia,Rockdale County,2015,88856,0.0,50761,756
-Georgia,Rockdale County,2016,89355,0.0,56820,789
-Georgia,Rockdale County,2017,90312,0.0,62429,816
-Georgia,Rockdale County,2018,90594,0.0,61222,956
-Georgia,Rockdale County,2019,90896,0.0,60560,875
-Georgia,Rockdale County,2021,94082,0.0,66267,935
-Georgia,Rockdale County,2022,94984,0.0,73998,1199
-Georgia,Spalding County,2017,65380,0.0,47027,603
-Georgia,Spalding County,2018,66100,0.0,42920,645
-Georgia,Spalding County,2019,66703,0.0,51677,548
-Georgia,Spalding County,2021,67909,0.0,54585,719
-Georgia,Spalding County,2022,68919,0.0,54803,755
-Georgia,Troup County,2010,67187,0.0,41477,470
-Georgia,Troup County,2011,67764,0.0,40368,497
-Georgia,Troup County,2012,68468,0.0,36739,480
-Georgia,Troup County,2013,69053,0.0,43642,553
-Georgia,Troup County,2014,69469,0.0,40486,580
-Georgia,Troup County,2015,69763,0.0,39067,516
-Georgia,Troup County,2016,70005,0.0,42371,594
-Georgia,Troup County,2017,69786,0.0,38977,494
-Georgia,Troup County,2018,70034,0.0,44260,610
-Georgia,Troup County,2019,69922,0.0,46198,581
-Georgia,Troup County,2021,69720,0.0,49187,638
-Georgia,Troup County,2022,70191,0.0,57988,767
-Georgia,Walker County,2010,68761,0.0,36927,408
-Georgia,Walker County,2011,68848,0.0,38187,416
-Georgia,Walker County,2012,68094,0.0,35824,441
-Georgia,Walker County,2013,68198,0.0,42018,483
-Georgia,Walker County,2014,68218,0.0,38493,446
-Georgia,Walker County,2015,68066,0.0,44358,517
-Georgia,Walker County,2016,67896,0.0,39209,538
-Georgia,Walker County,2017,68939,0.0,45410,552
-Georgia,Walker County,2018,69410,0.0,42609,577
-Georgia,Walker County,2019,69761,0.0,47856,499
-Georgia,Walker County,2021,68510,0.0,43672,545
-Georgia,Walker County,2022,68915,0.0,52957,667
-Georgia,Walton County,2005,74866,0.0,51489,657
-Georgia,Walton County,2006,79388,0.0,53152,503
-Georgia,Walton County,2007,83144,0.0,48205,495
-Georgia,Walton County,2008,85813,0.0,51771,504
-Georgia,Walton County,2009,87311,0.0,47466,656
-Georgia,Walton County,2010,84004,0.0,50173,548
-Georgia,Walton County,2011,84580,0.0,50129,608
-Georgia,Walton County,2012,84575,0.0,48703,580
-Georgia,Walton County,2013,85754,0.0,53233,624
-Georgia,Walton County,2014,87615,0.0,50895,587
-Georgia,Walton County,2015,88399,0.0,57278,706
-Georgia,Walton County,2016,90184,0.0,53202,719
-Georgia,Walton County,2017,91600,0.0,54867,642
-Georgia,Walton County,2018,93503,0.0,66640,752
-Georgia,Walton County,2019,94593,0.0,66176,743
-Georgia,Walton County,2021,99853,0.0,73151,753
-Georgia,Walton County,2022,103065,0.0,86240,875
-Georgia,Whitfield County,2005,89734,0.0,39581,482
-Georgia,Whitfield County,2006,92999,0.0,40375,471
-Georgia,Whitfield County,2007,93379,0.0,40406,497
-Georgia,Whitfield County,2008,93835,0.0,43529,501
-Georgia,Whitfield County,2009,93698,0.0,39145,489
-Georgia,Whitfield County,2010,102934,0.0,39423,514
-Georgia,Whitfield County,2011,103184,0.0,36928,504
-Georgia,Whitfield County,2012,103359,0.0,34972,507
-Georgia,Whitfield County,2013,102945,0.0,38126,522
-Georgia,Whitfield County,2014,103542,0.0,42069,507
-Georgia,Whitfield County,2015,104216,0.0,45894,563
-Georgia,Whitfield County,2016,104589,0.0,46399,543
-Georgia,Whitfield County,2017,104658,0.0,40717,531
-Georgia,Whitfield County,2018,104062,0.0,45028,588
-Georgia,Whitfield County,2019,104628,0.0,52198,591
-Georgia,Whitfield County,2021,102848,0.0,55519,673
-Georgia,Whitfield County,2022,103132,0.0,61037,729
+Georgia,Rockdale County,2005,77375,,50544,721
+Georgia,Rockdale County,2006,80332,,54579,692
+Georgia,Rockdale County,2007,82052,,55247,674
+Georgia,Rockdale County,2008,83222,,58742,760
+Georgia,Rockdale County,2009,84569,,49447,761
+Georgia,Rockdale County,2010,85434,,57266,750
+Georgia,Rockdale County,2011,85765,,51067,738
+Georgia,Rockdale County,2012,85820,,50200,675
+Georgia,Rockdale County,2013,86919,,49767,721
+Georgia,Rockdale County,2014,87754,,46524,701
+Georgia,Rockdale County,2015,88856,,50761,756
+Georgia,Rockdale County,2016,89355,,56820,789
+Georgia,Rockdale County,2017,90312,,62429,816
+Georgia,Rockdale County,2018,90594,,61222,956
+Georgia,Rockdale County,2019,90896,,60560,875
+Georgia,Rockdale County,2021,94082,,66267,935
+Georgia,Rockdale County,2022,94984,,73998,1199
+Georgia,Spalding County,2017,65380,,47027,603
+Georgia,Spalding County,2018,66100,,42920,645
+Georgia,Spalding County,2019,66703,,51677,548
+Georgia,Spalding County,2021,67909,,54585,719
+Georgia,Spalding County,2022,68919,,54803,755
+Georgia,Troup County,2010,67187,,41477,470
+Georgia,Troup County,2011,67764,,40368,497
+Georgia,Troup County,2012,68468,,36739,480
+Georgia,Troup County,2013,69053,,43642,553
+Georgia,Troup County,2014,69469,,40486,580
+Georgia,Troup County,2015,69763,,39067,516
+Georgia,Troup County,2016,70005,,42371,594
+Georgia,Troup County,2017,69786,,38977,494
+Georgia,Troup County,2018,70034,,44260,610
+Georgia,Troup County,2019,69922,,46198,581
+Georgia,Troup County,2021,69720,,49187,638
+Georgia,Troup County,2022,70191,,57988,767
+Georgia,Walker County,2010,68761,,36927,408
+Georgia,Walker County,2011,68848,,38187,416
+Georgia,Walker County,2012,68094,,35824,441
+Georgia,Walker County,2013,68198,,42018,483
+Georgia,Walker County,2014,68218,,38493,446
+Georgia,Walker County,2015,68066,,44358,517
+Georgia,Walker County,2016,67896,,39209,538
+Georgia,Walker County,2017,68939,,45410,552
+Georgia,Walker County,2018,69410,,42609,577
+Georgia,Walker County,2019,69761,,47856,499
+Georgia,Walker County,2021,68510,,43672,545
+Georgia,Walker County,2022,68915,,52957,667
+Georgia,Walton County,2005,74866,,51489,657
+Georgia,Walton County,2006,79388,,53152,503
+Georgia,Walton County,2007,83144,,48205,495
+Georgia,Walton County,2008,85813,,51771,504
+Georgia,Walton County,2009,87311,,47466,656
+Georgia,Walton County,2010,84004,,50173,548
+Georgia,Walton County,2011,84580,,50129,608
+Georgia,Walton County,2012,84575,,48703,580
+Georgia,Walton County,2013,85754,,53233,624
+Georgia,Walton County,2014,87615,,50895,587
+Georgia,Walton County,2015,88399,,57278,706
+Georgia,Walton County,2016,90184,,53202,719
+Georgia,Walton County,2017,91600,,54867,642
+Georgia,Walton County,2018,93503,,66640,752
+Georgia,Walton County,2019,94593,,66176,743
+Georgia,Walton County,2021,99853,,73151,753
+Georgia,Walton County,2022,103065,,86240,875
+Georgia,Whitfield County,2005,89734,,39581,482
+Georgia,Whitfield County,2006,92999,,40375,471
+Georgia,Whitfield County,2007,93379,,40406,497
+Georgia,Whitfield County,2008,93835,,43529,501
+Georgia,Whitfield County,2009,93698,,39145,489
+Georgia,Whitfield County,2010,102934,,39423,514
+Georgia,Whitfield County,2011,103184,,36928,504
+Georgia,Whitfield County,2012,103359,,34972,507
+Georgia,Whitfield County,2013,102945,,38126,522
+Georgia,Whitfield County,2014,103542,,42069,507
+Georgia,Whitfield County,2015,104216,,45894,563
+Georgia,Whitfield County,2016,104589,,46399,543
+Georgia,Whitfield County,2017,104658,,40717,531
+Georgia,Whitfield County,2018,104062,,45028,588
+Georgia,Whitfield County,2019,104628,,52198,591
+Georgia,Whitfield County,2021,102848,,55519,673
+Georgia,Whitfield County,2022,103132,,61037,729
 Hawaii,Hawaii County,2005,164437,5945.0,48524,742
 Hawaii,Hawaii County,2006,171191,5087.0,55390,804
 Hawaii,Hawaii County,2007,173057,5951.0,59111,871
@@ -3011,18 +3011,18 @@ Hawaii,Honolulu County,2018,980080,22611.0,84423,1593
 Hawaii,Honolulu County,2019,974563,19152.0,87470,1647
 Hawaii,Honolulu County,2021,1000890,51819.0,90704,1771
 Hawaii,Honolulu County,2022,995638,45632.0,96580,1738
-Hawaii,Kauai County,2010,67226,0.0,55246,935
+Hawaii,Kauai County,2010,67226,,55246,935
 Hawaii,Kauai County,2011,67701,1744.0,60751,1135
-Hawaii,Kauai County,2012,68434,0.0,59238,1051
-Hawaii,Kauai County,2013,69512,0.0,60155,1101
-Hawaii,Kauai County,2014,70475,0.0,64847,882
-Hawaii,Kauai County,2015,71735,0.0,77140,1104
-Hawaii,Kauai County,2016,72029,0.0,71344,1183
-Hawaii,Kauai County,2017,72159,0.0,83860,1258
-Hawaii,Kauai County,2018,72133,0.0,80921,1184
-Hawaii,Kauai County,2019,72293,0.0,81971,1179
-Hawaii,Kauai County,2021,73454,0.0,80582,1478
-Hawaii,Kauai County,2022,73810,0.0,87730,1636
+Hawaii,Kauai County,2012,68434,,59238,1051
+Hawaii,Kauai County,2013,69512,,60155,1101
+Hawaii,Kauai County,2014,70475,,64847,882
+Hawaii,Kauai County,2015,71735,,77140,1104
+Hawaii,Kauai County,2016,72029,,71344,1183
+Hawaii,Kauai County,2017,72159,,83860,1258
+Hawaii,Kauai County,2018,72133,,80921,1184
+Hawaii,Kauai County,2019,72293,,81971,1179
+Hawaii,Kauai County,2021,73454,,80582,1478
+Hawaii,Kauai County,2022,73810,,87730,1636
 Hawaii,Maui County,2005,138433,4314.0,57573,912
 Hawaii,Maui County,2006,141300,4696.0,58771,1081
 Hawaii,Maui County,2007,141843,4622.0,63550,1163
@@ -3057,24 +3057,24 @@ Idaho,Ada County,2018,469966,17599.0,66405,908
 Idaho,Ada County,2019,481587,19720.0,72021,997
 Idaho,Ada County,2021,511931,50904.0,79279,1205
 Idaho,Ada County,2022,518907,50641.0,87774,1388
-Idaho,Bannock County,2005,75817,0.0,36357,518
+Idaho,Bannock County,2005,75817,,36357,518
 Idaho,Bannock County,2006,78443,1078.0,39774,454
-Idaho,Bannock County,2007,79925,0.0,44374,464
+Idaho,Bannock County,2007,79925,,44374,464
 Idaho,Bannock County,2008,80812,1418.0,48816,508
 Idaho,Bannock County,2009,82539,1233.0,45878,494
-Idaho,Bannock County,2010,83071,0.0,38396,499
+Idaho,Bannock County,2010,83071,,38396,499
 Idaho,Bannock County,2011,83691,1132.0,41097,488
 Idaho,Bannock County,2012,83800,1556.0,42832,500
 Idaho,Bannock County,2013,83249,1330.0,42174,513
 Idaho,Bannock County,2014,83347,1384.0,44018,510
-Idaho,Bannock County,2015,83744,0.0,41530,548
+Idaho,Bannock County,2015,83744,,41530,548
 Idaho,Bannock County,2016,84377,1315.0,48429,551
 Idaho,Bannock County,2017,85269,2066.0,51612,567
-Idaho,Bannock County,2018,87138,0.0,50748,583
-Idaho,Bannock County,2019,87808,0.0,51989,576
-Idaho,Bannock County,2021,88263,0.0,60736,668
+Idaho,Bannock County,2018,87138,,50748,583
+Idaho,Bannock County,2019,87808,,51989,576
+Idaho,Bannock County,2021,88263,,60736,668
 Idaho,Bannock County,2022,89517,3707.0,61452,744
-Idaho,Bonneville County,2005,90711,0.0,44290,468
+Idaho,Bonneville County,2005,90711,,44290,468
 Idaho,Bonneville County,2006,94630,1902.0,45325,497
 Idaho,Bonneville County,2007,96545,1363.0,51065,550
 Idaho,Bonneville County,2008,99135,1716.0,51585,526
@@ -3085,64 +3085,64 @@ Idaho,Bonneville County,2012,106684,763.0,49450,546
 Idaho,Bonneville County,2013,107517,1885.0,49884,582
 Idaho,Bonneville County,2014,108623,2330.0,49626,569
 Idaho,Bonneville County,2015,110089,2550.0,53355,671
-Idaho,Bonneville County,2016,112232,0.0,59706,625
+Idaho,Bonneville County,2016,112232,,59706,625
 Idaho,Bonneville County,2017,114595,1819.0,53478,635
 Idaho,Bonneville County,2018,116854,2879.0,58729,659
 Idaho,Bonneville County,2019,119062,3130.0,64618,682
-Idaho,Bonneville County,2021,127930,0.0,68614,780
+Idaho,Bonneville County,2021,127930,,68614,780
 Idaho,Bonneville County,2022,129496,5004.0,74154,934
-Idaho,Canyon County,2005,161761,0.0,41363,521
+Idaho,Canyon County,2005,161761,,41363,521
 Idaho,Canyon County,2006,173302,3629.0,41804,558
 Idaho,Canyon County,2007,179381,3428.0,42869,583
 Idaho,Canyon County,2008,183939,3159.0,43546,598
 Idaho,Canyon County,2009,186615,3219.0,38653,578
 Idaho,Canyon County,2010,189428,3738.0,42732,590
-Idaho,Canyon County,2011,191694,0.0,38470,547
+Idaho,Canyon County,2011,191694,,38470,547
 Idaho,Canyon County,2012,193888,5196.0,41555,574
 Idaho,Canyon County,2013,198871,4180.0,41941,585
-Idaho,Canyon County,2014,203143,0.0,43250,626
-Idaho,Canyon County,2015,207478,0.0,42786,623
+Idaho,Canyon County,2014,203143,,43250,626
+Idaho,Canyon County,2015,207478,,42786,623
 Idaho,Canyon County,2016,211698,4628.0,48437,677
 Idaho,Canyon County,2017,216699,6207.0,47324,724
-Idaho,Canyon County,2018,223499,0.0,53374,707
+Idaho,Canyon County,2018,223499,,53374,707
 Idaho,Canyon County,2019,229849,6567.0,58945,818
 Idaho,Canyon County,2021,243115,11121.0,64314,936
 Idaho,Canyon County,2022,251065,15217.0,70818,1108
-Idaho,Kootenai County,2005,126079,0.0,36675,593
+Idaho,Kootenai County,2005,126079,,36675,593
 Idaho,Kootenai County,2006,131507,4631.0,40346,621
 Idaho,Kootenai County,2007,134442,3121.0,46669,623
 Idaho,Kootenai County,2008,137475,4291.0,50047,661
-Idaho,Kootenai County,2009,139390,0.0,47431,677
-Idaho,Kootenai County,2010,138901,0.0,42316,639
+Idaho,Kootenai County,2009,139390,,47431,677
+Idaho,Kootenai County,2010,138901,,42316,639
 Idaho,Kootenai County,2011,141132,3630.0,47782,647
-Idaho,Kootenai County,2012,142357,0.0,46870,692
-Idaho,Kootenai County,2013,144265,0.0,54919,695
-Idaho,Kootenai County,2014,147326,0.0,48776,686
+Idaho,Kootenai County,2012,142357,,46870,692
+Idaho,Kootenai County,2013,144265,,54919,695
+Idaho,Kootenai County,2014,147326,,48776,686
 Idaho,Kootenai County,2015,150346,4312.0,47860,758
-Idaho,Kootenai County,2016,154311,0.0,51765,792
-Idaho,Kootenai County,2017,157637,0.0,57219,838
-Idaho,Kootenai County,2018,161505,0.0,55236,869
-Idaho,Kootenai County,2019,165697,0.0,62579,849
-Idaho,Kootenai County,2021,179789,0.0,67593,1073
+Idaho,Kootenai County,2016,154311,,51765,792
+Idaho,Kootenai County,2017,157637,,57219,838
+Idaho,Kootenai County,2018,161505,,55236,869
+Idaho,Kootenai County,2019,165697,,62579,849
+Idaho,Kootenai County,2021,179789,,67593,1073
 Idaho,Kootenai County,2022,183578,14030.0,75328,1303
-Idaho,Twin Falls County,2005,71334,0.0,38702,475
-Idaho,Twin Falls County,2006,75541,0.0,39389,483
-Idaho,Twin Falls County,2007,73086,0.0,39220,524
-Idaho,Twin Falls County,2008,75613,0.0,41094,491
-Idaho,Twin Falls County,2009,75296,0.0,40631,579
-Idaho,Twin Falls County,2010,77517,0.0,42106,567
-Idaho,Twin Falls County,2011,78005,0.0,42015,558
-Idaho,Twin Falls County,2012,78595,0.0,40745,570
-Idaho,Twin Falls County,2013,79957,0.0,47403,641
-Idaho,Twin Falls County,2014,80914,0.0,43624,579
-Idaho,Twin Falls County,2015,82375,0.0,45499,634
-Idaho,Twin Falls County,2016,83514,0.0,51210,705
-Idaho,Twin Falls County,2017,85124,0.0,51589,672
-Idaho,Twin Falls County,2018,86081,0.0,51196,622
-Idaho,Twin Falls County,2019,86878,0.0,56276,669
-Idaho,Twin Falls County,2021,92243,0.0,52880,687
-Idaho,Twin Falls County,2022,93696,0.0,63560,881
-Illinois,Champaign County,2005,168902,0.0,39129,562
+Idaho,Twin Falls County,2005,71334,,38702,475
+Idaho,Twin Falls County,2006,75541,,39389,483
+Idaho,Twin Falls County,2007,73086,,39220,524
+Idaho,Twin Falls County,2008,75613,,41094,491
+Idaho,Twin Falls County,2009,75296,,40631,579
+Idaho,Twin Falls County,2010,77517,,42106,567
+Idaho,Twin Falls County,2011,78005,,42015,558
+Idaho,Twin Falls County,2012,78595,,40745,570
+Idaho,Twin Falls County,2013,79957,,47403,641
+Idaho,Twin Falls County,2014,80914,,43624,579
+Idaho,Twin Falls County,2015,82375,,45499,634
+Idaho,Twin Falls County,2016,83514,,51210,705
+Idaho,Twin Falls County,2017,85124,,51589,672
+Idaho,Twin Falls County,2018,86081,,51196,622
+Idaho,Twin Falls County,2019,86878,,56276,669
+Idaho,Twin Falls County,2021,92243,,52880,687
+Idaho,Twin Falls County,2022,93696,,63560,881
+Illinois,Champaign County,2005,168902,,39129,562
 Illinois,Champaign County,2006,185682,4547.0,43290,539
 Illinois,Champaign County,2007,190260,2584.0,43407,556
 Illinois,Champaign County,2008,193636,3897.0,43985,599
@@ -3176,23 +3176,23 @@ Illinois,Cook County,2018,5180493,130229.0,63353,978
 Illinois,Cook County,2019,5150233,138947.0,69429,1014
 Illinois,Cook County,2021,5173146,583219.0,72092,1113
 Illinois,Cook County,2022,5109292,490221.0,76632,1161
-Illinois,DeKalb County,2005,89223,0.0,47100,602
-Illinois,DeKalb County,2006,100139,0.0,51055,623
-Illinois,DeKalb County,2007,103729,0.0,54894,669
-Illinois,DeKalb County,2008,106321,0.0,53372,637
-Illinois,DeKalb County,2009,107333,0.0,49714,660
-Illinois,DeKalb County,2010,105201,0.0,51518,687
-Illinois,DeKalb County,2011,104743,0.0,51327,672
-Illinois,DeKalb County,2012,104704,0.0,45901,705
-Illinois,DeKalb County,2013,104741,0.0,52867,696
-Illinois,DeKalb County,2014,105462,0.0,56450,742
-Illinois,DeKalb County,2015,104352,0.0,55471,774
+Illinois,DeKalb County,2005,89223,,47100,602
+Illinois,DeKalb County,2006,100139,,51055,623
+Illinois,DeKalb County,2007,103729,,54894,669
+Illinois,DeKalb County,2008,106321,,53372,637
+Illinois,DeKalb County,2009,107333,,49714,660
+Illinois,DeKalb County,2010,105201,,51518,687
+Illinois,DeKalb County,2011,104743,,51327,672
+Illinois,DeKalb County,2012,104704,,45901,705
+Illinois,DeKalb County,2013,104741,,52867,696
+Illinois,DeKalb County,2014,105462,,56450,742
+Illinois,DeKalb County,2015,104352,,55471,774
 Illinois,DeKalb County,2016,104528,2550.0,59285,748
-Illinois,DeKalb County,2017,104733,0.0,59942,747
-Illinois,DeKalb County,2018,104143,0.0,63085,797
-Illinois,DeKalb County,2019,104897,0.0,64131,810
-Illinois,DeKalb County,2021,100414,0.0,65615,817
-Illinois,DeKalb County,2022,100232,0.0,68590,803
+Illinois,DeKalb County,2017,104733,,59942,747
+Illinois,DeKalb County,2018,104143,,63085,797
+Illinois,DeKalb County,2019,104897,,64131,810
+Illinois,DeKalb County,2021,100414,,65615,817
+Illinois,DeKalb County,2022,100232,,68590,803
 Illinois,DuPage County,2005,913781,20740.0,70560,840
 Illinois,DuPage County,2006,932670,19727.0,73677,845
 Illinois,DuPage County,2007,929192,20671.0,73472,882
@@ -3227,40 +3227,40 @@ Illinois,Kane County,2018,534216,16493.0,79818,988
 Illinois,Kane County,2019,532403,15908.0,84368,970
 Illinois,Kane County,2021,515588,51848.0,91336,1097
 Illinois,Kane County,2022,514182,36972.0,93343,1146
-Illinois,Kankakee County,2005,103593,0.0,46074,524
-Illinois,Kankakee County,2006,109090,0.0,50507,546
+Illinois,Kankakee County,2005,103593,,46074,524
+Illinois,Kankakee County,2006,109090,,50507,546
 Illinois,Kankakee County,2007,110705,1124.0,46418,558
-Illinois,Kankakee County,2008,112524,0.0,50535,596
-Illinois,Kankakee County,2009,113215,0.0,50858,616
-Illinois,Kankakee County,2010,113502,0.0,44784,588
-Illinois,Kankakee County,2011,113698,0.0,45669,639
-Illinois,Kankakee County,2012,113040,0.0,51703,631
-Illinois,Kankakee County,2013,112120,0.0,49761,668
-Illinois,Kankakee County,2014,111375,0.0,58378,698
-Illinois,Kankakee County,2015,110879,0.0,53850,703
+Illinois,Kankakee County,2008,112524,,50535,596
+Illinois,Kankakee County,2009,113215,,50858,616
+Illinois,Kankakee County,2010,113502,,44784,588
+Illinois,Kankakee County,2011,113698,,45669,639
+Illinois,Kankakee County,2012,113040,,51703,631
+Illinois,Kankakee County,2013,112120,,49761,668
+Illinois,Kankakee County,2014,111375,,58378,698
+Illinois,Kankakee County,2015,110879,,53850,703
 Illinois,Kankakee County,2016,110008,1639.0,54911,702
 Illinois,Kankakee County,2017,109605,1465.0,58539,653
 Illinois,Kankakee County,2018,110024,1832.0,51404,731
-Illinois,Kankakee County,2019,109862,0.0,60923,772
-Illinois,Kankakee County,2021,106601,0.0,63364,739
+Illinois,Kankakee County,2019,109862,,60923,772
+Illinois,Kankakee County,2021,106601,,63364,739
 Illinois,Kankakee County,2022,106074,4161.0,71416,795
-Illinois,Kendall County,2005,79322,0.0,69536,665
-Illinois,Kendall County,2006,88158,0.0,73069,938
-Illinois,Kendall County,2007,96818,0.0,76020,866
-Illinois,Kendall County,2008,103460,0.0,85545,944
-Illinois,Kendall County,2009,104821,0.0,81826,1061
-Illinois,Kendall County,2010,115304,0.0,77987,888
-Illinois,Kendall County,2011,116631,0.0,80655,1037
-Illinois,Kendall County,2012,118105,0.0,77361,956
-Illinois,Kendall County,2013,119348,0.0,74859,981
-Illinois,Kendall County,2014,121350,0.0,90072,942
-Illinois,Kendall County,2015,123355,0.0,85979,1170
-Illinois,Kendall County,2016,124695,0.0,90482,1013
-Illinois,Kendall County,2017,126218,0.0,91250,956
-Illinois,Kendall County,2018,127915,0.0,89862,1341
-Illinois,Kendall County,2019,128990,0.0,104858,1408
-Illinois,Kendall County,2021,134867,0.0,91560,1066
-Illinois,Kendall County,2022,137254,0.0,101447,1297
+Illinois,Kendall County,2005,79322,,69536,665
+Illinois,Kendall County,2006,88158,,73069,938
+Illinois,Kendall County,2007,96818,,76020,866
+Illinois,Kendall County,2008,103460,,85545,944
+Illinois,Kendall County,2009,104821,,81826,1061
+Illinois,Kendall County,2010,115304,,77987,888
+Illinois,Kendall County,2011,116631,,80655,1037
+Illinois,Kendall County,2012,118105,,77361,956
+Illinois,Kendall County,2013,119348,,74859,981
+Illinois,Kendall County,2014,121350,,90072,942
+Illinois,Kendall County,2015,123355,,85979,1170
+Illinois,Kendall County,2016,124695,,90482,1013
+Illinois,Kendall County,2017,126218,,91250,956
+Illinois,Kendall County,2018,127915,,89862,1341
+Illinois,Kendall County,2019,128990,,104858,1408
+Illinois,Kendall County,2021,134867,,91560,1066
+Illinois,Kendall County,2022,137254,,101447,1297
 Illinois,Lake County,2005,684726,14158.0,68744,761
 Illinois,Lake County,2006,713076,17242.0,75170,797
 Illinois,Lake County,2007,710241,16792.0,77834,820
@@ -3278,24 +3278,24 @@ Illinois,Lake County,2018,700832,24105.0,87133,1045
 Illinois,Lake County,2019,696535,26987.0,92511,1072
 Illinois,Lake County,2021,711239,75010.0,95796,1147
 Illinois,Lake County,2022,709150,67783.0,101442,1207
-Illinois,LaSalle County,2005,109658,0.0,41052,455
+Illinois,LaSalle County,2005,109658,,41052,455
 Illinois,LaSalle County,2006,113065,1922.0,46670,479
-Illinois,LaSalle County,2007,112616,0.0,48110,453
-Illinois,LaSalle County,2008,112474,0.0,49563,493
-Illinois,LaSalle County,2009,112498,0.0,53260,474
-Illinois,LaSalle County,2010,113840,0.0,50206,512
+Illinois,LaSalle County,2007,112616,,48110,453
+Illinois,LaSalle County,2008,112474,,49563,493
+Illinois,LaSalle County,2009,112498,,53260,474
+Illinois,LaSalle County,2010,113840,,50206,512
 Illinois,LaSalle County,2011,113518,1739.0,48935,504
-Illinois,LaSalle County,2012,112973,0.0,49183,499
-Illinois,LaSalle County,2013,112183,0.0,48552,523
-Illinois,LaSalle County,2014,111241,0.0,50432,523
-Illinois,LaSalle County,2015,111333,0.0,51936,593
-Illinois,LaSalle County,2016,110642,0.0,57476,607
-Illinois,LaSalle County,2017,110067,0.0,56896,606
-Illinois,LaSalle County,2018,109430,0.0,51838,584
+Illinois,LaSalle County,2012,112973,,49183,499
+Illinois,LaSalle County,2013,112183,,48552,523
+Illinois,LaSalle County,2014,111241,,50432,523
+Illinois,LaSalle County,2015,111333,,51936,593
+Illinois,LaSalle County,2016,110642,,57476,607
+Illinois,LaSalle County,2017,110067,,56896,606
+Illinois,LaSalle County,2018,109430,,51838,584
 Illinois,LaSalle County,2019,108669,1649.0,59130,630
-Illinois,LaSalle County,2021,108965,0.0,64673,639
-Illinois,LaSalle County,2022,108078,0.0,63626,722
-Illinois,McHenry County,2005,302471,0.0,70908,777
+Illinois,LaSalle County,2021,108965,,64673,639
+Illinois,LaSalle County,2022,108078,,63626,722
+Illinois,McHenry County,2005,302471,,70908,777
 Illinois,McHenry County,2006,312373,8989.0,71945,813
 Illinois,McHenry County,2007,315943,8520.0,73286,818
 Illinois,McHenry County,2008,318641,7868.0,79665,854
@@ -3312,7 +3312,7 @@ Illinois,McHenry County,2018,308570,11916.0,85275,1019
 Illinois,McHenry County,2019,307774,10671.0,88879,1043
 Illinois,McHenry County,2021,311122,32501.0,91887,1113
 Illinois,McHenry County,2022,311747,27275.0,98907,997
-Illinois,McLean County,2005,146894,0.0,51563,554
+Illinois,McLean County,2005,146894,,51563,554
 Illinois,McLean County,2006,161202,2682.0,51035,545
 Illinois,McLean County,2007,164209,3382.0,54071,563
 Illinois,McLean County,2008,165298,2920.0,58117,540
@@ -3329,24 +3329,24 @@ Illinois,McLean County,2018,172828,4861.0,66256,713
 Illinois,McLean County,2019,171517,4169.0,68784,714
 Illinois,McLean County,2021,170889,19760.0,69612,745
 Illinois,McLean County,2022,171141,17984.0,70674,803
-Illinois,Macon County,2005,106433,0.0,39123,397
-Illinois,Macon County,2006,109309,0.0,41009,430
+Illinois,Macon County,2005,106433,,39123,397
+Illinois,Macon County,2006,109309,,41009,430
 Illinois,Macon County,2007,108732,1237.0,44762,437
-Illinois,Macon County,2008,108328,0.0,45649,446
-Illinois,Macon County,2009,108204,0.0,44105,471
+Illinois,Macon County,2008,108328,,45649,446
+Illinois,Macon County,2009,108204,,44105,471
 Illinois,Macon County,2010,110715,1047.0,40919,460
-Illinois,Macon County,2011,110730,0.0,44415,512
+Illinois,Macon County,2011,110730,,44415,512
 Illinois,Macon County,2012,110122,1408.0,44533,504
 Illinois,Macon County,2013,109278,1105.0,45957,521
 Illinois,Macon County,2014,108350,1435.0,47574,487
-Illinois,Macon County,2015,107303,0.0,48040,502
-Illinois,Macon County,2016,106550,0.0,46198,506
-Illinois,Macon County,2017,105801,0.0,51970,507
-Illinois,Macon County,2018,104712,0.0,50066,552
-Illinois,Macon County,2019,104009,0.0,50839,500
-Illinois,Macon County,2021,102432,0.0,46807,521
-Illinois,Macon County,2022,101483,0.0,60332,575
-Illinois,Madison County,2005,258567,0.0,47350,465
+Illinois,Macon County,2015,107303,,48040,502
+Illinois,Macon County,2016,106550,,46198,506
+Illinois,Macon County,2017,105801,,51970,507
+Illinois,Macon County,2018,104712,,50066,552
+Illinois,Macon County,2019,104009,,50839,500
+Illinois,Macon County,2021,102432,,46807,521
+Illinois,Macon County,2022,101483,,60332,575
+Illinois,Madison County,2005,258567,,47350,465
 Illinois,Madison County,2006,265303,3158.0,46847,488
 Illinois,Madison County,2007,267347,4325.0,52217,508
 Illinois,Madison County,2008,268078,3769.0,51174,520
@@ -3361,10 +3361,10 @@ Illinois,Madison County,2016,265759,4715.0,56035,619
 Illinois,Madison County,2017,265428,3891.0,57890,608
 Illinois,Madison County,2018,264461,5469.0,59987,639
 Illinois,Madison County,2019,262966,6108.0,67440,637
-Illinois,Madison County,2021,264490,0.0,65663,721
+Illinois,Madison County,2021,264490,,65663,721
 Illinois,Madison County,2022,263864,17140.0,66996,699
-Illinois,Peoria County,2005,175166,0.0,44291,478
-Illinois,Peoria County,2006,182495,0.0,45691,506
+Illinois,Peoria County,2005,175166,,44291,478
+Illinois,Peoria County,2006,182495,,45691,506
 Illinois,Peoria County,2007,182993,1422.0,46652,491
 Illinois,Peoria County,2008,183655,3288.0,49533,516
 Illinois,Peoria County,2009,185816,1781.0,46961,512
@@ -3378,12 +3378,12 @@ Illinois,Peoria County,2016,185006,3043.0,51975,616
 Illinois,Peoria County,2017,183011,2303.0,53843,596
 Illinois,Peoria County,2018,180621,2906.0,56138,641
 Illinois,Peoria County,2019,179179,3189.0,57247,614
-Illinois,Peoria County,2021,179432,0.0,55949,654
-Illinois,Peoria County,2022,178383,0.0,65301,691
-Illinois,Rock Island County,2005,143140,0.0,41365,443
+Illinois,Peoria County,2021,179432,,55949,654
+Illinois,Peoria County,2022,178383,,65301,691
+Illinois,Rock Island County,2005,143140,,41365,443
 Illinois,Rock Island County,2006,147545,1729.0,43635,440
 Illinois,Rock Island County,2007,147329,1382.0,45031,474
-Illinois,Rock Island County,2008,146886,0.0,44957,519
+Illinois,Rock Island County,2008,146886,,44957,519
 Illinois,Rock Island County,2009,146826,1690.0,49486,487
 Illinois,Rock Island County,2010,147517,1737.0,45005,484
 Illinois,Rock Island County,2011,147556,2814.0,43597,540
@@ -3393,7 +3393,7 @@ Illinois,Rock Island County,2014,146063,2045.0,47751,559
 Illinois,Rock Island County,2015,146133,1994.0,50542,555
 Illinois,Rock Island County,2016,144784,1999.0,50948,591
 Illinois,Rock Island County,2017,144808,2236.0,51711,611
-Illinois,Rock Island County,2018,143477,0.0,52148,624
+Illinois,Rock Island County,2018,143477,,52148,624
 Illinois,Rock Island County,2019,141879,1249.0,58313,613
 Illinois,Rock Island County,2021,142909,4606.0,57895,685
 Illinois,Rock Island County,2022,141527,6643.0,62086,669
@@ -3414,7 +3414,7 @@ Illinois,St. Clair County,2018,261059,3599.0,59141,641
 Illinois,St. Clair County,2019,259686,5145.0,57169,590
 Illinois,St. Clair County,2021,254796,18980.0,67530,728
 Illinois,St. Clair County,2022,252671,17045.0,67395,759
-Illinois,Sangamon County,2005,189438,0.0,46115,441
+Illinois,Sangamon County,2005,189438,,46115,441
 Illinois,Sangamon County,2006,193524,2504.0,48430,499
 Illinois,Sangamon County,2007,194122,2353.0,47830,499
 Illinois,Sangamon County,2008,194925,3030.0,53507,523
@@ -3430,41 +3430,41 @@ Illinois,Sangamon County,2017,196452,3579.0,61542,621
 Illinois,Sangamon County,2018,195348,3127.0,61997,663
 Illinois,Sangamon County,2019,194672,5417.0,61280,647
 Illinois,Sangamon County,2021,194734,10377.0,68466,677
-Illinois,Sangamon County,2022,194534,0.0,73784,719
-Illinois,Tazewell County,2005,126797,0.0,49037,462
-Illinois,Tazewell County,2006,130559,0.0,49698,444
-Illinois,Tazewell County,2007,131154,0.0,52332,497
-Illinois,Tazewell County,2008,131524,0.0,55898,515
+Illinois,Sangamon County,2022,194534,,73784,719
+Illinois,Tazewell County,2005,126797,,49037,462
+Illinois,Tazewell County,2006,130559,,49698,444
+Illinois,Tazewell County,2007,131154,,52332,497
+Illinois,Tazewell County,2008,131524,,55898,515
 Illinois,Tazewell County,2009,132466,2318.0,53515,514
-Illinois,Tazewell County,2010,135433,0.0,49962,489
-Illinois,Tazewell County,2011,135661,0.0,49237,515
-Illinois,Tazewell County,2012,135949,0.0,61339,527
-Illinois,Tazewell County,2013,136352,0.0,56656,558
-Illinois,Tazewell County,2014,135707,0.0,60801,570
+Illinois,Tazewell County,2010,135433,,49962,489
+Illinois,Tazewell County,2011,135661,,49237,515
+Illinois,Tazewell County,2012,135949,,61339,527
+Illinois,Tazewell County,2013,136352,,56656,558
+Illinois,Tazewell County,2014,135707,,60801,570
 Illinois,Tazewell County,2015,134800,2088.0,57020,560
-Illinois,Tazewell County,2016,134385,0.0,60152,579
-Illinois,Tazewell County,2017,133526,0.0,60306,566
-Illinois,Tazewell County,2018,132328,0.0,60857,606
-Illinois,Tazewell County,2019,131803,0.0,65848,594
-Illinois,Tazewell County,2021,130413,0.0,63621,641
-Illinois,Tazewell County,2022,129911,0.0,72930,671
-Illinois,Vermilion County,2005,79235,0.0,34664,379
-Illinois,Vermilion County,2006,81941,0.0,39318,407
-Illinois,Vermilion County,2007,81191,0.0,37227,393
-Illinois,Vermilion County,2008,80680,0.0,41532,406
-Illinois,Vermilion County,2009,80067,0.0,35012,369
-Illinois,Vermilion County,2010,81551,0.0,38167,437
-Illinois,Vermilion County,2011,81509,0.0,40869,431
-Illinois,Vermilion County,2012,80727,0.0,40311,452
-Illinois,Vermilion County,2013,80329,0.0,45089,440
-Illinois,Vermilion County,2014,79728,0.0,41690,463
-Illinois,Vermilion County,2015,79282,0.0,45098,496
-Illinois,Vermilion County,2016,78111,0.0,45481,474
-Illinois,Vermilion County,2017,77909,0.0,42345,504
-Illinois,Vermilion County,2018,76806,0.0,43655,493
-Illinois,Vermilion County,2019,75758,0.0,43111,508
-Illinois,Vermilion County,2021,73095,0.0,49091,577
-Illinois,Vermilion County,2022,72337,0.0,51515,547
+Illinois,Tazewell County,2016,134385,,60152,579
+Illinois,Tazewell County,2017,133526,,60306,566
+Illinois,Tazewell County,2018,132328,,60857,606
+Illinois,Tazewell County,2019,131803,,65848,594
+Illinois,Tazewell County,2021,130413,,63621,641
+Illinois,Tazewell County,2022,129911,,72930,671
+Illinois,Vermilion County,2005,79235,,34664,379
+Illinois,Vermilion County,2006,81941,,39318,407
+Illinois,Vermilion County,2007,81191,,37227,393
+Illinois,Vermilion County,2008,80680,,41532,406
+Illinois,Vermilion County,2009,80067,,35012,369
+Illinois,Vermilion County,2010,81551,,38167,437
+Illinois,Vermilion County,2011,81509,,40869,431
+Illinois,Vermilion County,2012,80727,,40311,452
+Illinois,Vermilion County,2013,80329,,45089,440
+Illinois,Vermilion County,2014,79728,,41690,463
+Illinois,Vermilion County,2015,79282,,45098,496
+Illinois,Vermilion County,2016,78111,,45481,474
+Illinois,Vermilion County,2017,77909,,42345,504
+Illinois,Vermilion County,2018,76806,,43655,493
+Illinois,Vermilion County,2019,75758,,43111,508
+Illinois,Vermilion County,2021,73095,,49091,577
+Illinois,Vermilion County,2022,72337,,51515,547
 Illinois,Will County,2005,634183,10373.0,68414,684
 Illinois,Will County,2006,668217,12372.0,72816,687
 Illinois,Will County,2007,673586,11626.0,71384,723
@@ -3482,20 +3482,20 @@ Illinois,Will County,2018,692310,18677.0,85818,974
 Illinois,Will County,2019,690743,19139.0,90134,964
 Illinois,Will County,2021,697252,60105.0,93752,1106
 Illinois,Will County,2022,696757,52261.0,96668,1163
-Illinois,Williamson County,2009,65169,0.0,39169,458
-Illinois,Williamson County,2010,66369,0.0,43709,411
-Illinois,Williamson County,2011,66622,0.0,40439,505
-Illinois,Williamson County,2012,66674,0.0,40658,445
-Illinois,Williamson County,2013,66924,0.0,44418,483
-Illinois,Williamson County,2014,67008,0.0,49153,516
-Illinois,Williamson County,2015,67466,0.0,48736,574
-Illinois,Williamson County,2016,67560,0.0,48409,525
-Illinois,Williamson County,2017,67328,0.0,50408,540
-Illinois,Williamson County,2018,67056,0.0,43568,533
-Illinois,Williamson County,2019,66597,0.0,58097,626
-Illinois,Williamson County,2021,66879,0.0,54859,650
-Illinois,Williamson County,2022,66695,0.0,67631,613
-Illinois,Winnebago County,2005,283565,0.0,43451,495
+Illinois,Williamson County,2009,65169,,39169,458
+Illinois,Williamson County,2010,66369,,43709,411
+Illinois,Williamson County,2011,66622,,40439,505
+Illinois,Williamson County,2012,66674,,40658,445
+Illinois,Williamson County,2013,66924,,44418,483
+Illinois,Williamson County,2014,67008,,49153,516
+Illinois,Williamson County,2015,67466,,48736,574
+Illinois,Williamson County,2016,67560,,48409,525
+Illinois,Williamson County,2017,67328,,50408,540
+Illinois,Williamson County,2018,67056,,43568,533
+Illinois,Williamson County,2019,66597,,58097,626
+Illinois,Williamson County,2021,66879,,54859,650
+Illinois,Williamson County,2022,66695,,67631,613
+Illinois,Winnebago County,2005,283565,,43451,495
 Illinois,Winnebago County,2006,295635,4137.0,44776,496
 Illinois,Winnebago County,2007,298759,3821.0,48101,536
 Illinois,Winnebago County,2008,300252,3324.0,47150,537
@@ -3529,63 +3529,63 @@ Indiana,Allen County,2018,375351,7468.0,54260,624
 Indiana,Allen County,2019,379299,8096.0,56519,626
 Indiana,Allen County,2021,388608,17869.0,62542,697
 Indiana,Allen County,2022,391449,19076.0,65732,778
-Indiana,Bartholomew County,2005,72650,0.0,44320,545
-Indiana,Bartholomew County,2006,74444,0.0,49838,519
-Indiana,Bartholomew County,2007,74750,0.0,54406,590
-Indiana,Bartholomew County,2008,75360,0.0,50933,550
-Indiana,Bartholomew County,2009,76063,0.0,49415,571
-Indiana,Bartholomew County,2010,76855,0.0,47192,607
-Indiana,Bartholomew County,2011,77870,0.0,54197,599
-Indiana,Bartholomew County,2012,79129,0.0,53671,641
-Indiana,Bartholomew County,2013,79587,0.0,52505,614
-Indiana,Bartholomew County,2014,80217,0.0,53002,626
-Indiana,Bartholomew County,2015,81162,0.0,54447,687
-Indiana,Bartholomew County,2016,81402,0.0,59102,723
-Indiana,Bartholomew County,2017,82040,0.0,61533,707
-Indiana,Bartholomew County,2018,82753,0.0,62047,732
-Indiana,Bartholomew County,2019,83779,0.0,72555,770
-Indiana,Bartholomew County,2021,82475,0.0,73564,847
+Indiana,Bartholomew County,2005,72650,,44320,545
+Indiana,Bartholomew County,2006,74444,,49838,519
+Indiana,Bartholomew County,2007,74750,,54406,590
+Indiana,Bartholomew County,2008,75360,,50933,550
+Indiana,Bartholomew County,2009,76063,,49415,571
+Indiana,Bartholomew County,2010,76855,,47192,607
+Indiana,Bartholomew County,2011,77870,,54197,599
+Indiana,Bartholomew County,2012,79129,,53671,641
+Indiana,Bartholomew County,2013,79587,,52505,614
+Indiana,Bartholomew County,2014,80217,,53002,626
+Indiana,Bartholomew County,2015,81162,,54447,687
+Indiana,Bartholomew County,2016,81402,,59102,723
+Indiana,Bartholomew County,2017,82040,,61533,707
+Indiana,Bartholomew County,2018,82753,,62047,732
+Indiana,Bartholomew County,2019,83779,,72555,770
+Indiana,Bartholomew County,2021,82475,,73564,847
 Indiana,Bartholomew County,2022,83540,4133.0,65739,807
-Indiana,Boone County,2017,65875,0.0,81785,894
-Indiana,Boone County,2018,66999,0.0,81145,850
-Indiana,Boone County,2019,67843,0.0,70813,885
-Indiana,Boone County,2021,73052,0.0,98867,1003
-Indiana,Boone County,2022,74164,0.0,102005,955
-Indiana,Clark County,2005,100014,0.0,42153,477
-Indiana,Clark County,2006,103569,0.0,41719,494
-Indiana,Clark County,2007,105035,0.0,44454,498
-Indiana,Clark County,2008,106673,0.0,48449,536
-Indiana,Clark County,2009,108634,0.0,48605,565
-Indiana,Clark County,2010,110610,0.0,44099,545
-Indiana,Clark County,2011,111570,0.0,52464,541
-Indiana,Clark County,2012,111951,0.0,50075,582
-Indiana,Clark County,2013,112938,0.0,50760,600
+Indiana,Boone County,2017,65875,,81785,894
+Indiana,Boone County,2018,66999,,81145,850
+Indiana,Boone County,2019,67843,,70813,885
+Indiana,Boone County,2021,73052,,98867,1003
+Indiana,Boone County,2022,74164,,102005,955
+Indiana,Clark County,2005,100014,,42153,477
+Indiana,Clark County,2006,103569,,41719,494
+Indiana,Clark County,2007,105035,,44454,498
+Indiana,Clark County,2008,106673,,48449,536
+Indiana,Clark County,2009,108634,,48605,565
+Indiana,Clark County,2010,110610,,44099,545
+Indiana,Clark County,2011,111570,,52464,541
+Indiana,Clark County,2012,111951,,50075,582
+Indiana,Clark County,2013,112938,,50760,600
 Indiana,Clark County,2014,114262,1658.0,52674,605
-Indiana,Clark County,2015,115371,0.0,51828,634
-Indiana,Clark County,2016,116031,0.0,51401,637
-Indiana,Clark County,2017,116973,0.0,52036,652
-Indiana,Clark County,2018,117360,0.0,56307,675
-Indiana,Clark County,2019,118302,0.0,59064,710
-Indiana,Clark County,2021,122738,0.0,62231,735
-Indiana,Clark County,2022,124237,0.0,68350,831
-Indiana,Delaware County,2005,108356,0.0,34227,471
+Indiana,Clark County,2015,115371,,51828,634
+Indiana,Clark County,2016,116031,,51401,637
+Indiana,Clark County,2017,116973,,52036,652
+Indiana,Clark County,2018,117360,,56307,675
+Indiana,Clark County,2019,118302,,59064,710
+Indiana,Clark County,2021,122738,,62231,735
+Indiana,Clark County,2022,124237,,68350,831
+Indiana,Delaware County,2005,108356,,34227,471
 Indiana,Delaware County,2006,114879,1458.0,34516,481
-Indiana,Delaware County,2007,115419,0.0,37702,471
-Indiana,Delaware County,2008,114685,0.0,38927,517
-Indiana,Delaware County,2009,115192,0.0,34781,472
-Indiana,Delaware County,2010,117669,0.0,35902,505
+Indiana,Delaware County,2007,115419,,37702,471
+Indiana,Delaware County,2008,114685,,38927,517
+Indiana,Delaware County,2009,115192,,34781,472
+Indiana,Delaware County,2010,117669,,35902,505
 Indiana,Delaware County,2011,117660,1035.0,36811,539
-Indiana,Delaware County,2012,117364,0.0,37032,517
+Indiana,Delaware County,2012,117364,,37032,517
 Indiana,Delaware County,2013,117484,1880.0,36402,550
-Indiana,Delaware County,2014,117074,0.0,39323,533
+Indiana,Delaware County,2014,117074,,39323,533
 Indiana,Delaware County,2015,116852,841.0,40606,540
-Indiana,Delaware County,2016,115603,0.0,41041,523
+Indiana,Delaware County,2016,115603,,41041,523
 Indiana,Delaware County,2017,115184,3209.0,41255,543
-Indiana,Delaware County,2018,114772,0.0,41662,611
+Indiana,Delaware County,2018,114772,,41662,611
 Indiana,Delaware County,2019,114135,1585.0,45065,579
-Indiana,Delaware County,2021,111871,0.0,50497,595
-Indiana,Delaware County,2022,112031,0.0,54087,681
-Indiana,Elkhart County,2005,192562,0.0,44886,540
+Indiana,Delaware County,2021,111871,,50497,595
+Indiana,Delaware County,2022,112031,,54087,681
+Indiana,Elkhart County,2005,192562,,44886,540
 Indiana,Elkhart County,2006,198105,3630.0,46710,562
 Indiana,Elkhart County,2007,197942,2314.0,47965,562
 Indiana,Elkhart County,2008,199137,3393.0,49507,583
@@ -3602,141 +3602,141 @@ Indiana,Elkhart County,2018,205560,3671.0,58350,667
 Indiana,Elkhart County,2019,206341,3910.0,54531,697
 Indiana,Elkhart County,2021,206921,5816.0,60143,754
 Indiana,Elkhart County,2022,206890,5173.0,61922,792
-Indiana,Floyd County,2005,70932,0.0,46922,483
-Indiana,Floyd County,2006,72570,0.0,51213,527
-Indiana,Floyd County,2007,73064,0.0,53441,536
-Indiana,Floyd County,2008,73780,0.0,49295,537
-Indiana,Floyd County,2009,74426,0.0,52109,545
-Indiana,Floyd County,2010,74679,0.0,47804,564
-Indiana,Floyd County,2011,74989,0.0,50940,533
-Indiana,Floyd County,2012,75283,0.0,53990,558
-Indiana,Floyd County,2013,76244,0.0,57401,571
-Indiana,Floyd County,2014,76179,0.0,52819,601
-Indiana,Floyd County,2015,76778,0.0,58096,552
-Indiana,Floyd County,2016,76990,0.0,58586,616
-Indiana,Floyd County,2017,77071,0.0,60690,615
-Indiana,Floyd County,2018,77781,0.0,66391,685
-Indiana,Floyd County,2019,78522,0.0,63219,673
-Indiana,Floyd County,2021,80454,0.0,66596,765
-Indiana,Floyd County,2022,80714,0.0,73899,838
-Indiana,Grant County,2005,65632,0.0,34286,388
-Indiana,Grant County,2006,69825,0.0,39219,372
-Indiana,Grant County,2007,68847,0.0,36143,423
-Indiana,Grant County,2008,68609,0.0,36694,423
-Indiana,Grant County,2009,68796,0.0,39006,451
-Indiana,Grant County,2010,69975,0.0,34716,417
-Indiana,Grant County,2011,69793,0.0,38187,433
-Indiana,Grant County,2012,69330,0.0,38877,481
-Indiana,Grant County,2013,69126,0.0,38665,463
-Indiana,Grant County,2014,68569,0.0,39851,481
-Indiana,Grant County,2015,67979,0.0,38645,498
-Indiana,Grant County,2016,66937,0.0,37117,492
-Indiana,Grant County,2017,66491,0.0,44768,516
-Indiana,Grant County,2018,65936,0.0,44839,466
-Indiana,Grant County,2019,65769,0.0,47206,554
-Indiana,Grant County,2021,66263,0.0,49401,560
-Indiana,Grant County,2022,66022,0.0,50366,612
-Indiana,Hamilton County,2005,239043,0.0,78932,687
+Indiana,Floyd County,2005,70932,,46922,483
+Indiana,Floyd County,2006,72570,,51213,527
+Indiana,Floyd County,2007,73064,,53441,536
+Indiana,Floyd County,2008,73780,,49295,537
+Indiana,Floyd County,2009,74426,,52109,545
+Indiana,Floyd County,2010,74679,,47804,564
+Indiana,Floyd County,2011,74989,,50940,533
+Indiana,Floyd County,2012,75283,,53990,558
+Indiana,Floyd County,2013,76244,,57401,571
+Indiana,Floyd County,2014,76179,,52819,601
+Indiana,Floyd County,2015,76778,,58096,552
+Indiana,Floyd County,2016,76990,,58586,616
+Indiana,Floyd County,2017,77071,,60690,615
+Indiana,Floyd County,2018,77781,,66391,685
+Indiana,Floyd County,2019,78522,,63219,673
+Indiana,Floyd County,2021,80454,,66596,765
+Indiana,Floyd County,2022,80714,,73899,838
+Indiana,Grant County,2005,65632,,34286,388
+Indiana,Grant County,2006,69825,,39219,372
+Indiana,Grant County,2007,68847,,36143,423
+Indiana,Grant County,2008,68609,,36694,423
+Indiana,Grant County,2009,68796,,39006,451
+Indiana,Grant County,2010,69975,,34716,417
+Indiana,Grant County,2011,69793,,38187,433
+Indiana,Grant County,2012,69330,,38877,481
+Indiana,Grant County,2013,69126,,38665,463
+Indiana,Grant County,2014,68569,,39851,481
+Indiana,Grant County,2015,67979,,38645,498
+Indiana,Grant County,2016,66937,,37117,492
+Indiana,Grant County,2017,66491,,44768,516
+Indiana,Grant County,2018,65936,,44839,466
+Indiana,Grant County,2019,65769,,47206,554
+Indiana,Grant County,2021,66263,,49401,560
+Indiana,Grant County,2022,66022,,50366,612
+Indiana,Hamilton County,2005,239043,,78932,687
 Indiana,Hamilton County,2006,250979,7609.0,75410,723
 Indiana,Hamilton County,2007,261661,7763.0,81916,740
 Indiana,Hamilton County,2008,269785,8750.0,85234,767
 Indiana,Hamilton County,2009,279287,8204.0,74931,782
-Indiana,Hamilton County,2010,276390,0.0,80808,749
-Indiana,Hamilton County,2011,282810,0.0,80999,755
-Indiana,Hamilton County,2012,289495,0.0,85567,792
+Indiana,Hamilton County,2010,276390,,80808,749
+Indiana,Hamilton County,2011,282810,,80999,755
+Indiana,Hamilton County,2012,289495,,85567,792
 Indiana,Hamilton County,2013,296693,9999.0,81958,861
 Indiana,Hamilton County,2014,302623,11323.0,88155,896
 Indiana,Hamilton County,2015,309697,12252.0,90613,919
-Indiana,Hamilton County,2016,316373,0.0,89823,973
-Indiana,Hamilton County,2017,323747,0.0,93604,953
-Indiana,Hamilton County,2018,330086,0.0,100209,1053
-Indiana,Hamilton County,2019,338011,0.0,105062,1074
-Indiana,Hamilton County,2021,356650,0.0,102452,1206
+Indiana,Hamilton County,2016,316373,,89823,973
+Indiana,Hamilton County,2017,323747,,93604,953
+Indiana,Hamilton County,2018,330086,,100209,1053
+Indiana,Hamilton County,2019,338011,,105062,1074
+Indiana,Hamilton County,2021,356650,,102452,1206
 Indiana,Hamilton County,2022,364921,37250.0,114807,1283
-Indiana,Hancock County,2006,65050,0.0,60815,575
-Indiana,Hancock County,2007,66305,0.0,62005,563
-Indiana,Hancock County,2008,67282,0.0,61296,564
-Indiana,Hancock County,2009,68334,0.0,56096,617
-Indiana,Hancock County,2010,70250,0.0,58587,638
-Indiana,Hancock County,2011,70529,0.0,57062,628
-Indiana,Hancock County,2012,70933,0.0,62794,683
-Indiana,Hancock County,2013,71575,0.0,65421,623
-Indiana,Hancock County,2014,71978,0.0,67485,682
-Indiana,Hancock County,2015,72520,0.0,69968,700
-Indiana,Hancock County,2016,73717,0.0,67799,721
-Indiana,Hancock County,2017,74985,0.0,70473,752
-Indiana,Hancock County,2018,76351,0.0,71653,739
-Indiana,Hancock County,2019,78168,0.0,69392,805
-Indiana,Hancock County,2021,81789,0.0,79182,830
-Indiana,Hancock County,2022,83070,0.0,86504,934
-Indiana,Hendricks County,2005,123931,0.0,57538,636
-Indiana,Hendricks County,2006,131204,0.0,60891,642
-Indiana,Hendricks County,2007,134558,0.0,66251,714
-Indiana,Hendricks County,2008,137240,0.0,65624,727
-Indiana,Hendricks County,2009,140606,0.0,65805,725
-Indiana,Hendricks County,2010,145867,0.0,65218,699
-Indiana,Hendricks County,2011,147979,0.0,61687,703
-Indiana,Hendricks County,2012,150434,0.0,70867,737
-Indiana,Hendricks County,2013,153879,0.0,67535,734
-Indiana,Hendricks County,2014,156056,0.0,66989,805
-Indiana,Hendricks County,2015,158192,0.0,73050,847
-Indiana,Hendricks County,2016,160610,0.0,78307,858
-Indiana,Hendricks County,2017,163685,0.0,70991,848
-Indiana,Hendricks County,2018,167009,0.0,80582,878
-Indiana,Hendricks County,2019,170311,0.0,85381,980
-Indiana,Hendricks County,2021,179355,0.0,89228,1031
-Indiana,Hendricks County,2022,182534,0.0,93193,1140
-Indiana,Howard County,2005,83865,0.0,45251,480
-Indiana,Howard County,2006,84500,0.0,42055,456
-Indiana,Howard County,2007,83776,0.0,44361,458
-Indiana,Howard County,2008,83381,0.0,48117,490
-Indiana,Howard County,2009,82895,0.0,47668,502
-Indiana,Howard County,2010,82770,0.0,36733,484
-Indiana,Howard County,2011,82800,0.0,37589,472
-Indiana,Howard County,2012,82849,0.0,38849,495
-Indiana,Howard County,2013,82760,0.0,44265,464
-Indiana,Howard County,2014,82982,0.0,47159,530
-Indiana,Howard County,2015,82556,0.0,46793,513
-Indiana,Howard County,2016,82568,0.0,45702,558
-Indiana,Howard County,2017,82363,0.0,49346,548
-Indiana,Howard County,2018,82366,0.0,55868,565
-Indiana,Howard County,2019,82544,0.0,53440,569
-Indiana,Howard County,2021,83687,0.0,55088,714
-Indiana,Howard County,2022,83574,0.0,55297,699
-Indiana,Johnson County,2005,124745,0.0,56251,564
-Indiana,Johnson County,2006,133316,0.0,60977,632
-Indiana,Johnson County,2007,135951,0.0,59333,604
-Indiana,Johnson County,2008,139158,0.0,61900,633
-Indiana,Johnson County,2009,141501,0.0,56671,622
-Indiana,Johnson County,2010,140009,0.0,58318,679
-Indiana,Johnson County,2011,141656,0.0,62274,667
-Indiana,Johnson County,2012,143191,0.0,61597,672
-Indiana,Johnson County,2013,145535,0.0,57245,684
-Indiana,Johnson County,2014,147538,0.0,55201,664
-Indiana,Johnson County,2015,149633,0.0,68744,690
-Indiana,Johnson County,2016,151982,0.0,65991,756
-Indiana,Johnson County,2017,153897,0.0,70339,749
-Indiana,Johnson County,2018,156225,0.0,68209,758
-Indiana,Johnson County,2019,158167,0.0,73651,795
-Indiana,Johnson County,2021,164298,0.0,78697,901
-Indiana,Johnson County,2022,165782,0.0,81670,1020
-Indiana,Kosciusko County,2005,74665,0.0,46787,445
-Indiana,Kosciusko County,2006,76541,0.0,47352,497
-Indiana,Kosciusko County,2007,76115,0.0,50332,492
-Indiana,Kosciusko County,2008,76275,0.0,49142,524
-Indiana,Kosciusko County,2009,76499,0.0,46494,478
-Indiana,Kosciusko County,2010,77368,0.0,47308,553
-Indiana,Kosciusko County,2011,77336,0.0,50803,521
-Indiana,Kosciusko County,2012,77609,0.0,49301,530
-Indiana,Kosciusko County,2013,77963,0.0,51221,502
-Indiana,Kosciusko County,2014,78564,0.0,53825,587
-Indiana,Kosciusko County,2015,78620,0.0,52888,605
-Indiana,Kosciusko County,2016,79092,0.0,53963,599
-Indiana,Kosciusko County,2017,79206,0.0,63463,583
-Indiana,Kosciusko County,2018,79344,0.0,55253,625
-Indiana,Kosciusko County,2019,79456,0.0,64099,536
-Indiana,Kosciusko County,2021,80106,0.0,65540,759
-Indiana,Kosciusko County,2022,80826,0.0,68778,811
+Indiana,Hancock County,2006,65050,,60815,575
+Indiana,Hancock County,2007,66305,,62005,563
+Indiana,Hancock County,2008,67282,,61296,564
+Indiana,Hancock County,2009,68334,,56096,617
+Indiana,Hancock County,2010,70250,,58587,638
+Indiana,Hancock County,2011,70529,,57062,628
+Indiana,Hancock County,2012,70933,,62794,683
+Indiana,Hancock County,2013,71575,,65421,623
+Indiana,Hancock County,2014,71978,,67485,682
+Indiana,Hancock County,2015,72520,,69968,700
+Indiana,Hancock County,2016,73717,,67799,721
+Indiana,Hancock County,2017,74985,,70473,752
+Indiana,Hancock County,2018,76351,,71653,739
+Indiana,Hancock County,2019,78168,,69392,805
+Indiana,Hancock County,2021,81789,,79182,830
+Indiana,Hancock County,2022,83070,,86504,934
+Indiana,Hendricks County,2005,123931,,57538,636
+Indiana,Hendricks County,2006,131204,,60891,642
+Indiana,Hendricks County,2007,134558,,66251,714
+Indiana,Hendricks County,2008,137240,,65624,727
+Indiana,Hendricks County,2009,140606,,65805,725
+Indiana,Hendricks County,2010,145867,,65218,699
+Indiana,Hendricks County,2011,147979,,61687,703
+Indiana,Hendricks County,2012,150434,,70867,737
+Indiana,Hendricks County,2013,153879,,67535,734
+Indiana,Hendricks County,2014,156056,,66989,805
+Indiana,Hendricks County,2015,158192,,73050,847
+Indiana,Hendricks County,2016,160610,,78307,858
+Indiana,Hendricks County,2017,163685,,70991,848
+Indiana,Hendricks County,2018,167009,,80582,878
+Indiana,Hendricks County,2019,170311,,85381,980
+Indiana,Hendricks County,2021,179355,,89228,1031
+Indiana,Hendricks County,2022,182534,,93193,1140
+Indiana,Howard County,2005,83865,,45251,480
+Indiana,Howard County,2006,84500,,42055,456
+Indiana,Howard County,2007,83776,,44361,458
+Indiana,Howard County,2008,83381,,48117,490
+Indiana,Howard County,2009,82895,,47668,502
+Indiana,Howard County,2010,82770,,36733,484
+Indiana,Howard County,2011,82800,,37589,472
+Indiana,Howard County,2012,82849,,38849,495
+Indiana,Howard County,2013,82760,,44265,464
+Indiana,Howard County,2014,82982,,47159,530
+Indiana,Howard County,2015,82556,,46793,513
+Indiana,Howard County,2016,82568,,45702,558
+Indiana,Howard County,2017,82363,,49346,548
+Indiana,Howard County,2018,82366,,55868,565
+Indiana,Howard County,2019,82544,,53440,569
+Indiana,Howard County,2021,83687,,55088,714
+Indiana,Howard County,2022,83574,,55297,699
+Indiana,Johnson County,2005,124745,,56251,564
+Indiana,Johnson County,2006,133316,,60977,632
+Indiana,Johnson County,2007,135951,,59333,604
+Indiana,Johnson County,2008,139158,,61900,633
+Indiana,Johnson County,2009,141501,,56671,622
+Indiana,Johnson County,2010,140009,,58318,679
+Indiana,Johnson County,2011,141656,,62274,667
+Indiana,Johnson County,2012,143191,,61597,672
+Indiana,Johnson County,2013,145535,,57245,684
+Indiana,Johnson County,2014,147538,,55201,664
+Indiana,Johnson County,2015,149633,,68744,690
+Indiana,Johnson County,2016,151982,,65991,756
+Indiana,Johnson County,2017,153897,,70339,749
+Indiana,Johnson County,2018,156225,,68209,758
+Indiana,Johnson County,2019,158167,,73651,795
+Indiana,Johnson County,2021,164298,,78697,901
+Indiana,Johnson County,2022,165782,,81670,1020
+Indiana,Kosciusko County,2005,74665,,46787,445
+Indiana,Kosciusko County,2006,76541,,47352,497
+Indiana,Kosciusko County,2007,76115,,50332,492
+Indiana,Kosciusko County,2008,76275,,49142,524
+Indiana,Kosciusko County,2009,76499,,46494,478
+Indiana,Kosciusko County,2010,77368,,47308,553
+Indiana,Kosciusko County,2011,77336,,50803,521
+Indiana,Kosciusko County,2012,77609,,49301,530
+Indiana,Kosciusko County,2013,77963,,51221,502
+Indiana,Kosciusko County,2014,78564,,53825,587
+Indiana,Kosciusko County,2015,78620,,52888,605
+Indiana,Kosciusko County,2016,79092,,53963,599
+Indiana,Kosciusko County,2017,79206,,63463,583
+Indiana,Kosciusko County,2018,79344,,55253,625
+Indiana,Kosciusko County,2019,79456,,64099,536
+Indiana,Kosciusko County,2021,80106,,65540,759
+Indiana,Kosciusko County,2022,80826,,68778,811
 Indiana,Lake County,2005,487663,3586.0,42420,535
 Indiana,Lake County,2006,494202,3976.0,46436,587
 Indiana,Lake County,2007,492104,4805.0,48042,576
@@ -3754,40 +3754,40 @@ Indiana,Lake County,2018,484411,7052.0,55154,722
 Indiana,Lake County,2019,485493,6632.0,57081,750
 Indiana,Lake County,2021,498558,17434.0,61443,797
 Indiana,Lake County,2022,499689,21747.0,66085,823
-Indiana,LaPorte County,2005,104164,0.0,45960,463
-Indiana,LaPorte County,2006,110479,0.0,47043,519
-Indiana,LaPorte County,2007,109787,0.0,43480,480
-Indiana,LaPorte County,2008,110888,0.0,45613,535
-Indiana,LaPorte County,2009,111063,0.0,46168,499
-Indiana,LaPorte County,2010,111465,0.0,43765,551
-Indiana,LaPorte County,2011,111374,0.0,48389,557
-Indiana,LaPorte County,2012,111246,0.0,46048,548
-Indiana,LaPorte County,2013,111281,0.0,46506,574
-Indiana,LaPorte County,2014,111444,0.0,45744,588
+Indiana,LaPorte County,2005,104164,,45960,463
+Indiana,LaPorte County,2006,110479,,47043,519
+Indiana,LaPorte County,2007,109787,,43480,480
+Indiana,LaPorte County,2008,110888,,45613,535
+Indiana,LaPorte County,2009,111063,,46168,499
+Indiana,LaPorte County,2010,111465,,43765,551
+Indiana,LaPorte County,2011,111374,,48389,557
+Indiana,LaPorte County,2012,111246,,46048,548
+Indiana,LaPorte County,2013,111281,,46506,574
+Indiana,LaPorte County,2014,111444,,45744,588
 Indiana,LaPorte County,2015,110884,1623.0,45838,568
-Indiana,LaPorte County,2016,110015,0.0,53507,613
-Indiana,LaPorte County,2017,110029,0.0,50736,593
-Indiana,LaPorte County,2018,110007,0.0,51584,624
-Indiana,LaPorte County,2019,109888,0.0,56019,610
-Indiana,LaPorte County,2021,112390,0.0,63714,764
-Indiana,LaPorte County,2022,111675,0.0,66659,740
-Indiana,Madison County,2005,125161,0.0,40050,467
-Indiana,Madison County,2006,130575,0.0,40990,467
-Indiana,Madison County,2007,131312,0.0,42783,462
+Indiana,LaPorte County,2016,110015,,53507,613
+Indiana,LaPorte County,2017,110029,,50736,593
+Indiana,LaPorte County,2018,110007,,51584,624
+Indiana,LaPorte County,2019,109888,,56019,610
+Indiana,LaPorte County,2021,112390,,63714,764
+Indiana,LaPorte County,2022,111675,,66659,740
+Indiana,Madison County,2005,125161,,40050,467
+Indiana,Madison County,2006,130575,,40990,467
+Indiana,Madison County,2007,131312,,42783,462
 Indiana,Madison County,2008,131501,1537.0,44133,476
-Indiana,Madison County,2009,131417,0.0,41741,497
+Indiana,Madison County,2009,131417,,41741,497
 Indiana,Madison County,2010,131642,1062.0,38772,509
-Indiana,Madison County,2011,131235,0.0,42129,491
+Indiana,Madison County,2011,131235,,42129,491
 Indiana,Madison County,2012,130348,1959.0,42933,514
 Indiana,Madison County,2013,130482,2273.0,40913,521
-Indiana,Madison County,2014,130069,0.0,45134,533
+Indiana,Madison County,2014,130069,,45134,533
 Indiana,Madison County,2015,129723,1781.0,45257,560
 Indiana,Madison County,2016,129296,1956.0,45495,532
-Indiana,Madison County,2017,129498,0.0,43060,550
-Indiana,Madison County,2018,129641,0.0,49615,594
+Indiana,Madison County,2017,129498,,43060,550
+Indiana,Madison County,2018,129641,,49615,594
 Indiana,Madison County,2019,129569,2607.0,55142,609
-Indiana,Madison County,2021,130782,0.0,53785,608
-Indiana,Madison County,2022,131744,0.0,58937,628
+Indiana,Madison County,2021,130782,,53785,608
+Indiana,Madison County,2022,131744,,58937,628
 Indiana,Marion County,2005,844187,11244.0,41964,540
 Indiana,Marion County,2006,865504,13429.0,41947,546
 Indiana,Marion County,2007,876804,11543.0,45071,560
@@ -3805,10 +3805,10 @@ Indiana,Marion County,2018,954670,15264.0,47780,711
 Indiana,Marion County,2019,964582,18508.0,50458,731
 Indiana,Marion County,2021,971102,76962.0,58560,799
 Indiana,Marion County,2022,969466,69647.0,62565,850
-Indiana,Monroe County,2005,107671,0.0,34308,549
+Indiana,Monroe County,2005,107671,,34308,549
 Indiana,Monroe County,2006,122613,2919.0,38264,585
 Indiana,Monroe County,2007,128643,1730.0,37534,577
-Indiana,Monroe County,2008,128992,0.0,38409,592
+Indiana,Monroe County,2008,128992,,38409,592
 Indiana,Monroe County,2009,130738,2458.0,34675,623
 Indiana,Monroe County,2010,138422,2262.0,36392,614
 Indiana,Monroe County,2011,139799,1306.0,38149,663
@@ -3817,46 +3817,46 @@ Indiana,Monroe County,2013,141888,3431.0,41972,688
 Indiana,Monroe County,2014,143339,3278.0,43657,719
 Indiana,Monroe County,2015,144705,2664.0,45062,718
 Indiana,Monroe County,2016,145496,2017.0,43582,756
-Indiana,Monroe County,2017,146986,0.0,48713,726
+Indiana,Monroe County,2017,146986,,48713,726
 Indiana,Monroe County,2018,146917,3402.0,47369,760
 Indiana,Monroe County,2019,148431,3649.0,52453,823
 Indiana,Monroe County,2021,139875,12149.0,51945,871
 Indiana,Monroe County,2022,139745,10178.0,65043,903
-Indiana,Morgan County,2005,69141,0.0,50145,512
-Indiana,Morgan County,2006,70290,0.0,52352,543
-Indiana,Morgan County,2007,69874,0.0,52399,556
-Indiana,Morgan County,2008,70668,0.0,54991,508
-Indiana,Morgan County,2009,70876,0.0,55668,572
-Indiana,Morgan County,2010,69061,0.0,52965,534
-Indiana,Morgan County,2011,69464,0.0,52051,597
-Indiana,Morgan County,2012,69356,0.0,50519,592
-Indiana,Morgan County,2013,69782,0.0,56664,579
-Indiana,Morgan County,2014,69693,0.0,52891,558
-Indiana,Morgan County,2015,69648,0.0,58755,616
-Indiana,Morgan County,2016,69698,0.0,60530,634
-Indiana,Morgan County,2017,69713,0.0,60946,605
-Indiana,Morgan County,2018,70116,0.0,68338,624
-Indiana,Morgan County,2019,70489,0.0,62862,683
-Indiana,Morgan County,2021,72206,0.0,67848,703
-Indiana,Morgan County,2022,72236,0.0,75344,770
-Indiana,Porter County,2005,154188,0.0,55241,628
+Indiana,Morgan County,2005,69141,,50145,512
+Indiana,Morgan County,2006,70290,,52352,543
+Indiana,Morgan County,2007,69874,,52399,556
+Indiana,Morgan County,2008,70668,,54991,508
+Indiana,Morgan County,2009,70876,,55668,572
+Indiana,Morgan County,2010,69061,,52965,534
+Indiana,Morgan County,2011,69464,,52051,597
+Indiana,Morgan County,2012,69356,,50519,592
+Indiana,Morgan County,2013,69782,,56664,579
+Indiana,Morgan County,2014,69693,,52891,558
+Indiana,Morgan County,2015,69648,,58755,616
+Indiana,Morgan County,2016,69698,,60530,634
+Indiana,Morgan County,2017,69713,,60946,605
+Indiana,Morgan County,2018,70116,,68338,624
+Indiana,Morgan County,2019,70489,,62862,683
+Indiana,Morgan County,2021,72206,,67848,703
+Indiana,Morgan County,2022,72236,,75344,770
+Indiana,Porter County,2005,154188,,55241,628
 Indiana,Porter County,2006,160105,2734.0,56710,618
 Indiana,Porter County,2007,160578,2567.0,59521,612
-Indiana,Porter County,2008,162181,0.0,62120,658
+Indiana,Porter County,2008,162181,,62120,658
 Indiana,Porter County,2009,163598,1705.0,57234,689
-Indiana,Porter County,2010,164592,0.0,55186,692
-Indiana,Porter County,2011,165537,0.0,61432,712
-Indiana,Porter County,2012,165682,0.0,63050,700
+Indiana,Porter County,2010,164592,,55186,692
+Indiana,Porter County,2011,165537,,61432,712
+Indiana,Porter County,2012,165682,,63050,700
 Indiana,Porter County,2013,166557,2219.0,63806,713
 Indiana,Porter County,2014,167076,3235.0,60903,717
-Indiana,Porter County,2015,167688,0.0,63807,744
-Indiana,Porter County,2016,167791,0.0,66196,746
+Indiana,Porter County,2015,167688,,63807,744
+Indiana,Porter County,2016,167791,,66196,746
 Indiana,Porter County,2017,168404,5340.0,65747,749
-Indiana,Porter County,2018,169594,0.0,66476,814
-Indiana,Porter County,2019,170389,0.0,72483,775
-Indiana,Porter County,2021,174243,0.0,80547,915
-Indiana,Porter County,2022,174791,0.0,83395,910
-Indiana,St. Joseph County,2005,252673,0.0,41273,557
+Indiana,Porter County,2018,169594,,66476,814
+Indiana,Porter County,2019,170389,,72483,775
+Indiana,Porter County,2021,174243,,80547,915
+Indiana,Porter County,2022,174791,,83395,910
+Indiana,St. Joseph County,2005,252673,,41273,557
 Indiana,St. Joseph County,2006,266678,3927.0,43691,564
 Indiana,St. Joseph County,2007,266088,3148.0,44260,545
 Indiana,St. Joseph County,2008,266680,3499.0,43129,582
@@ -3873,7 +3873,7 @@ Indiana,St. Joseph County,2018,270771,4907.0,54434,677
 Indiana,St. Joseph County,2019,271826,5903.0,53456,697
 Indiana,St. Joseph County,2021,272212,13755.0,59189,732
 Indiana,St. Joseph County,2022,272234,12303.0,60627,829
-Indiana,Tippecanoe County,2005,139317,0.0,39981,564
+Indiana,Tippecanoe County,2005,139317,,39981,564
 Indiana,Tippecanoe County,2006,156169,2150.0,39365,566
 Indiana,Tippecanoe County,2007,163364,3819.0,40910,565
 Indiana,Tippecanoe County,2008,164237,2450.0,44793,580
@@ -3888,9 +3888,9 @@ Indiana,Tippecanoe County,2016,188059,2232.0,51361,663
 Indiana,Tippecanoe County,2017,190587,3409.0,52183,664
 Indiana,Tippecanoe County,2018,193048,2864.0,50256,698
 Indiana,Tippecanoe County,2019,195732,3370.0,49352,747
-Indiana,Tippecanoe County,2021,187076,0.0,52617,772
+Indiana,Tippecanoe County,2021,187076,,52617,772
 Indiana,Tippecanoe County,2022,188717,10024.0,54168,861
-Indiana,Vanderburgh County,2005,165769,0.0,41744,466
+Indiana,Vanderburgh County,2005,165769,,41744,466
 Indiana,Vanderburgh County,2006,173356,1599.0,38787,455
 Indiana,Vanderburgh County,2007,174425,1530.0,42015,489
 Indiana,Vanderburgh County,2008,174729,1762.0,41084,493
@@ -3903,91 +3903,91 @@ Indiana,Vanderburgh County,2014,182006,2235.0,42044,555
 Indiana,Vanderburgh County,2015,181877,1928.0,42564,540
 Indiana,Vanderburgh County,2016,181721,1635.0,46064,555
 Indiana,Vanderburgh County,2017,181616,2169.0,46681,595
-Indiana,Vanderburgh County,2018,180974,0.0,50325,600
+Indiana,Vanderburgh County,2018,180974,,50325,600
 Indiana,Vanderburgh County,2019,181451,2015.0,51350,643
 Indiana,Vanderburgh County,2021,179987,7520.0,53171,670
 Indiana,Vanderburgh County,2022,179744,6440.0,57028,716
-Indiana,Vigo County,2005,95094,0.0,34862,417
-Indiana,Vigo County,2006,103009,0.0,34815,442
-Indiana,Vigo County,2007,104915,0.0,36584,435
-Indiana,Vigo County,2008,105968,0.0,37929,465
-Indiana,Vigo County,2009,105967,0.0,37534,464
-Indiana,Vigo County,2010,107958,0.0,39429,502
-Indiana,Vigo County,2011,108182,0.0,39229,525
-Indiana,Vigo County,2012,108428,0.0,40646,508
-Indiana,Vigo County,2013,108291,0.0,37930,519
+Indiana,Vigo County,2005,95094,,34862,417
+Indiana,Vigo County,2006,103009,,34815,442
+Indiana,Vigo County,2007,104915,,36584,435
+Indiana,Vigo County,2008,105968,,37929,465
+Indiana,Vigo County,2009,105967,,37534,464
+Indiana,Vigo County,2010,107958,,39429,502
+Indiana,Vigo County,2011,108182,,39229,525
+Indiana,Vigo County,2012,108428,,40646,508
+Indiana,Vigo County,2013,108291,,37930,519
 Indiana,Vigo County,2014,108175,1232.0,41385,511
-Indiana,Vigo County,2015,107896,0.0,38632,527
-Indiana,Vigo County,2016,107931,0.0,43910,545
-Indiana,Vigo County,2017,107516,0.0,41125,590
-Indiana,Vigo County,2018,107386,0.0,48961,546
+Indiana,Vigo County,2015,107896,,38632,527
+Indiana,Vigo County,2016,107931,,43910,545
+Indiana,Vigo County,2017,107516,,41125,590
+Indiana,Vigo County,2018,107386,,48961,546
 Indiana,Vigo County,2019,107038,1449.0,48013,549
-Indiana,Vigo County,2021,105994,0.0,46802,628
-Indiana,Vigo County,2022,106006,0.0,51125,657
-Indiana,Warrick County,2022,65185,0.0,79901,750
-Indiana,Wayne County,2005,66972,0.0,34384,423
-Indiana,Wayne County,2006,68846,0.0,40183,430
-Indiana,Wayne County,2007,68260,0.0,39082,408
-Indiana,Wayne County,2008,67795,0.0,41453,433
-Indiana,Wayne County,2009,67552,0.0,39598,455
-Indiana,Wayne County,2010,68853,0.0,36079,459
-Indiana,Wayne County,2011,68643,0.0,36358,443
-Indiana,Wayne County,2012,68346,0.0,33385,440
-Indiana,Wayne County,2013,67893,0.0,34745,506
-Indiana,Wayne County,2014,67671,0.0,41204,443
-Indiana,Wayne County,2015,67001,0.0,42160,463
-Indiana,Wayne County,2016,66568,0.0,43401,471
-Indiana,Wayne County,2017,66185,0.0,45017,542
-Indiana,Wayne County,2018,65936,0.0,44928,485
-Indiana,Wayne County,2019,65884,0.0,47944,496
-Indiana,Wayne County,2021,66456,0.0,50138,559
-Indiana,Wayne County,2022,66273,0.0,49024,549
-Iowa,Black Hawk County,2005,120313,0.0,40053,472
-Iowa,Black Hawk County,2006,126106,0.0,42111,482
-Iowa,Black Hawk County,2007,127446,0.0,41434,475
-Iowa,Black Hawk County,2008,128347,0.0,45459,512
-Iowa,Black Hawk County,2009,129276,0.0,42013,498
+Indiana,Vigo County,2021,105994,,46802,628
+Indiana,Vigo County,2022,106006,,51125,657
+Indiana,Warrick County,2022,65185,,79901,750
+Indiana,Wayne County,2005,66972,,34384,423
+Indiana,Wayne County,2006,68846,,40183,430
+Indiana,Wayne County,2007,68260,,39082,408
+Indiana,Wayne County,2008,67795,,41453,433
+Indiana,Wayne County,2009,67552,,39598,455
+Indiana,Wayne County,2010,68853,,36079,459
+Indiana,Wayne County,2011,68643,,36358,443
+Indiana,Wayne County,2012,68346,,33385,440
+Indiana,Wayne County,2013,67893,,34745,506
+Indiana,Wayne County,2014,67671,,41204,443
+Indiana,Wayne County,2015,67001,,42160,463
+Indiana,Wayne County,2016,66568,,43401,471
+Indiana,Wayne County,2017,66185,,45017,542
+Indiana,Wayne County,2018,65936,,44928,485
+Indiana,Wayne County,2019,65884,,47944,496
+Indiana,Wayne County,2021,66456,,50138,559
+Indiana,Wayne County,2022,66273,,49024,549
+Iowa,Black Hawk County,2005,120313,,40053,472
+Iowa,Black Hawk County,2006,126106,,42111,482
+Iowa,Black Hawk County,2007,127446,,41434,475
+Iowa,Black Hawk County,2008,128347,,45459,512
+Iowa,Black Hawk County,2009,129276,,42013,498
 Iowa,Black Hawk County,2010,131221,1755.0,43341,528
 Iowa,Black Hawk County,2011,131549,1693.0,42438,536
 Iowa,Black Hawk County,2012,131820,982.0,49086,546
 Iowa,Black Hawk County,2013,132546,1856.0,45666,571
 Iowa,Black Hawk County,2014,132897,1517.0,51685,591
 Iowa,Black Hawk County,2015,133455,2691.0,50169,605
-Iowa,Black Hawk County,2016,132904,0.0,50470,629
+Iowa,Black Hawk County,2016,132904,,50470,629
 Iowa,Black Hawk County,2017,132648,2878.0,49779,623
-Iowa,Black Hawk County,2018,132408,0.0,51920,637
-Iowa,Black Hawk County,2019,131228,0.0,60506,687
-Iowa,Black Hawk County,2021,130368,0.0,60264,693
-Iowa,Black Hawk County,2022,130274,0.0,60529,763
-Iowa,Dallas County,2010,66616,0.0,63915,598
-Iowa,Dallas County,2011,69444,0.0,69831,785
-Iowa,Dallas County,2012,71967,0.0,70198,722
-Iowa,Dallas County,2013,74641,0.0,78837,759
-Iowa,Dallas County,2014,77400,0.0,77412,724
-Iowa,Dallas County,2015,80133,0.0,78634,780
-Iowa,Dallas County,2016,84516,0.0,75899,846
-Iowa,Dallas County,2017,87235,0.0,88561,856
-Iowa,Dallas County,2018,90180,0.0,83990,933
-Iowa,Dallas County,2019,93453,0.0,94885,995
-Iowa,Dallas County,2021,103796,0.0,90750,954
-Iowa,Dallas County,2022,108016,0.0,105132,1183
-Iowa,Dubuque County,2005,86626,0.0,44161,410
+Iowa,Black Hawk County,2018,132408,,51920,637
+Iowa,Black Hawk County,2019,131228,,60506,687
+Iowa,Black Hawk County,2021,130368,,60264,693
+Iowa,Black Hawk County,2022,130274,,60529,763
+Iowa,Dallas County,2010,66616,,63915,598
+Iowa,Dallas County,2011,69444,,69831,785
+Iowa,Dallas County,2012,71967,,70198,722
+Iowa,Dallas County,2013,74641,,78837,759
+Iowa,Dallas County,2014,77400,,77412,724
+Iowa,Dallas County,2015,80133,,78634,780
+Iowa,Dallas County,2016,84516,,75899,846
+Iowa,Dallas County,2017,87235,,88561,856
+Iowa,Dallas County,2018,90180,,83990,933
+Iowa,Dallas County,2019,93453,,94885,995
+Iowa,Dallas County,2021,103796,,90750,954
+Iowa,Dallas County,2022,108016,,105132,1183
+Iowa,Dubuque County,2005,86626,,44161,410
 Iowa,Dubuque County,2006,92384,1839.0,45419,472
-Iowa,Dubuque County,2007,92359,0.0,46320,446
-Iowa,Dubuque County,2008,92724,0.0,49023,457
-Iowa,Dubuque County,2009,93072,0.0,46637,458
-Iowa,Dubuque County,2010,93880,0.0,49776,508
-Iowa,Dubuque County,2011,94648,0.0,53011,534
+Iowa,Dubuque County,2007,92359,,46320,446
+Iowa,Dubuque County,2008,92724,,49023,457
+Iowa,Dubuque County,2009,93072,,46637,458
+Iowa,Dubuque County,2010,93880,,49776,508
+Iowa,Dubuque County,2011,94648,,53011,534
 Iowa,Dubuque County,2012,95097,2789.0,49793,582
 Iowa,Dubuque County,2013,95697,2155.0,51735,548
-Iowa,Dubuque County,2014,96370,0.0,56129,594
+Iowa,Dubuque County,2014,96370,,56129,594
 Iowa,Dubuque County,2015,97125,1947.0,58487,565
 Iowa,Dubuque County,2016,97003,1448.0,60456,635
 Iowa,Dubuque County,2017,97041,2312.0,61497,642
-Iowa,Dubuque County,2018,96854,0.0,60225,616
-Iowa,Dubuque County,2019,97311,0.0,62178,673
-Iowa,Dubuque County,2021,98718,0.0,75590,703
-Iowa,Dubuque County,2022,98677,0.0,73671,754
+Iowa,Dubuque County,2018,96854,,60225,616
+Iowa,Dubuque County,2019,97311,,62178,673
+Iowa,Dubuque County,2021,98718,,75590,703
+Iowa,Dubuque County,2022,98677,,73671,754
 Iowa,Johnson County,2005,108919,2381.0,43830,586
 Iowa,Johnson County,2006,118038,2032.0,46018,603
 Iowa,Johnson County,2007,125692,3314.0,51589,595
@@ -4005,7 +4005,7 @@ Iowa,Johnson County,2018,151260,3429.0,63035,861
 Iowa,Johnson County,2019,151140,5109.0,66011,862
 Iowa,Johnson County,2021,154748,17248.0,67134,864
 Iowa,Johnson County,2022,156420,11601.0,74140,919
-Iowa,Linn County,2005,193749,0.0,48822,489
+Iowa,Linn County,2005,193749,,48822,489
 Iowa,Linn County,2006,201853,3250.0,46190,489
 Iowa,Linn County,2007,205836,2909.0,52320,465
 Iowa,Linn County,2008,208574,3287.0,54425,501
@@ -4021,7 +4021,7 @@ Iowa,Linn County,2017,224115,4438.0,63149,623
 Iowa,Linn County,2018,225909,4436.0,64103,623
 Iowa,Linn County,2019,226706,6293.0,63559,648
 Iowa,Linn County,2021,228939,21908.0,69420,708
-Iowa,Linn County,2022,229033,0.0,72527,722
+Iowa,Linn County,2022,229033,,72527,722
 Iowa,Polk County,2005,391914,5880.0,51948,583
 Iowa,Polk County,2006,408888,7830.0,52418,586
 Iowa,Polk County,2007,418339,5931.0,54167,604
@@ -4039,28 +4039,28 @@ Iowa,Polk County,2018,487204,14145.0,68291,785
 Iowa,Polk County,2019,490161,12475.0,66918,825
 Iowa,Polk County,2021,496844,52595.0,73292,870
 Iowa,Polk County,2022,501089,42702.0,77038,929
-Iowa,Pottawattamie County,2005,87999,0.0,45348,530
-Iowa,Pottawattamie County,2006,90218,0.0,46788,564
-Iowa,Pottawattamie County,2007,89409,0.0,48912,518
-Iowa,Pottawattamie County,2008,89647,0.0,50302,537
+Iowa,Pottawattamie County,2005,87999,,45348,530
+Iowa,Pottawattamie County,2006,90218,,46788,564
+Iowa,Pottawattamie County,2007,89409,,48912,518
+Iowa,Pottawattamie County,2008,89647,,50302,537
 Iowa,Pottawattamie County,2009,90224,2731.0,44954,561
-Iowa,Pottawattamie County,2010,93359,0.0,47864,561
-Iowa,Pottawattamie County,2011,93518,0.0,48850,583
-Iowa,Pottawattamie County,2012,92913,0.0,50171,593
-Iowa,Pottawattamie County,2013,92728,0.0,50557,607
-Iowa,Pottawattamie County,2014,93128,0.0,52239,655
-Iowa,Pottawattamie County,2015,93671,0.0,53117,626
-Iowa,Pottawattamie County,2016,93582,0.0,55972,667
+Iowa,Pottawattamie County,2010,93359,,47864,561
+Iowa,Pottawattamie County,2011,93518,,48850,583
+Iowa,Pottawattamie County,2012,92913,,50171,593
+Iowa,Pottawattamie County,2013,92728,,50557,607
+Iowa,Pottawattamie County,2014,93128,,52239,655
+Iowa,Pottawattamie County,2015,93671,,53117,626
+Iowa,Pottawattamie County,2016,93582,,55972,667
 Iowa,Pottawattamie County,2017,93386,1793.0,58633,668
-Iowa,Pottawattamie County,2018,93533,0.0,55376,721
-Iowa,Pottawattamie County,2019,93206,0.0,60056,734
-Iowa,Pottawattamie County,2021,93304,0.0,66542,734
-Iowa,Pottawattamie County,2022,93173,0.0,68681,808
-Iowa,Scott County,2005,157749,0.0,49282,492
+Iowa,Pottawattamie County,2018,93533,,55376,721
+Iowa,Pottawattamie County,2019,93206,,60056,734
+Iowa,Pottawattamie County,2021,93304,,66542,734
+Iowa,Pottawattamie County,2022,93173,,68681,808
+Iowa,Scott County,2005,157749,,49282,492
 Iowa,Scott County,2006,162621,1883.0,46127,506
-Iowa,Scott County,2007,162687,0.0,47052,483
+Iowa,Scott County,2007,162687,,47052,483
 Iowa,Scott County,2008,164690,1973.0,52013,514
-Iowa,Scott County,2009,166650,0.0,50418,521
+Iowa,Scott County,2009,166650,,50418,521
 Iowa,Scott County,2010,165841,3273.0,47206,541
 Iowa,Scott County,2011,167095,1731.0,49549,552
 Iowa,Scott County,2012,168799,2495.0,52940,573
@@ -4068,14 +4068,14 @@ Iowa,Scott County,2013,170385,2105.0,53884,585
 Iowa,Scott County,2014,171387,4058.0,54679,626
 Iowa,Scott County,2015,172126,4323.0,57831,655
 Iowa,Scott County,2016,172474,3349.0,54730,652
-Iowa,Scott County,2017,172509,0.0,58129,669
-Iowa,Scott County,2018,173283,0.0,58175,680
+Iowa,Scott County,2017,172509,,58129,669
+Iowa,Scott County,2018,173283,,58175,680
 Iowa,Scott County,2019,172943,4205.0,65122,679
-Iowa,Scott County,2021,174170,0.0,65566,742
+Iowa,Scott County,2021,174170,,65566,742
 Iowa,Scott County,2022,173924,10143.0,66832,795
-Iowa,Story County,2005,70480,0.0,40471,566
+Iowa,Story County,2005,70480,,40471,566
 Iowa,Story County,2006,80145,1496.0,43326,606
-Iowa,Story County,2007,84752,0.0,47827,582
+Iowa,Story County,2007,84752,,47827,582
 Iowa,Story County,2008,86754,1117.0,48076,598
 Iowa,Story County,2009,87214,1237.0,45516,606
 Iowa,Story County,2010,89575,1346.0,48034,607
@@ -4084,42 +4084,42 @@ Iowa,Story County,2012,91140,1694.0,49489,636
 Iowa,Story County,2013,92406,1414.0,50279,655
 Iowa,Story County,2014,94073,2656.0,46091,686
 Iowa,Story County,2015,96021,2015.0,50811,753
-Iowa,Story County,2016,97090,0.0,53371,775
+Iowa,Story County,2016,97090,,53371,775
 Iowa,Story County,2017,97502,3100.0,60351,781
 Iowa,Story County,2018,98105,2432.0,54586,790
-Iowa,Story County,2019,97117,0.0,63107,841
-Iowa,Story County,2021,99472,0.0,63774,787
+Iowa,Story County,2019,97117,,63107,841
+Iowa,Story County,2021,99472,,63774,787
 Iowa,Story County,2022,99673,4452.0,66033,808
-Iowa,Woodbury County,2005,99729,0.0,41013,421
-Iowa,Woodbury County,2006,102972,0.0,41475,465
+Iowa,Woodbury County,2005,99729,,41013,421
+Iowa,Woodbury County,2006,102972,,41475,465
 Iowa,Woodbury County,2007,102287,2862.0,44565,437
-Iowa,Woodbury County,2008,102559,0.0,42824,476
-Iowa,Woodbury County,2009,102831,0.0,43903,491
-Iowa,Woodbury County,2010,102407,0.0,42208,469
+Iowa,Woodbury County,2008,102559,,42824,476
+Iowa,Woodbury County,2009,102831,,43903,491
+Iowa,Woodbury County,2010,102407,,42208,469
 Iowa,Woodbury County,2011,102509,2030.0,42435,495
-Iowa,Woodbury County,2012,102323,0.0,42013,511
+Iowa,Woodbury County,2012,102323,,42013,511
 Iowa,Woodbury County,2013,102130,1890.0,45594,546
-Iowa,Woodbury County,2014,102271,0.0,44721,532
-Iowa,Woodbury County,2015,102782,0.0,51146,564
-Iowa,Woodbury County,2016,102779,0.0,52324,588
-Iowa,Woodbury County,2017,102429,0.0,55273,625
-Iowa,Woodbury County,2018,102539,0.0,61516,632
-Iowa,Woodbury County,2019,103107,0.0,58945,689
-Iowa,Woodbury County,2021,105607,0.0,59376,694
+Iowa,Woodbury County,2014,102271,,44721,532
+Iowa,Woodbury County,2015,102782,,51146,564
+Iowa,Woodbury County,2016,102779,,52324,588
+Iowa,Woodbury County,2017,102429,,55273,625
+Iowa,Woodbury County,2018,102539,,61516,632
+Iowa,Woodbury County,2019,103107,,58945,689
+Iowa,Woodbury County,2021,105607,,59376,694
 Iowa,Woodbury County,2022,105671,2510.0,67817,793
-Kansas,Butler County,2010,65923,0.0,53503,469
-Kansas,Butler County,2011,65817,0.0,51843,488
-Kansas,Butler County,2012,65827,0.0,58187,504
-Kansas,Butler County,2013,65803,0.0,55647,528
-Kansas,Butler County,2014,66227,0.0,58791,549
-Kansas,Butler County,2015,66741,0.0,60714,599
-Kansas,Butler County,2016,67025,0.0,60182,546
-Kansas,Butler County,2017,66878,0.0,64149,578
-Kansas,Butler County,2018,66765,0.0,64898,672
-Kansas,Butler County,2019,66911,0.0,61951,650
-Kansas,Butler County,2021,67889,0.0,71274,642
-Kansas,Butler County,2022,68240,0.0,80853,701
-Kansas,Douglas County,2005,94200,0.0,39191,586
+Kansas,Butler County,2010,65923,,53503,469
+Kansas,Butler County,2011,65817,,51843,488
+Kansas,Butler County,2012,65827,,58187,504
+Kansas,Butler County,2013,65803,,55647,528
+Kansas,Butler County,2014,66227,,58791,549
+Kansas,Butler County,2015,66741,,60714,599
+Kansas,Butler County,2016,67025,,60182,546
+Kansas,Butler County,2017,66878,,64149,578
+Kansas,Butler County,2018,66765,,64898,672
+Kansas,Butler County,2019,66911,,61951,650
+Kansas,Butler County,2021,67889,,71274,642
+Kansas,Butler County,2022,68240,,80853,701
+Kansas,Douglas County,2005,94200,,39191,586
 Kansas,Douglas County,2006,112123,2079.0,46857,618
 Kansas,Douglas County,2007,113488,2289.0,42772,584
 Kansas,Douglas County,2008,114748,2825.0,46394,594
@@ -4127,16 +4127,16 @@ Kansas,Douglas County,2009,116383,2990.0,43367,664
 Kansas,Douglas County,2010,111130,2340.0,47263,670
 Kansas,Douglas County,2011,112211,2250.0,47757,716
 Kansas,Douglas County,2012,112864,2983.0,50184,660
-Kansas,Douglas County,2013,114322,0.0,52150,667
+Kansas,Douglas County,2013,114322,,52150,667
 Kansas,Douglas County,2014,116585,3007.0,48565,693
 Kansas,Douglas County,2015,118053,2802.0,52964,693
 Kansas,Douglas County,2016,119440,1916.0,56345,714
 Kansas,Douglas County,2017,120793,2795.0,55646,743
 Kansas,Douglas County,2018,121436,3180.0,54668,796
-Kansas,Douglas County,2019,122259,0.0,64233,789
-Kansas,Douglas County,2021,119363,0.0,56576,746
+Kansas,Douglas County,2019,122259,,64233,789
+Kansas,Douglas County,2021,119363,,56576,746
 Kansas,Douglas County,2022,119964,10163.0,65774,828
-Kansas,Johnson County,2005,501584,0.0,66685,666
+Kansas,Johnson County,2005,501584,,66685,666
 Kansas,Johnson County,2006,516731,13207.0,69817,676
 Kansas,Johnson County,2007,526319,14811.0,71658,704
 Kansas,Johnson County,2008,534093,15850.0,76108,748
@@ -4153,37 +4153,37 @@ Kansas,Johnson County,2018,597555,19816.0,86746,928
 Kansas,Johnson County,2019,602401,26136.0,91771,971
 Kansas,Johnson County,2021,613219,89541.0,92945,1059
 Kansas,Johnson County,2022,619195,79349.0,98523,1145
-Kansas,Leavenworth County,2005,64791,0.0,55127,492
-Kansas,Leavenworth County,2006,74177,0.0,54627,551
-Kansas,Leavenworth County,2007,74018,0.0,59659,620
-Kansas,Leavenworth County,2008,75946,0.0,60298,644
-Kansas,Leavenworth County,2009,73712,0.0,57381,711
-Kansas,Leavenworth County,2010,73749,0.0,61310,656
-Kansas,Leavenworth County,2011,75527,0.0,62453,666
-Kansas,Leavenworth County,2012,77739,0.0,59683,733
-Kansas,Leavenworth County,2013,78185,0.0,68266,728
-Kansas,Leavenworth County,2014,78797,0.0,66779,696
-Kansas,Leavenworth County,2015,79315,0.0,60423,641
-Kansas,Leavenworth County,2016,80204,0.0,68299,819
-Kansas,Leavenworth County,2017,81095,0.0,70920,695
-Kansas,Leavenworth County,2018,81352,0.0,71071,762
-Kansas,Leavenworth County,2019,81758,0.0,77070,728
-Kansas,Leavenworth County,2021,82184,0.0,83028,792
-Kansas,Leavenworth County,2022,82892,0.0,77925,959
-Kansas,Riley County,2007,69083,0.0,36570,608
-Kansas,Riley County,2008,71069,0.0,40104,637
-Kansas,Riley County,2009,71341,0.0,38923,642
-Kansas,Riley County,2010,71481,0.0,45246,687
-Kansas,Riley County,2011,72997,0.0,45122,692
-Kansas,Riley County,2012,75508,0.0,41835,718
+Kansas,Leavenworth County,2005,64791,,55127,492
+Kansas,Leavenworth County,2006,74177,,54627,551
+Kansas,Leavenworth County,2007,74018,,59659,620
+Kansas,Leavenworth County,2008,75946,,60298,644
+Kansas,Leavenworth County,2009,73712,,57381,711
+Kansas,Leavenworth County,2010,73749,,61310,656
+Kansas,Leavenworth County,2011,75527,,62453,666
+Kansas,Leavenworth County,2012,77739,,59683,733
+Kansas,Leavenworth County,2013,78185,,68266,728
+Kansas,Leavenworth County,2014,78797,,66779,696
+Kansas,Leavenworth County,2015,79315,,60423,641
+Kansas,Leavenworth County,2016,80204,,68299,819
+Kansas,Leavenworth County,2017,81095,,70920,695
+Kansas,Leavenworth County,2018,81352,,71071,762
+Kansas,Leavenworth County,2019,81758,,77070,728
+Kansas,Leavenworth County,2021,82184,,83028,792
+Kansas,Leavenworth County,2022,82892,,77925,959
+Kansas,Riley County,2007,69083,,36570,608
+Kansas,Riley County,2008,71069,,40104,637
+Kansas,Riley County,2009,71341,,38923,642
+Kansas,Riley County,2010,71481,,45246,687
+Kansas,Riley County,2011,72997,,45122,692
+Kansas,Riley County,2012,75508,,41835,718
 Kansas,Riley County,2013,75394,3037.0,43778,808
-Kansas,Riley County,2014,75194,0.0,44825,741
-Kansas,Riley County,2015,75247,0.0,46677,817
-Kansas,Riley County,2016,73343,0.0,50737,814
-Kansas,Riley County,2017,74172,0.0,50067,787
-Kansas,Riley County,2018,73703,0.0,44697,720
-Kansas,Riley County,2019,74232,0.0,50920,740
-Kansas,Riley County,2021,72208,0.0,57335,760
+Kansas,Riley County,2014,75194,,44825,741
+Kansas,Riley County,2015,75247,,46677,817
+Kansas,Riley County,2016,73343,,50737,814
+Kansas,Riley County,2017,74172,,50067,787
+Kansas,Riley County,2018,73703,,44697,720
+Kansas,Riley County,2019,74232,,50920,740
+Kansas,Riley County,2021,72208,,57335,760
 Kansas,Riley County,2022,71108,4780.0,53043,815
 Kansas,Sedgwick County,2005,459902,7669.0,42785,459
 Kansas,Sedgwick County,2006,470895,8486.0,44588,460
@@ -4202,7 +4202,7 @@ Kansas,Sedgwick County,2018,513607,8465.0,55882,608
 Kansas,Sedgwick County,2019,516042,8647.0,59716,654
 Kansas,Sedgwick County,2021,523828,22938.0,60364,694
 Kansas,Sedgwick County,2022,525525,19585.0,64286,732
-Kansas,Shawnee County,2005,167513,0.0,44052,467
+Kansas,Shawnee County,2005,167513,,44052,467
 Kansas,Shawnee County,2006,172693,2240.0,43436,454
 Kansas,Shawnee County,2007,173476,2972.0,46566,460
 Kansas,Shawnee County,2008,174709,2290.0,47718,497
@@ -4212,116 +4212,116 @@ Kansas,Shawnee County,2011,178941,2536.0,43900,524
 Kansas,Shawnee County,2012,178991,2898.0,47982,542
 Kansas,Shawnee County,2013,178831,2300.0,50150,531
 Kansas,Shawnee County,2014,178406,1723.0,53507,590
-Kansas,Shawnee County,2015,178725,0.0,51123,584
+Kansas,Shawnee County,2015,178725,,51123,584
 Kansas,Shawnee County,2016,178146,2287.0,55710,585
 Kansas,Shawnee County,2017,178187,3039.0,57095,619
 Kansas,Shawnee County,2018,177499,3080.0,52104,649
 Kansas,Shawnee County,2019,176875,3737.0,59441,657
 Kansas,Shawnee County,2021,178264,11854.0,55499,638
 Kansas,Shawnee County,2022,177480,10433.0,60544,682
-Kansas,Wyandotte County,2005,154158,0.0,33700,488
+Kansas,Wyandotte County,2005,154158,,33700,488
 Kansas,Wyandotte County,2006,155509,907.0,36660,510
 Kansas,Wyandotte County,2007,153956,838.0,37233,494
 Kansas,Wyandotte County,2008,154287,1161.0,38031,511
-Kansas,Wyandotte County,2009,155085,0.0,36488,494
-Kansas,Wyandotte County,2010,157845,0.0,37293,528
+Kansas,Wyandotte County,2009,155085,,36488,494
+Kansas,Wyandotte County,2010,157845,,37293,528
 Kansas,Wyandotte County,2011,158224,1417.0,37991,529
 Kansas,Wyandotte County,2012,159129,894.0,37529,535
 Kansas,Wyandotte County,2013,160384,1596.0,38412,552
 Kansas,Wyandotte County,2014,161636,1718.0,36637,564
 Kansas,Wyandotte County,2015,163369,1906.0,41800,607
 Kansas,Wyandotte County,2016,163831,2343.0,43129,586
-Kansas,Wyandotte County,2017,165288,0.0,46310,632
+Kansas,Wyandotte County,2017,165288,,46310,632
 Kansas,Wyandotte County,2018,165324,1840.0,47285,667
 Kansas,Wyandotte County,2019,165429,1373.0,46964,676
 Kansas,Wyandotte County,2021,167046,10265.0,55605,763
-Kansas,Wyandotte County,2022,165746,0.0,59362,796
-Kentucky,Boone County,2005,105684,0.0,54185,616
-Kentucky,Boone County,2006,110080,0.0,56477,602
-Kentucky,Boone County,2007,112459,0.0,67224,624
-Kentucky,Boone County,2008,115231,0.0,66017,704
-Kentucky,Boone County,2009,118576,0.0,68369,701
-Kentucky,Boone County,2010,119290,0.0,64008,691
-Kentucky,Boone County,2011,121737,0.0,63556,652
-Kentucky,Boone County,2012,123316,0.0,65909,740
-Kentucky,Boone County,2013,124442,0.0,64414,729
-Kentucky,Boone County,2014,126413,0.0,65736,741
-Kentucky,Boone County,2015,127712,0.0,67047,814
-Kentucky,Boone County,2016,128536,0.0,72374,820
-Kentucky,Boone County,2017,130728,0.0,78415,772
-Kentucky,Boone County,2018,131533,0.0,77429,846
-Kentucky,Boone County,2019,133581,0.0,76443,855
-Kentucky,Boone County,2021,137412,0.0,83877,1010
-Kentucky,Boone County,2022,139093,0.0,89931,1086
-Kentucky,Bullitt County,2005,68243,0.0,48915,468
-Kentucky,Bullitt County,2006,72851,0.0,52147,498
-Kentucky,Bullitt County,2007,73931,0.0,47200,494
-Kentucky,Bullitt County,2008,75028,0.0,52550,562
-Kentucky,Bullitt County,2009,75653,0.0,46370,563
-Kentucky,Bullitt County,2010,74473,0.0,50702,656
-Kentucky,Bullitt County,2011,75109,0.0,51436,533
-Kentucky,Bullitt County,2012,75896,0.0,57886,550
-Kentucky,Bullitt County,2013,76854,0.0,60264,595
-Kentucky,Bullitt County,2014,77955,0.0,54690,621
-Kentucky,Bullitt County,2015,78702,0.0,53434,611
-Kentucky,Bullitt County,2016,79151,0.0,65359,563
-Kentucky,Bullitt County,2017,80246,0.0,62319,670
-Kentucky,Bullitt County,2018,81069,0.0,58119,664
-Kentucky,Bullitt County,2019,81676,0.0,65560,662
-Kentucky,Bullitt County,2021,82918,0.0,68269,726
-Kentucky,Bullitt County,2022,83836,0.0,76810,760
-Kentucky,Campbell County,2005,85210,0.0,46695,477
-Kentucky,Campbell County,2006,86866,0.0,46020,480
-Kentucky,Campbell County,2007,86858,0.0,51724,498
+Kansas,Wyandotte County,2022,165746,,59362,796
+Kentucky,Boone County,2005,105684,,54185,616
+Kentucky,Boone County,2006,110080,,56477,602
+Kentucky,Boone County,2007,112459,,67224,624
+Kentucky,Boone County,2008,115231,,66017,704
+Kentucky,Boone County,2009,118576,,68369,701
+Kentucky,Boone County,2010,119290,,64008,691
+Kentucky,Boone County,2011,121737,,63556,652
+Kentucky,Boone County,2012,123316,,65909,740
+Kentucky,Boone County,2013,124442,,64414,729
+Kentucky,Boone County,2014,126413,,65736,741
+Kentucky,Boone County,2015,127712,,67047,814
+Kentucky,Boone County,2016,128536,,72374,820
+Kentucky,Boone County,2017,130728,,78415,772
+Kentucky,Boone County,2018,131533,,77429,846
+Kentucky,Boone County,2019,133581,,76443,855
+Kentucky,Boone County,2021,137412,,83877,1010
+Kentucky,Boone County,2022,139093,,89931,1086
+Kentucky,Bullitt County,2005,68243,,48915,468
+Kentucky,Bullitt County,2006,72851,,52147,498
+Kentucky,Bullitt County,2007,73931,,47200,494
+Kentucky,Bullitt County,2008,75028,,52550,562
+Kentucky,Bullitt County,2009,75653,,46370,563
+Kentucky,Bullitt County,2010,74473,,50702,656
+Kentucky,Bullitt County,2011,75109,,51436,533
+Kentucky,Bullitt County,2012,75896,,57886,550
+Kentucky,Bullitt County,2013,76854,,60264,595
+Kentucky,Bullitt County,2014,77955,,54690,621
+Kentucky,Bullitt County,2015,78702,,53434,611
+Kentucky,Bullitt County,2016,79151,,65359,563
+Kentucky,Bullitt County,2017,80246,,62319,670
+Kentucky,Bullitt County,2018,81069,,58119,664
+Kentucky,Bullitt County,2019,81676,,65560,662
+Kentucky,Bullitt County,2021,82918,,68269,726
+Kentucky,Bullitt County,2022,83836,,76810,760
+Kentucky,Campbell County,2005,85210,,46695,477
+Kentucky,Campbell County,2006,86866,,46020,480
+Kentucky,Campbell County,2007,86858,,51724,498
 Kentucky,Campbell County,2008,87038,1326.0,49702,511
-Kentucky,Campbell County,2009,88423,0.0,50282,532
-Kentucky,Campbell County,2010,90532,0.0,44829,557
-Kentucky,Campbell County,2011,90940,0.0,53968,552
-Kentucky,Campbell County,2012,90908,0.0,55888,601
-Kentucky,Campbell County,2013,90988,0.0,53323,616
-Kentucky,Campbell County,2014,91833,0.0,50872,552
-Kentucky,Campbell County,2015,92066,0.0,51208,622
+Kentucky,Campbell County,2009,88423,,50282,532
+Kentucky,Campbell County,2010,90532,,44829,557
+Kentucky,Campbell County,2011,90940,,53968,552
+Kentucky,Campbell County,2012,90908,,55888,601
+Kentucky,Campbell County,2013,90988,,53323,616
+Kentucky,Campbell County,2014,91833,,50872,552
+Kentucky,Campbell County,2015,92066,,51208,622
 Kentucky,Campbell County,2016,92211,2582.0,62536,706
-Kentucky,Campbell County,2017,92488,0.0,61379,691
-Kentucky,Campbell County,2018,93152,0.0,59524,677
-Kentucky,Campbell County,2019,93584,0.0,66439,671
-Kentucky,Campbell County,2021,93050,0.0,71701,820
-Kentucky,Campbell County,2022,93300,0.0,72967,905
-Kentucky,Christian County,2005,64062,0.0,33485,500
-Kentucky,Christian County,2006,66989,0.0,36757,452
-Kentucky,Christian County,2007,80868,0.0,38698,475
-Kentucky,Christian County,2008,79820,0.0,35920,461
-Kentucky,Christian County,2009,80938,0.0,35877,496
-Kentucky,Christian County,2010,74179,0.0,36153,491
-Kentucky,Christian County,2011,73591,0.0,35573,499
-Kentucky,Christian County,2012,75427,0.0,38843,577
-Kentucky,Christian County,2013,74167,0.0,45206,528
-Kentucky,Christian County,2014,74250,0.0,35755,528
-Kentucky,Christian County,2015,73309,0.0,39827,538
-Kentucky,Christian County,2016,72351,0.0,41140,614
-Kentucky,Christian County,2017,70416,0.0,43940,594
-Kentucky,Christian County,2018,71671,0.0,38448,668
-Kentucky,Christian County,2019,70461,0.0,47445,686
-Kentucky,Christian County,2021,72357,0.0,47754,736
-Kentucky,Christian County,2022,73037,0.0,60767,770
-Kentucky,Daviess County,2005,90465,0.0,37171,367
-Kentucky,Daviess County,2006,93613,0.0,40936,373
-Kentucky,Daviess County,2007,93756,0.0,40928,418
-Kentucky,Daviess County,2008,94418,0.0,42243,398
-Kentucky,Daviess County,2009,95394,0.0,42711,452
-Kentucky,Daviess County,2010,96762,0.0,41277,409
-Kentucky,Daviess County,2011,97234,0.0,44622,464
-Kentucky,Daviess County,2012,97847,0.0,43885,469
-Kentucky,Daviess County,2013,98218,0.0,47252,489
-Kentucky,Daviess County,2014,98275,0.0,41685,490
-Kentucky,Daviess County,2015,99259,0.0,48791,470
-Kentucky,Daviess County,2016,99674,0.0,51764,525
-Kentucky,Daviess County,2017,100374,0.0,49507,595
-Kentucky,Daviess County,2018,101104,0.0,50934,560
-Kentucky,Daviess County,2019,101511,0.0,50964,615
-Kentucky,Daviess County,2021,103063,0.0,59307,575
-Kentucky,Daviess County,2022,103222,0.0,66837,621
-Kentucky,Fayette County,2005,255389,0.0,42442,516
+Kentucky,Campbell County,2017,92488,,61379,691
+Kentucky,Campbell County,2018,93152,,59524,677
+Kentucky,Campbell County,2019,93584,,66439,671
+Kentucky,Campbell County,2021,93050,,71701,820
+Kentucky,Campbell County,2022,93300,,72967,905
+Kentucky,Christian County,2005,64062,,33485,500
+Kentucky,Christian County,2006,66989,,36757,452
+Kentucky,Christian County,2007,80868,,38698,475
+Kentucky,Christian County,2008,79820,,35920,461
+Kentucky,Christian County,2009,80938,,35877,496
+Kentucky,Christian County,2010,74179,,36153,491
+Kentucky,Christian County,2011,73591,,35573,499
+Kentucky,Christian County,2012,75427,,38843,577
+Kentucky,Christian County,2013,74167,,45206,528
+Kentucky,Christian County,2014,74250,,35755,528
+Kentucky,Christian County,2015,73309,,39827,538
+Kentucky,Christian County,2016,72351,,41140,614
+Kentucky,Christian County,2017,70416,,43940,594
+Kentucky,Christian County,2018,71671,,38448,668
+Kentucky,Christian County,2019,70461,,47445,686
+Kentucky,Christian County,2021,72357,,47754,736
+Kentucky,Christian County,2022,73037,,60767,770
+Kentucky,Daviess County,2005,90465,,37171,367
+Kentucky,Daviess County,2006,93613,,40936,373
+Kentucky,Daviess County,2007,93756,,40928,418
+Kentucky,Daviess County,2008,94418,,42243,398
+Kentucky,Daviess County,2009,95394,,42711,452
+Kentucky,Daviess County,2010,96762,,41277,409
+Kentucky,Daviess County,2011,97234,,44622,464
+Kentucky,Daviess County,2012,97847,,43885,469
+Kentucky,Daviess County,2013,98218,,47252,489
+Kentucky,Daviess County,2014,98275,,41685,490
+Kentucky,Daviess County,2015,99259,,48791,470
+Kentucky,Daviess County,2016,99674,,51764,525
+Kentucky,Daviess County,2017,100374,,49507,595
+Kentucky,Daviess County,2018,101104,,50934,560
+Kentucky,Daviess County,2019,101511,,50964,615
+Kentucky,Daviess County,2021,103063,,59307,575
+Kentucky,Daviess County,2022,103222,,66837,621
+Kentucky,Fayette County,2005,255389,,42442,516
 Kentucky,Fayette County,2006,270789,4459.0,44211,538
 Kentucky,Fayette County,2007,279044,4682.0,46296,571
 Kentucky,Fayette County,2008,282114,4465.0,50325,583
@@ -4338,23 +4338,23 @@ Kentucky,Fayette County,2018,323780,7426.0,54896,755
 Kentucky,Fayette County,2019,323152,7194.0,58356,789
 Kentucky,Fayette County,2021,321793,22485.0,60942,839
 Kentucky,Fayette County,2022,320347,19417.0,62908,878
-Kentucky,Hardin County,2005,93024,0.0,42921,418
-Kentucky,Hardin County,2006,97087,0.0,41263,431
-Kentucky,Hardin County,2007,97949,0.0,49159,442
-Kentucky,Hardin County,2008,98546,0.0,50148,478
-Kentucky,Hardin County,2009,99770,0.0,45081,560
-Kentucky,Hardin County,2010,106933,0.0,43421,519
-Kentucky,Hardin County,2011,107456,0.0,47448,558
-Kentucky,Hardin County,2012,107025,0.0,49233,599
-Kentucky,Hardin County,2013,108191,0.0,48035,556
-Kentucky,Hardin County,2014,108266,0.0,50900,605
-Kentucky,Hardin County,2015,106439,0.0,49229,599
-Kentucky,Hardin County,2016,107316,0.0,52148,609
-Kentucky,Hardin County,2017,108071,0.0,51167,635
-Kentucky,Hardin County,2018,110356,0.0,50981,651
-Kentucky,Hardin County,2019,110958,0.0,57463,685
-Kentucky,Hardin County,2021,111607,0.0,61089,690
-Kentucky,Hardin County,2022,111862,0.0,60878,734
+Kentucky,Hardin County,2005,93024,,42921,418
+Kentucky,Hardin County,2006,97087,,41263,431
+Kentucky,Hardin County,2007,97949,,49159,442
+Kentucky,Hardin County,2008,98546,,50148,478
+Kentucky,Hardin County,2009,99770,,45081,560
+Kentucky,Hardin County,2010,106933,,43421,519
+Kentucky,Hardin County,2011,107456,,47448,558
+Kentucky,Hardin County,2012,107025,,49233,599
+Kentucky,Hardin County,2013,108191,,48035,556
+Kentucky,Hardin County,2014,108266,,50900,605
+Kentucky,Hardin County,2015,106439,,49229,599
+Kentucky,Hardin County,2016,107316,,52148,609
+Kentucky,Hardin County,2017,108071,,51167,635
+Kentucky,Hardin County,2018,110356,,50981,651
+Kentucky,Hardin County,2019,110958,,57463,685
+Kentucky,Hardin County,2021,111607,,61089,690
+Kentucky,Hardin County,2022,111862,,60878,734
 Kentucky,Jefferson County,2005,687032,6736.0,40793,500
 Kentucky,Jefferson County,2006,701500,8291.0,43355,513
 Kentucky,Jefferson County,2007,709264,8359.0,43262,531
@@ -4372,114 +4372,114 @@ Kentucky,Jefferson County,2018,770517,19618.0,55851,705
 Kentucky,Jefferson County,2019,766757,18647.0,59049,754
 Kentucky,Jefferson County,2021,777874,61387.0,60561,801
 Kentucky,Jefferson County,2022,773399,55999.0,64619,872
-Kentucky,Kenton County,2005,151799,0.0,48619,492
+Kentucky,Kenton County,2005,151799,,48619,492
 Kentucky,Kenton County,2006,154911,2118.0,53978,528
 Kentucky,Kenton County,2007,156675,2262.0,50328,543
 Kentucky,Kenton County,2008,157629,2038.0,52222,561
 Kentucky,Kenton County,2009,158729,2201.0,50660,560
-Kentucky,Kenton County,2010,159876,0.0,50872,586
-Kentucky,Kenton County,2011,160406,0.0,49367,577
-Kentucky,Kenton County,2012,161711,0.0,53561,583
-Kentucky,Kenton County,2013,163145,0.0,53761,593
+Kentucky,Kenton County,2010,159876,,50872,586
+Kentucky,Kenton County,2011,160406,,49367,577
+Kentucky,Kenton County,2012,161711,,53561,583
+Kentucky,Kenton County,2013,163145,,53761,593
 Kentucky,Kenton County,2014,163929,2879.0,54300,617
 Kentucky,Kenton County,2015,165012,2163.0,52043,644
 Kentucky,Kenton County,2016,164945,3142.0,62182,649
 Kentucky,Kenton County,2017,165399,2860.0,58595,646
 Kentucky,Kenton County,2018,166051,3888.0,64441,726
 Kentucky,Kenton County,2019,166998,3465.0,68849,687
-Kentucky,Kenton County,2021,169495,0.0,70171,772
+Kentucky,Kenton County,2021,169495,,70171,772
 Kentucky,Kenton County,2022,170313,15370.0,77099,839
-Kentucky,McCracken County,2008,65109,0.0,41527,376
-Kentucky,McCracken County,2009,65880,0.0,41174,434
-Kentucky,McCracken County,2010,65539,0.0,42035,446
-Kentucky,McCracken County,2011,65864,0.0,45220,449
-Kentucky,McCracken County,2012,65549,0.0,43137,481
-Kentucky,McCracken County,2013,65373,0.0,41209,450
-Kentucky,McCracken County,2014,65316,0.0,36712,472
-Kentucky,McCracken County,2015,65018,0.0,51114,508
-Kentucky,McCracken County,2016,65162,0.0,39048,517
-Kentucky,McCracken County,2017,65385,0.0,49436,493
-Kentucky,McCracken County,2018,65346,0.0,47764,584
-Kentucky,McCracken County,2019,65418,0.0,45084,551
-Kentucky,McCracken County,2021,67454,0.0,64082,644
-Kentucky,McCracken County,2022,67490,0.0,60935,651
-Kentucky,Madison County,2005,72450,0.0,36962,432
-Kentucky,Madison County,2006,79015,0.0,38117,419
-Kentucky,Madison County,2007,81103,0.0,38760,415
-Kentucky,Madison County,2008,82192,0.0,44583,444
-Kentucky,Madison County,2009,83258,0.0,39586,503
-Kentucky,Madison County,2010,83157,0.0,42013,483
+Kentucky,McCracken County,2008,65109,,41527,376
+Kentucky,McCracken County,2009,65880,,41174,434
+Kentucky,McCracken County,2010,65539,,42035,446
+Kentucky,McCracken County,2011,65864,,45220,449
+Kentucky,McCracken County,2012,65549,,43137,481
+Kentucky,McCracken County,2013,65373,,41209,450
+Kentucky,McCracken County,2014,65316,,36712,472
+Kentucky,McCracken County,2015,65018,,51114,508
+Kentucky,McCracken County,2016,65162,,39048,517
+Kentucky,McCracken County,2017,65385,,49436,493
+Kentucky,McCracken County,2018,65346,,47764,584
+Kentucky,McCracken County,2019,65418,,45084,551
+Kentucky,McCracken County,2021,67454,,64082,644
+Kentucky,McCracken County,2022,67490,,60935,651
+Kentucky,Madison County,2005,72450,,36962,432
+Kentucky,Madison County,2006,79015,,38117,419
+Kentucky,Madison County,2007,81103,,38760,415
+Kentucky,Madison County,2008,82192,,44583,444
+Kentucky,Madison County,2009,83258,,39586,503
+Kentucky,Madison County,2010,83157,,42013,483
 Kentucky,Madison County,2011,84188,720.0,38596,479
 Kentucky,Madison County,2012,84786,937.0,38005,522
 Kentucky,Madison County,2013,85590,1228.0,45316,563
-Kentucky,Madison County,2014,87340,0.0,43973,522
-Kentucky,Madison County,2015,87824,0.0,45383,551
-Kentucky,Madison County,2016,89547,0.0,43840,565
-Kentucky,Madison County,2017,91226,0.0,50893,556
-Kentucky,Madison County,2018,92368,0.0,52047,607
-Kentucky,Madison County,2019,92987,0.0,49421,561
-Kentucky,Madison County,2021,94666,0.0,52425,635
-Kentucky,Madison County,2022,95187,0.0,60685,696
-Kentucky,Oldham County,2016,65560,0.0,90341,687
-Kentucky,Oldham County,2017,66415,0.0,96576,769
-Kentucky,Oldham County,2018,66470,0.0,102033,677
-Kentucky,Oldham County,2019,66799,0.0,97968,781
-Kentucky,Oldham County,2021,68685,0.0,110041,696
-Kentucky,Oldham County,2022,69431,0.0,115187,758
-Kentucky,Pulaski County,2021,65423,0.0,44561,506
-Kentucky,Pulaski County,2022,65795,0.0,44649,566
-Kentucky,Warren County,2005,93401,0.0,41046,440
-Kentucky,Warren County,2006,101266,0.0,43507,477
+Kentucky,Madison County,2014,87340,,43973,522
+Kentucky,Madison County,2015,87824,,45383,551
+Kentucky,Madison County,2016,89547,,43840,565
+Kentucky,Madison County,2017,91226,,50893,556
+Kentucky,Madison County,2018,92368,,52047,607
+Kentucky,Madison County,2019,92987,,49421,561
+Kentucky,Madison County,2021,94666,,52425,635
+Kentucky,Madison County,2022,95187,,60685,696
+Kentucky,Oldham County,2016,65560,,90341,687
+Kentucky,Oldham County,2017,66415,,96576,769
+Kentucky,Oldham County,2018,66470,,102033,677
+Kentucky,Oldham County,2019,66799,,97968,781
+Kentucky,Oldham County,2021,68685,,110041,696
+Kentucky,Oldham County,2022,69431,,115187,758
+Kentucky,Pulaski County,2021,65423,,44561,506
+Kentucky,Pulaski County,2022,65795,,44649,566
+Kentucky,Warren County,2005,93401,,41046,440
+Kentucky,Warren County,2006,101266,,43507,477
 Kentucky,Warren County,2007,104023,922.0,41327,458
 Kentucky,Warren County,2008,105862,1259.0,42981,463
-Kentucky,Warren County,2009,108669,0.0,43592,480
-Kentucky,Warren County,2010,114172,0.0,38700,502
+Kentucky,Warren County,2009,108669,,43592,480
+Kentucky,Warren County,2010,114172,,38700,502
 Kentucky,Warren County,2011,115517,747.0,38244,497
-Kentucky,Warren County,2012,117110,0.0,41498,507
-Kentucky,Warren County,2013,118370,0.0,48783,553
-Kentucky,Warren County,2014,120460,0.0,50752,549
-Kentucky,Warren County,2015,122851,0.0,44679,562
-Kentucky,Warren County,2016,125532,0.0,46686,559
-Kentucky,Warren County,2017,128845,0.0,48962,613
-Kentucky,Warren County,2018,131264,0.0,53601,645
-Kentucky,Warren County,2019,132896,0.0,52645,643
-Kentucky,Warren County,2021,137212,0.0,59752,661
-Kentucky,Warren County,2022,139843,0.0,59784,782
-Louisiana,Ascension Parish,2005,89855,0.0,46424,458
-Louisiana,Ascension Parish,2006,97335,0.0,55602,439
-Louisiana,Ascension Parish,2007,99056,0.0,57541,486
-Louisiana,Ascension Parish,2008,101789,0.0,62494,601
-Louisiana,Ascension Parish,2009,104822,0.0,61573,684
-Louisiana,Ascension Parish,2010,107891,0.0,63814,683
-Louisiana,Ascension Parish,2011,109985,0.0,64530,721
-Louisiana,Ascension Parish,2012,112286,0.0,66315,644
-Louisiana,Ascension Parish,2013,114393,0.0,75308,670
-Louisiana,Ascension Parish,2014,117029,0.0,66576,792
-Louisiana,Ascension Parish,2015,119455,0.0,76632,740
-Louisiana,Ascension Parish,2016,121587,0.0,76581,889
-Louisiana,Ascension Parish,2017,122948,0.0,70561,826
-Louisiana,Ascension Parish,2018,124672,0.0,79495,690
-Louisiana,Ascension Parish,2019,126604,0.0,85425,878
-Louisiana,Ascension Parish,2021,128369,0.0,72662,901
-Louisiana,Ascension Parish,2022,130458,0.0,79515,915
-Louisiana,Bossier Parish,2005,103391,0.0,44894,480
-Louisiana,Bossier Parish,2006,107270,0.0,47344,552
-Louisiana,Bossier Parish,2007,108705,0.0,48211,533
-Louisiana,Bossier Parish,2008,110250,0.0,49379,596
-Louisiana,Bossier Parish,2009,111492,0.0,49503,579
-Louisiana,Bossier Parish,2010,117522,0.0,49154,594
-Louisiana,Bossier Parish,2011,119732,0.0,50604,630
-Louisiana,Bossier Parish,2012,122197,0.0,53275,681
-Louisiana,Bossier Parish,2013,123823,0.0,51796,730
-Louisiana,Bossier Parish,2014,125064,0.0,50704,736
-Louisiana,Bossier Parish,2015,125175,0.0,56140,729
-Louisiana,Bossier Parish,2016,126057,0.0,48163,820
-Louisiana,Bossier Parish,2017,127634,0.0,49038,796
-Louisiana,Bossier Parish,2018,127185,0.0,55922,697
-Louisiana,Bossier Parish,2019,127039,0.0,49962,805
-Louisiana,Bossier Parish,2021,129144,0.0,59041,873
-Louisiana,Bossier Parish,2022,129276,0.0,62421,878
-Louisiana,Caddo Parish,2005,244819,0.0,33314,412
+Kentucky,Warren County,2012,117110,,41498,507
+Kentucky,Warren County,2013,118370,,48783,553
+Kentucky,Warren County,2014,120460,,50752,549
+Kentucky,Warren County,2015,122851,,44679,562
+Kentucky,Warren County,2016,125532,,46686,559
+Kentucky,Warren County,2017,128845,,48962,613
+Kentucky,Warren County,2018,131264,,53601,645
+Kentucky,Warren County,2019,132896,,52645,643
+Kentucky,Warren County,2021,137212,,59752,661
+Kentucky,Warren County,2022,139843,,59784,782
+Louisiana,Ascension Parish,2005,89855,,46424,458
+Louisiana,Ascension Parish,2006,97335,,55602,439
+Louisiana,Ascension Parish,2007,99056,,57541,486
+Louisiana,Ascension Parish,2008,101789,,62494,601
+Louisiana,Ascension Parish,2009,104822,,61573,684
+Louisiana,Ascension Parish,2010,107891,,63814,683
+Louisiana,Ascension Parish,2011,109985,,64530,721
+Louisiana,Ascension Parish,2012,112286,,66315,644
+Louisiana,Ascension Parish,2013,114393,,75308,670
+Louisiana,Ascension Parish,2014,117029,,66576,792
+Louisiana,Ascension Parish,2015,119455,,76632,740
+Louisiana,Ascension Parish,2016,121587,,76581,889
+Louisiana,Ascension Parish,2017,122948,,70561,826
+Louisiana,Ascension Parish,2018,124672,,79495,690
+Louisiana,Ascension Parish,2019,126604,,85425,878
+Louisiana,Ascension Parish,2021,128369,,72662,901
+Louisiana,Ascension Parish,2022,130458,,79515,915
+Louisiana,Bossier Parish,2005,103391,,44894,480
+Louisiana,Bossier Parish,2006,107270,,47344,552
+Louisiana,Bossier Parish,2007,108705,,48211,533
+Louisiana,Bossier Parish,2008,110250,,49379,596
+Louisiana,Bossier Parish,2009,111492,,49503,579
+Louisiana,Bossier Parish,2010,117522,,49154,594
+Louisiana,Bossier Parish,2011,119732,,50604,630
+Louisiana,Bossier Parish,2012,122197,,53275,681
+Louisiana,Bossier Parish,2013,123823,,51796,730
+Louisiana,Bossier Parish,2014,125064,,50704,736
+Louisiana,Bossier Parish,2015,125175,,56140,729
+Louisiana,Bossier Parish,2016,126057,,48163,820
+Louisiana,Bossier Parish,2017,127634,,49038,796
+Louisiana,Bossier Parish,2018,127185,,55922,697
+Louisiana,Bossier Parish,2019,127039,,49962,805
+Louisiana,Bossier Parish,2021,129144,,59041,873
+Louisiana,Bossier Parish,2022,129276,,62421,878
+Louisiana,Caddo Parish,2005,244819,,33314,412
 Louisiana,Caddo Parish,2006,253118,1838.0,32509,449
 Louisiana,Caddo Parish,2007,252609,2400.0,34744,449
 Louisiana,Caddo Parish,2008,252895,1329.0,35840,526
@@ -4493,25 +4493,25 @@ Louisiana,Caddo Parish,2015,251460,1940.0,41040,582
 Louisiana,Caddo Parish,2016,248851,2538.0,37104,587
 Louisiana,Caddo Parish,2017,246581,2965.0,36165,580
 Louisiana,Caddo Parish,2018,242922,2802.0,39077,630
-Louisiana,Caddo Parish,2019,240204,0.0,45537,640
-Louisiana,Caddo Parish,2021,233092,0.0,44022,676
+Louisiana,Caddo Parish,2019,240204,,45537,640
+Louisiana,Caddo Parish,2021,233092,,44022,676
 Louisiana,Caddo Parish,2022,229025,6169.0,46967,701
-Louisiana,Calcasieu Parish,2005,180709,0.0,34804,409
+Louisiana,Calcasieu Parish,2005,180709,,34804,409
 Louisiana,Calcasieu Parish,2006,184524,1505.0,40046,420
-Louisiana,Calcasieu Parish,2007,184512,0.0,42008,500
+Louisiana,Calcasieu Parish,2007,184512,,42008,500
 Louisiana,Calcasieu Parish,2008,185618,586.0,45074,495
 Louisiana,Calcasieu Parish,2009,187554,1969.0,43863,535
 Louisiana,Calcasieu Parish,2010,193230,1635.0,39830,538
-Louisiana,Calcasieu Parish,2011,194092,0.0,40253,569
+Louisiana,Calcasieu Parish,2011,194092,,40253,569
 Louisiana,Calcasieu Parish,2012,194493,1481.0,44300,558
-Louisiana,Calcasieu Parish,2013,195296,0.0,42625,603
+Louisiana,Calcasieu Parish,2013,195296,,42625,603
 Louisiana,Calcasieu Parish,2014,197204,1820.0,45742,624
 Louisiana,Calcasieu Parish,2015,198788,1480.0,45767,619
-Louisiana,Calcasieu Parish,2016,200601,0.0,45962,650
+Louisiana,Calcasieu Parish,2016,200601,,45962,650
 Louisiana,Calcasieu Parish,2017,202445,2259.0,52319,691
-Louisiana,Calcasieu Parish,2018,203112,0.0,49113,684
-Louisiana,Calcasieu Parish,2019,203436,0.0,51246,748
-Louisiana,Calcasieu Parish,2021,205282,0.0,58020,826
+Louisiana,Calcasieu Parish,2018,203112,,49113,684
+Louisiana,Calcasieu Parish,2019,203436,,51246,748
+Louisiana,Calcasieu Parish,2021,205282,,58020,826
 Louisiana,Calcasieu Parish,2022,202418,7001.0,62197,837
 Louisiana,East Baton Rouge Parish,2005,396735,3545.0,39847,497
 Louisiana,East Baton Rouge Parish,2006,429073,6166.0,44286,531
@@ -4530,23 +4530,23 @@ Louisiana,East Baton Rouge Parish,2018,440956,5987.0,52947,777
 Louisiana,East Baton Rouge Parish,2019,440059,6834.0,56451,778
 Louisiana,East Baton Rouge Parish,2021,453301,20097.0,51432,838
 Louisiana,East Baton Rouge Parish,2022,450544,16337.0,61387,925
-Louisiana,Iberia Parish,2005,72773,0.0,35476,323
-Louisiana,Iberia Parish,2006,75509,0.0,37819,357
-Louisiana,Iberia Parish,2007,74965,0.0,40137,379
-Louisiana,Iberia Parish,2008,75097,0.0,40869,437
-Louisiana,Iberia Parish,2009,75101,0.0,43204,449
-Louisiana,Iberia Parish,2010,73236,0.0,41709,508
-Louisiana,Iberia Parish,2011,73400,0.0,42488,482
-Louisiana,Iberia Parish,2012,73999,0.0,43869,453
-Louisiana,Iberia Parish,2013,73878,0.0,39793,473
-Louisiana,Iberia Parish,2014,73913,0.0,46290,455
-Louisiana,Iberia Parish,2015,74103,0.0,46365,521
-Louisiana,Iberia Parish,2016,73273,0.0,41424,585
-Louisiana,Iberia Parish,2017,72176,0.0,40019,549
-Louisiana,Iberia Parish,2018,70941,0.0,42994,513
-Louisiana,Iberia Parish,2019,69830,0.0,50991,548
-Louisiana,Iberia Parish,2021,68975,0.0,49447,551
-Louisiana,Iberia Parish,2022,68327,0.0,43513,569
+Louisiana,Iberia Parish,2005,72773,,35476,323
+Louisiana,Iberia Parish,2006,75509,,37819,357
+Louisiana,Iberia Parish,2007,74965,,40137,379
+Louisiana,Iberia Parish,2008,75097,,40869,437
+Louisiana,Iberia Parish,2009,75101,,43204,449
+Louisiana,Iberia Parish,2010,73236,,41709,508
+Louisiana,Iberia Parish,2011,73400,,42488,482
+Louisiana,Iberia Parish,2012,73999,,43869,453
+Louisiana,Iberia Parish,2013,73878,,39793,473
+Louisiana,Iberia Parish,2014,73913,,46290,455
+Louisiana,Iberia Parish,2015,74103,,46365,521
+Louisiana,Iberia Parish,2016,73273,,41424,585
+Louisiana,Iberia Parish,2017,72176,,40019,549
+Louisiana,Iberia Parish,2018,70941,,42994,513
+Louisiana,Iberia Parish,2019,69830,,50991,548
+Louisiana,Iberia Parish,2021,68975,,49447,551
+Louisiana,Iberia Parish,2022,68327,,43513,569
 Louisiana,Jefferson Parish,2005,448578,3031.0,41773,546
 Louisiana,Jefferson Parish,2006,431361,4405.0,44958,630
 Louisiana,Jefferson Parish,2007,423520,7969.0,48305,699
@@ -4564,7 +4564,7 @@ Louisiana,Jefferson Parish,2018,434051,6648.0,50766,827
 Louisiana,Jefferson Parish,2019,432493,6617.0,56069,827
 Louisiana,Jefferson Parish,2021,433688,18829.0,56282,910
 Louisiana,Jefferson Parish,2022,425884,19165.0,61397,948
-Louisiana,Lafayette Parish,2005,192448,0.0,40981,452
+Louisiana,Lafayette Parish,2005,192448,,40981,452
 Louisiana,Lafayette Parish,2006,203091,2605.0,42195,466
 Louisiana,Lafayette Parish,2007,204843,2288.0,44020,521
 Louisiana,Lafayette Parish,2008,206976,1981.0,48260,566
@@ -4572,49 +4572,49 @@ Louisiana,Lafayette Parish,2009,210954,2106.0,48050,617
 Louisiana,Lafayette Parish,2010,222051,2212.0,48368,570
 Louisiana,Lafayette Parish,2011,224390,2235.0,45172,631
 Louisiana,Lafayette Parish,2012,227055,2931.0,47341,621
-Louisiana,Lafayette Parish,2013,230845,0.0,57949,642
+Louisiana,Lafayette Parish,2013,230845,,57949,642
 Louisiana,Lafayette Parish,2014,235644,4060.0,51060,660
 Louisiana,Lafayette Parish,2015,240098,2644.0,51981,657
 Louisiana,Lafayette Parish,2016,241398,3639.0,49969,669
 Louisiana,Lafayette Parish,2017,242485,5174.0,52265,659
 Louisiana,Lafayette Parish,2018,242782,4486.0,60071,731
 Louisiana,Lafayette Parish,2019,244390,3910.0,60567,722
-Louisiana,Lafayette Parish,2021,244205,0.0,59093,738
-Louisiana,Lafayette Parish,2022,247866,0.0,56496,817
-Louisiana,Lafourche Parish,2005,90543,0.0,40232,376
-Louisiana,Lafourche Parish,2006,93554,0.0,40633,345
-Louisiana,Lafourche Parish,2007,92713,0.0,40418,394
-Louisiana,Lafourche Parish,2008,92572,0.0,51227,403
-Louisiana,Lafourche Parish,2009,93682,0.0,47825,483
-Louisiana,Lafourche Parish,2010,96328,0.0,47442,526
-Louisiana,Lafourche Parish,2011,96666,0.0,46697,543
-Louisiana,Lafourche Parish,2012,97029,0.0,48767,537
-Louisiana,Lafourche Parish,2013,97141,0.0,52373,539
-Louisiana,Lafourche Parish,2014,98020,0.0,41842,592
-Louisiana,Lafourche Parish,2015,98325,0.0,52589,536
-Louisiana,Lafourche Parish,2016,98305,0.0,51772,671
-Louisiana,Lafourche Parish,2017,98426,0.0,52283,610
-Louisiana,Lafourche Parish,2018,98115,0.0,50296,625
-Louisiana,Lafourche Parish,2019,97614,0.0,51339,684
-Louisiana,Lafourche Parish,2021,97504,0.0,59637,647
-Louisiana,Lafourche Parish,2022,95870,0.0,58593,562
-Louisiana,Livingston Parish,2005,108622,0.0,46081,370
-Louisiana,Livingston Parish,2006,114805,0.0,42339,525
-Louisiana,Livingston Parish,2007,116580,0.0,54498,541
-Louisiana,Livingston Parish,2008,120256,0.0,54517,500
-Louisiana,Livingston Parish,2009,123326,0.0,51962,570
-Louisiana,Livingston Parish,2010,128549,0.0,53277,631
-Louisiana,Livingston Parish,2011,130251,0.0,55817,602
-Louisiana,Livingston Parish,2012,131942,0.0,52397,623
-Louisiana,Livingston Parish,2013,134053,0.0,52246,615
-Louisiana,Livingston Parish,2014,135751,0.0,60466,673
-Louisiana,Livingston Parish,2015,137788,0.0,58677,691
-Louisiana,Livingston Parish,2016,140138,0.0,56534,672
-Louisiana,Livingston Parish,2017,138228,0.0,60471,670
-Louisiana,Livingston Parish,2018,139567,0.0,64067,864
-Louisiana,Livingston Parish,2019,140789,0.0,62187,814
-Louisiana,Livingston Parish,2021,145830,0.0,75682,922
-Louisiana,Livingston Parish,2022,148425,0.0,73126,781
+Louisiana,Lafayette Parish,2021,244205,,59093,738
+Louisiana,Lafayette Parish,2022,247866,,56496,817
+Louisiana,Lafourche Parish,2005,90543,,40232,376
+Louisiana,Lafourche Parish,2006,93554,,40633,345
+Louisiana,Lafourche Parish,2007,92713,,40418,394
+Louisiana,Lafourche Parish,2008,92572,,51227,403
+Louisiana,Lafourche Parish,2009,93682,,47825,483
+Louisiana,Lafourche Parish,2010,96328,,47442,526
+Louisiana,Lafourche Parish,2011,96666,,46697,543
+Louisiana,Lafourche Parish,2012,97029,,48767,537
+Louisiana,Lafourche Parish,2013,97141,,52373,539
+Louisiana,Lafourche Parish,2014,98020,,41842,592
+Louisiana,Lafourche Parish,2015,98325,,52589,536
+Louisiana,Lafourche Parish,2016,98305,,51772,671
+Louisiana,Lafourche Parish,2017,98426,,52283,610
+Louisiana,Lafourche Parish,2018,98115,,50296,625
+Louisiana,Lafourche Parish,2019,97614,,51339,684
+Louisiana,Lafourche Parish,2021,97504,,59637,647
+Louisiana,Lafourche Parish,2022,95870,,58593,562
+Louisiana,Livingston Parish,2005,108622,,46081,370
+Louisiana,Livingston Parish,2006,114805,,42339,525
+Louisiana,Livingston Parish,2007,116580,,54498,541
+Louisiana,Livingston Parish,2008,120256,,54517,500
+Louisiana,Livingston Parish,2009,123326,,51962,570
+Louisiana,Livingston Parish,2010,128549,,53277,631
+Louisiana,Livingston Parish,2011,130251,,55817,602
+Louisiana,Livingston Parish,2012,131942,,52397,623
+Louisiana,Livingston Parish,2013,134053,,52246,615
+Louisiana,Livingston Parish,2014,135751,,60466,673
+Louisiana,Livingston Parish,2015,137788,,58677,691
+Louisiana,Livingston Parish,2016,140138,,56534,672
+Louisiana,Livingston Parish,2017,138228,,60471,670
+Louisiana,Livingston Parish,2018,139567,,64067,864
+Louisiana,Livingston Parish,2019,140789,,62187,814
+Louisiana,Livingston Parish,2021,145830,,75682,922
+Louisiana,Livingston Parish,2022,148425,,73126,781
 Louisiana,Orleans Parish,2005,437186,6451.0,30711,464
 Louisiana,Orleans Parish,2006,223388,3291.0,35859,675
 Louisiana,Orleans Parish,2007,239124,3001.0,38614,763
@@ -4632,142 +4632,142 @@ Louisiana,Orleans Parish,2018,391006,9663.0,38423,817
 Louisiana,Orleans Parish,2019,390144,12680.0,45615,851
 Louisiana,Orleans Parish,2021,376971,29234.0,46942,883
 Louisiana,Orleans Parish,2022,369749,23881.0,52322,948
-Louisiana,Ouachita Parish,2005,143857,0.0,34838,384
-Louisiana,Ouachita Parish,2006,149259,0.0,35252,390
-Louisiana,Ouachita Parish,2007,149502,0.0,36999,392
-Louisiana,Ouachita Parish,2008,150051,0.0,39355,417
-Louisiana,Ouachita Parish,2009,151502,0.0,38443,444
-Louisiana,Ouachita Parish,2010,153910,0.0,37449,483
+Louisiana,Ouachita Parish,2005,143857,,34838,384
+Louisiana,Ouachita Parish,2006,149259,,35252,390
+Louisiana,Ouachita Parish,2007,149502,,36999,392
+Louisiana,Ouachita Parish,2008,150051,,39355,417
+Louisiana,Ouachita Parish,2009,151502,,38443,444
+Louisiana,Ouachita Parish,2010,153910,,37449,483
 Louisiana,Ouachita Parish,2011,154919,1313.0,34421,504
 Louisiana,Ouachita Parish,2012,155363,598.0,36338,449
-Louisiana,Ouachita Parish,2013,156220,0.0,40473,505
-Louisiana,Ouachita Parish,2014,156325,0.0,41139,496
+Louisiana,Ouachita Parish,2013,156220,,40473,505
+Louisiana,Ouachita Parish,2014,156325,,41139,496
 Louisiana,Ouachita Parish,2015,156761,1255.0,36709,508
-Louisiana,Ouachita Parish,2016,156983,0.0,37275,526
-Louisiana,Ouachita Parish,2017,155874,0.0,40161,600
-Louisiana,Ouachita Parish,2018,154475,0.0,44059,598
+Louisiana,Ouachita Parish,2016,156983,,37275,526
+Louisiana,Ouachita Parish,2017,155874,,40161,600
+Louisiana,Ouachita Parish,2018,154475,,44059,598
 Louisiana,Ouachita Parish,2019,153279,897.0,41137,569
-Louisiana,Ouachita Parish,2021,158768,0.0,47400,590
-Louisiana,Ouachita Parish,2022,157702,0.0,45840,685
-Louisiana,Rapides Parish,2005,123090,0.0,34236,385
+Louisiana,Ouachita Parish,2021,158768,,47400,590
+Louisiana,Ouachita Parish,2022,157702,,45840,685
+Louisiana,Rapides Parish,2005,123090,,34236,385
 Louisiana,Rapides Parish,2006,130201,625.0,34965,432
 Louisiana,Rapides Parish,2007,130079,1070.0,37034,447
 Louisiana,Rapides Parish,2008,133131,817.0,42763,460
-Louisiana,Rapides Parish,2009,133937,0.0,39631,503
-Louisiana,Rapides Parish,2010,131779,0.0,40377,471
+Louisiana,Rapides Parish,2009,133937,,39631,503
+Louisiana,Rapides Parish,2010,131779,,40377,471
 Louisiana,Rapides Parish,2011,132374,943.0,35047,447
 Louisiana,Rapides Parish,2012,132373,954.0,41321,486
-Louisiana,Rapides Parish,2013,132723,0.0,39331,522
-Louisiana,Rapides Parish,2014,132488,0.0,40434,541
-Louisiana,Rapides Parish,2015,132141,0.0,43222,549
-Louisiana,Rapides Parish,2016,132424,0.0,42582,567
-Louisiana,Rapides Parish,2017,131648,0.0,41646,615
-Louisiana,Rapides Parish,2018,130562,0.0,49175,625
-Louisiana,Rapides Parish,2019,129648,0.0,50490,661
-Louisiana,Rapides Parish,2021,128654,0.0,45183,626
-Louisiana,Rapides Parish,2022,127189,0.0,58161,637
-Louisiana,St. Landry Parish,2005,88409,0.0,22460,237
-Louisiana,St. Landry Parish,2006,91528,0.0,23119,271
-Louisiana,St. Landry Parish,2007,91362,0.0,26275,246
-Louisiana,St. Landry Parish,2008,92173,0.0,33138,309
-Louisiana,St. Landry Parish,2009,92326,0.0,34559,317
-Louisiana,St. Landry Parish,2010,83454,0.0,33388,312
-Louisiana,St. Landry Parish,2011,83552,0.0,34337,358
-Louisiana,St. Landry Parish,2012,83662,0.0,35765,386
-Louisiana,St. Landry Parish,2013,83454,0.0,31955,418
-Louisiana,St. Landry Parish,2014,83709,0.0,27753,402
-Louisiana,St. Landry Parish,2015,83848,0.0,30286,410
-Louisiana,St. Landry Parish,2016,83883,0.0,31207,449
-Louisiana,St. Landry Parish,2017,83497,0.0,34462,446
-Louisiana,St. Landry Parish,2018,82764,0.0,32867,429
-Louisiana,St. Landry Parish,2019,82124,0.0,38681,463
-Louisiana,St. Landry Parish,2021,82071,0.0,38599,472
-Louisiana,St. Landry Parish,2022,81773,0.0,41976,549
-Louisiana,St. Tammany Parish,2005,217999,0.0,53979,586
+Louisiana,Rapides Parish,2013,132723,,39331,522
+Louisiana,Rapides Parish,2014,132488,,40434,541
+Louisiana,Rapides Parish,2015,132141,,43222,549
+Louisiana,Rapides Parish,2016,132424,,42582,567
+Louisiana,Rapides Parish,2017,131648,,41646,615
+Louisiana,Rapides Parish,2018,130562,,49175,625
+Louisiana,Rapides Parish,2019,129648,,50490,661
+Louisiana,Rapides Parish,2021,128654,,45183,626
+Louisiana,Rapides Parish,2022,127189,,58161,637
+Louisiana,St. Landry Parish,2005,88409,,22460,237
+Louisiana,St. Landry Parish,2006,91528,,23119,271
+Louisiana,St. Landry Parish,2007,91362,,26275,246
+Louisiana,St. Landry Parish,2008,92173,,33138,309
+Louisiana,St. Landry Parish,2009,92326,,34559,317
+Louisiana,St. Landry Parish,2010,83454,,33388,312
+Louisiana,St. Landry Parish,2011,83552,,34337,358
+Louisiana,St. Landry Parish,2012,83662,,35765,386
+Louisiana,St. Landry Parish,2013,83454,,31955,418
+Louisiana,St. Landry Parish,2014,83709,,27753,402
+Louisiana,St. Landry Parish,2015,83848,,30286,410
+Louisiana,St. Landry Parish,2016,83883,,31207,449
+Louisiana,St. Landry Parish,2017,83497,,34462,446
+Louisiana,St. Landry Parish,2018,82764,,32867,429
+Louisiana,St. Landry Parish,2019,82124,,38681,463
+Louisiana,St. Landry Parish,2021,82071,,38599,472
+Louisiana,St. Landry Parish,2022,81773,,41976,549
+Louisiana,St. Tammany Parish,2005,217999,,53979,586
 Louisiana,St. Tammany Parish,2006,230605,2685.0,58976,648
 Louisiana,St. Tammany Parish,2007,226625,4206.0,59774,680
 Louisiana,St. Tammany Parish,2008,228456,3786.0,55871,827
 Louisiana,St. Tammany Parish,2009,231495,3244.0,58807,835
 Louisiana,St. Tammany Parish,2010,234568,3214.0,59350,762
-Louisiana,St. Tammany Parish,2011,236785,0.0,56536,750
+Louisiana,St. Tammany Parish,2011,236785,,56536,750
 Louisiana,St. Tammany Parish,2012,239453,3269.0,56650,845
 Louisiana,St. Tammany Parish,2013,242333,2889.0,61280,826
 Louisiana,St. Tammany Parish,2014,245829,3492.0,63210,748
 Louisiana,St. Tammany Parish,2015,250088,5692.0,63180,830
-Louisiana,St. Tammany Parish,2016,253602,0.0,64639,827
+Louisiana,St. Tammany Parish,2016,253602,,64639,827
 Louisiana,St. Tammany Parish,2017,256327,6962.0,67396,917
 Louisiana,St. Tammany Parish,2018,258111,7971.0,65392,901
-Louisiana,St. Tammany Parish,2019,260419,0.0,69076,948
-Louisiana,St. Tammany Parish,2021,269388,0.0,66582,989
-Louisiana,St. Tammany Parish,2022,273263,0.0,76269,1014
-Louisiana,Tangipahoa Parish,2005,103261,0.0,35154,381
-Louisiana,Tangipahoa Parish,2006,113137,0.0,33075,509
-Louisiana,Tangipahoa Parish,2007,115398,0.0,32763,493
-Louisiana,Tangipahoa Parish,2008,117001,0.0,41399,496
-Louisiana,Tangipahoa Parish,2009,118688,0.0,37672,541
-Louisiana,Tangipahoa Parish,2010,121425,0.0,37390,566
-Louisiana,Tangipahoa Parish,2011,122571,0.0,39391,567
-Louisiana,Tangipahoa Parish,2012,123441,0.0,34904,578
-Louisiana,Tangipahoa Parish,2013,125412,0.0,44166,585
-Louisiana,Tangipahoa Parish,2014,127049,0.0,40689,590
-Louisiana,Tangipahoa Parish,2015,128755,0.0,42962,632
-Louisiana,Tangipahoa Parish,2016,130710,0.0,48162,616
-Louisiana,Tangipahoa Parish,2017,132497,0.0,44861,647
-Louisiana,Tangipahoa Parish,2018,133777,0.0,48205,684
-Louisiana,Tangipahoa Parish,2019,134758,0.0,47825,697
-Louisiana,Tangipahoa Parish,2021,135217,0.0,52872,725
-Louisiana,Tangipahoa Parish,2022,137048,0.0,55391,678
-Louisiana,Terrebonne Parish,2005,106078,0.0,37115,438
-Louisiana,Terrebonne Parish,2006,109348,0.0,45258,419
-Louisiana,Terrebonne Parish,2007,108424,0.0,44193,528
-Louisiana,Terrebonne Parish,2008,108576,0.0,51023,576
-Louisiana,Terrebonne Parish,2009,109291,0.0,47728,524
-Louisiana,Terrebonne Parish,2010,111861,0.0,48583,596
-Louisiana,Terrebonne Parish,2011,111917,0.0,43963,633
-Louisiana,Terrebonne Parish,2012,111893,0.0,48911,712
-Louisiana,Terrebonne Parish,2013,112749,0.0,55148,703
-Louisiana,Terrebonne Parish,2014,113328,0.0,46678,697
-Louisiana,Terrebonne Parish,2015,113972,0.0,41786,640
-Louisiana,Terrebonne Parish,2016,113220,0.0,46026,732
-Louisiana,Terrebonne Parish,2017,112086,0.0,42857,675
-Louisiana,Terrebonne Parish,2018,111021,0.0,52820,705
-Louisiana,Terrebonne Parish,2019,110461,0.0,48446,699
-Louisiana,Terrebonne Parish,2021,108708,0.0,63100,731
-Louisiana,Terrebonne Parish,2022,104786,0.0,57299,772
-Maine,Androscoggin County,2005,104298,0.0,43005,554
-Maine,Androscoggin County,2006,107552,0.0,37945,509
-Maine,Androscoggin County,2007,106815,0.0,46400,565
+Louisiana,St. Tammany Parish,2019,260419,,69076,948
+Louisiana,St. Tammany Parish,2021,269388,,66582,989
+Louisiana,St. Tammany Parish,2022,273263,,76269,1014
+Louisiana,Tangipahoa Parish,2005,103261,,35154,381
+Louisiana,Tangipahoa Parish,2006,113137,,33075,509
+Louisiana,Tangipahoa Parish,2007,115398,,32763,493
+Louisiana,Tangipahoa Parish,2008,117001,,41399,496
+Louisiana,Tangipahoa Parish,2009,118688,,37672,541
+Louisiana,Tangipahoa Parish,2010,121425,,37390,566
+Louisiana,Tangipahoa Parish,2011,122571,,39391,567
+Louisiana,Tangipahoa Parish,2012,123441,,34904,578
+Louisiana,Tangipahoa Parish,2013,125412,,44166,585
+Louisiana,Tangipahoa Parish,2014,127049,,40689,590
+Louisiana,Tangipahoa Parish,2015,128755,,42962,632
+Louisiana,Tangipahoa Parish,2016,130710,,48162,616
+Louisiana,Tangipahoa Parish,2017,132497,,44861,647
+Louisiana,Tangipahoa Parish,2018,133777,,48205,684
+Louisiana,Tangipahoa Parish,2019,134758,,47825,697
+Louisiana,Tangipahoa Parish,2021,135217,,52872,725
+Louisiana,Tangipahoa Parish,2022,137048,,55391,678
+Louisiana,Terrebonne Parish,2005,106078,,37115,438
+Louisiana,Terrebonne Parish,2006,109348,,45258,419
+Louisiana,Terrebonne Parish,2007,108424,,44193,528
+Louisiana,Terrebonne Parish,2008,108576,,51023,576
+Louisiana,Terrebonne Parish,2009,109291,,47728,524
+Louisiana,Terrebonne Parish,2010,111861,,48583,596
+Louisiana,Terrebonne Parish,2011,111917,,43963,633
+Louisiana,Terrebonne Parish,2012,111893,,48911,712
+Louisiana,Terrebonne Parish,2013,112749,,55148,703
+Louisiana,Terrebonne Parish,2014,113328,,46678,697
+Louisiana,Terrebonne Parish,2015,113972,,41786,640
+Louisiana,Terrebonne Parish,2016,113220,,46026,732
+Louisiana,Terrebonne Parish,2017,112086,,42857,675
+Louisiana,Terrebonne Parish,2018,111021,,52820,705
+Louisiana,Terrebonne Parish,2019,110461,,48446,699
+Louisiana,Terrebonne Parish,2021,108708,,63100,731
+Louisiana,Terrebonne Parish,2022,104786,,57299,772
+Maine,Androscoggin County,2005,104298,,43005,554
+Maine,Androscoggin County,2006,107552,,37945,509
+Maine,Androscoggin County,2007,106815,,46400,565
 Maine,Androscoggin County,2008,106877,1677.0,45225,567
-Maine,Androscoggin County,2009,106539,0.0,39990,573
-Maine,Androscoggin County,2010,107623,0.0,41190,594
-Maine,Androscoggin County,2011,107398,0.0,44689,609
-Maine,Androscoggin County,2012,107609,0.0,44297,625
-Maine,Androscoggin County,2013,107604,0.0,44127,626
-Maine,Androscoggin County,2014,107440,0.0,48007,621
-Maine,Androscoggin County,2015,107233,0.0,50338,659
-Maine,Androscoggin County,2016,107319,0.0,49081,657
-Maine,Androscoggin County,2017,107651,0.0,48286,625
+Maine,Androscoggin County,2009,106539,,39990,573
+Maine,Androscoggin County,2010,107623,,41190,594
+Maine,Androscoggin County,2011,107398,,44689,609
+Maine,Androscoggin County,2012,107609,,44297,625
+Maine,Androscoggin County,2013,107604,,44127,626
+Maine,Androscoggin County,2014,107440,,48007,621
+Maine,Androscoggin County,2015,107233,,50338,659
+Maine,Androscoggin County,2016,107319,,49081,657
+Maine,Androscoggin County,2017,107651,,48286,625
 Maine,Androscoggin County,2018,107679,1700.0,49697,713
-Maine,Androscoggin County,2019,108277,0.0,63813,734
-Maine,Androscoggin County,2021,111034,0.0,62958,812
-Maine,Androscoggin County,2022,113023,0.0,63438,868
-Maine,Aroostook County,2005,71046,0.0,32148,362
-Maine,Aroostook County,2006,73008,0.0,32642,377
+Maine,Androscoggin County,2019,108277,,63813,734
+Maine,Androscoggin County,2021,111034,,62958,812
+Maine,Androscoggin County,2022,113023,,63438,868
+Maine,Aroostook County,2005,71046,,32148,362
+Maine,Aroostook County,2006,73008,,32642,377
 Maine,Aroostook County,2007,72047,1403.0,35452,371
 Maine,Aroostook County,2008,71676,1513.0,36346,385
-Maine,Aroostook County,2009,71488,0.0,34610,459
-Maine,Aroostook County,2010,71720,0.0,36403,433
-Maine,Aroostook County,2011,71482,0.0,35148,409
+Maine,Aroostook County,2009,71488,,34610,459
+Maine,Aroostook County,2010,71720,,36403,433
+Maine,Aroostook County,2011,71482,,35148,409
 Maine,Aroostook County,2012,70868,1107.0,38453,473
-Maine,Aroostook County,2013,70055,0.0,36825,479
-Maine,Aroostook County,2014,69447,0.0,35439,472
-Maine,Aroostook County,2015,68628,0.0,36596,469
-Maine,Aroostook County,2016,67959,0.0,39450,478
-Maine,Aroostook County,2017,67653,0.0,43015,458
-Maine,Aroostook County,2018,67111,0.0,38233,477
-Maine,Aroostook County,2019,67055,0.0,38768,495
-Maine,Aroostook County,2021,66859,0.0,52849,593
-Maine,Aroostook County,2022,67255,0.0,51395,589
+Maine,Aroostook County,2013,70055,,36825,479
+Maine,Aroostook County,2014,69447,,35439,472
+Maine,Aroostook County,2015,68628,,36596,469
+Maine,Aroostook County,2016,67959,,39450,478
+Maine,Aroostook County,2017,67653,,43015,458
+Maine,Aroostook County,2018,67111,,38233,477
+Maine,Aroostook County,2019,67055,,38768,495
+Maine,Aroostook County,2021,66859,,52849,593
+Maine,Aroostook County,2022,67255,,51395,589
 Maine,Cumberland County,2005,264737,7854.0,50057,710
 Maine,Cumberland County,2006,274598,7620.0,51520,757
 Maine,Cumberland County,2007,275374,7173.0,55278,748
@@ -4785,47 +4785,47 @@ Maine,Cumberland County,2018,293557,12654.0,72452,1036
 Maine,Cumberland County,2019,295003,11747.0,76059,1086
 Maine,Cumberland County,2021,305231,42619.0,80982,1202
 Maine,Cumberland County,2022,307451,36661.0,89345,1326
-Maine,Kennebec County,2005,117620,0.0,44162,487
-Maine,Kennebec County,2006,121068,0.0,44758,487
-Maine,Kennebec County,2007,120839,0.0,44113,506
-Maine,Kennebec County,2008,120959,0.0,46314,543
-Maine,Kennebec County,2009,121090,0.0,45007,536
-Maine,Kennebec County,2010,122143,0.0,44964,601
+Maine,Kennebec County,2005,117620,,44162,487
+Maine,Kennebec County,2006,121068,,44758,487
+Maine,Kennebec County,2007,120839,,44113,506
+Maine,Kennebec County,2008,120959,,46314,543
+Maine,Kennebec County,2009,121090,,45007,536
+Maine,Kennebec County,2010,122143,,44964,601
 Maine,Kennebec County,2011,121935,1799.0,44259,617
-Maine,Kennebec County,2012,121853,0.0,46014,581
-Maine,Kennebec County,2013,121164,0.0,44724,614
-Maine,Kennebec County,2014,121112,0.0,44633,643
-Maine,Kennebec County,2015,119980,0.0,51335,619
-Maine,Kennebec County,2016,120569,0.0,51573,627
-Maine,Kennebec County,2017,121821,0.0,53073,646
-Maine,Kennebec County,2018,122083,0.0,51653,655
-Maine,Kennebec County,2019,122302,0.0,55389,680
-Maine,Kennebec County,2021,124486,0.0,60528,808
-Maine,Kennebec County,2022,125540,0.0,62943,853
-Maine,Penobscot County,2005,140625,0.0,40761,507
+Maine,Kennebec County,2012,121853,,46014,581
+Maine,Kennebec County,2013,121164,,44724,614
+Maine,Kennebec County,2014,121112,,44633,643
+Maine,Kennebec County,2015,119980,,51335,619
+Maine,Kennebec County,2016,120569,,51573,627
+Maine,Kennebec County,2017,121821,,53073,646
+Maine,Kennebec County,2018,122083,,51653,655
+Maine,Kennebec County,2019,122302,,55389,680
+Maine,Kennebec County,2021,124486,,60528,808
+Maine,Kennebec County,2022,125540,,62943,853
+Maine,Penobscot County,2005,140625,,40761,507
 Maine,Penobscot County,2006,147180,2140.0,39244,528
 Maine,Penobscot County,2007,148784,2474.0,41333,559
 Maine,Penobscot County,2008,148651,3208.0,42935,600
-Maine,Penobscot County,2009,149419,0.0,39906,608
+Maine,Penobscot County,2009,149419,,39906,608
 Maine,Penobscot County,2010,153849,3047.0,42964,607
 Maine,Penobscot County,2011,153786,2710.0,40669,614
 Maine,Penobscot County,2012,153746,3034.0,41653,663
 Maine,Penobscot County,2013,153364,2591.0,43598,666
 Maine,Penobscot County,2014,153414,2080.0,42242,616
 Maine,Penobscot County,2015,152692,3664.0,44173,681
-Maine,Penobscot County,2016,151806,0.0,47328,680
+Maine,Penobscot County,2016,151806,,47328,680
 Maine,Penobscot County,2017,151957,3089.0,50349,752
 Maine,Penobscot County,2018,151096,3026.0,47217,695
 Maine,Penobscot County,2019,152148,2947.0,50449,735
-Maine,Penobscot County,2021,152765,0.0,56250,819
+Maine,Penobscot County,2021,152765,,56250,819
 Maine,Penobscot County,2022,153704,6972.0,61134,863
-Maine,York County,2005,198899,0.0,49678,664
+Maine,York County,2005,198899,,49678,664
 Maine,York County,2006,202232,5434.0,50943,686
 Maine,York County,2007,201341,5047.0,52365,668
 Maine,York County,2008,201686,5421.0,54932,746
 Maine,York County,2009,201876,5539.0,54446,747
 Maine,York County,2010,197216,5464.0,54880,729
-Maine,York County,2011,198199,0.0,56777,774
+Maine,York County,2011,198199,,56777,774
 Maine,York County,2012,199005,5349.0,52408,794
 Maine,York County,2013,199431,6100.0,55350,808
 Maine,York County,2014,200710,6543.0,55509,776
@@ -4836,23 +4836,23 @@ Maine,York County,2018,206229,6316.0,66614,887
 Maine,York County,2019,207641,7318.0,66648,914
 Maine,York County,2021,214591,19190.0,73875,1024
 Maine,York County,2022,216732,17932.0,81928,995
-Maryland,Allegany County,2005,67114,0.0,33317,347
-Maryland,Allegany County,2006,72831,0.0,32984,350
-Maryland,Allegany County,2007,72594,0.0,37024,421
-Maryland,Allegany County,2008,72238,0.0,39871,439
-Maryland,Allegany County,2009,72532,0.0,36491,382
-Maryland,Allegany County,2010,75021,0.0,35039,452
-Maryland,Allegany County,2011,74692,0.0,38502,459
-Maryland,Allegany County,2012,74012,0.0,38509,488
-Maryland,Allegany County,2013,73521,0.0,40165,403
-Maryland,Allegany County,2014,72952,0.0,39653,526
-Maryland,Allegany County,2015,72528,0.0,38281,513
-Maryland,Allegany County,2016,72130,0.0,45606,573
-Maryland,Allegany County,2017,71615,0.0,42019,530
-Maryland,Allegany County,2018,70975,0.0,42068,509
-Maryland,Allegany County,2019,70416,0.0,48867,530
-Maryland,Allegany County,2021,67729,0.0,48888,561
-Maryland,Allegany County,2022,67267,0.0,46913,545
+Maryland,Allegany County,2005,67114,,33317,347
+Maryland,Allegany County,2006,72831,,32984,350
+Maryland,Allegany County,2007,72594,,37024,421
+Maryland,Allegany County,2008,72238,,39871,439
+Maryland,Allegany County,2009,72532,,36491,382
+Maryland,Allegany County,2010,75021,,35039,452
+Maryland,Allegany County,2011,74692,,38502,459
+Maryland,Allegany County,2012,74012,,38509,488
+Maryland,Allegany County,2013,73521,,40165,403
+Maryland,Allegany County,2014,72952,,39653,526
+Maryland,Allegany County,2015,72528,,38281,513
+Maryland,Allegany County,2016,72130,,45606,573
+Maryland,Allegany County,2017,71615,,42019,530
+Maryland,Allegany County,2018,70975,,42068,509
+Maryland,Allegany County,2019,70416,,48867,530
+Maryland,Allegany County,2021,67729,,48888,561
+Maryland,Allegany County,2022,67267,,46913,545
 Maryland,Anne Arundel County,2005,494676,11086.0,71961,940
 Maryland,Anne Arundel County,2006,509300,10043.0,79160,1009
 Maryland,Anne Arundel County,2007,512154,9623.0,80402,1060
@@ -4887,58 +4887,58 @@ Maryland,Baltimore County,2018,828431,16229.0,76182,1115
 Maryland,Baltimore County,2019,827370,19068.0,77358,1165
 Maryland,Baltimore County,2021,849316,79665.0,80453,1209
 Maryland,Baltimore County,2022,846161,69365.0,86526,1311
-Maryland,Calvert County,2005,87303,0.0,84388,1069
-Maryland,Calvert County,2006,88804,0.0,84891,840
-Maryland,Calvert County,2007,88223,0.0,95134,950
-Maryland,Calvert County,2008,88698,0.0,81662,781
-Maryland,Calvert County,2009,89212,0.0,89289,1088
-Maryland,Calvert County,2010,88936,0.0,88862,1037
-Maryland,Calvert County,2011,89256,0.0,89393,1213
-Maryland,Calvert County,2012,89628,0.0,87449,1192
-Maryland,Calvert County,2013,90484,0.0,94196,1268
-Maryland,Calvert County,2014,90613,0.0,95110,1314
-Maryland,Calvert County,2015,90595,0.0,106247,1418
-Maryland,Calvert County,2016,91251,0.0,98732,1194
-Maryland,Calvert County,2017,91502,0.0,100590,1363
-Maryland,Calvert County,2018,92003,0.0,107884,1301
-Maryland,Calvert County,2019,92525,0.0,112380,1203
-Maryland,Calvert County,2021,93928,0.0,122266,1254
-Maryland,Calvert County,2022,94573,0.0,120097,1535
-Maryland,Carroll County,2005,164663,0.0,75833,659
+Maryland,Calvert County,2005,87303,,84388,1069
+Maryland,Calvert County,2006,88804,,84891,840
+Maryland,Calvert County,2007,88223,,95134,950
+Maryland,Calvert County,2008,88698,,81662,781
+Maryland,Calvert County,2009,89212,,89289,1088
+Maryland,Calvert County,2010,88936,,88862,1037
+Maryland,Calvert County,2011,89256,,89393,1213
+Maryland,Calvert County,2012,89628,,87449,1192
+Maryland,Calvert County,2013,90484,,94196,1268
+Maryland,Calvert County,2014,90613,,95110,1314
+Maryland,Calvert County,2015,90595,,106247,1418
+Maryland,Calvert County,2016,91251,,98732,1194
+Maryland,Calvert County,2017,91502,,100590,1363
+Maryland,Calvert County,2018,92003,,107884,1301
+Maryland,Calvert County,2019,92525,,112380,1203
+Maryland,Calvert County,2021,93928,,122266,1254
+Maryland,Calvert County,2022,94573,,120097,1535
+Maryland,Carroll County,2005,164663,,75833,659
 Maryland,Carroll County,2006,170260,4353.0,74106,705
 Maryland,Carroll County,2007,169220,4057.0,82492,685
 Maryland,Carroll County,2008,169353,3394.0,78653,829
-Maryland,Carroll County,2009,170089,0.0,79227,777
+Maryland,Carroll County,2009,170089,,79227,777
 Maryland,Carroll County,2010,167241,4947.0,82077,783
 Maryland,Carroll County,2011,167288,4576.0,84117,887
 Maryland,Carroll County,2012,167217,3310.0,80028,890
 Maryland,Carroll County,2013,167564,3238.0,82955,885
-Maryland,Carroll County,2014,167830,0.0,85274,919
-Maryland,Carroll County,2015,167627,0.0,84887,914
-Maryland,Carroll County,2016,167656,0.0,90343,911
+Maryland,Carroll County,2014,167830,,85274,919
+Maryland,Carroll County,2015,167627,,84887,914
+Maryland,Carroll County,2016,167656,,90343,911
 Maryland,Carroll County,2017,167781,4465.0,93676,960
 Maryland,Carroll County,2018,168429,6418.0,97430,893
-Maryland,Carroll County,2019,168447,0.0,103014,912
-Maryland,Carroll County,2021,173873,0.0,102476,1136
-Maryland,Carroll County,2022,175305,0.0,104942,1090
-Maryland,Cecil County,2005,96309,0.0,59137,637
-Maryland,Cecil County,2006,99506,0.0,56509,659
-Maryland,Cecil County,2007,99695,0.0,63159,726
-Maryland,Cecil County,2008,99926,0.0,68338,727
-Maryland,Cecil County,2009,100796,0.0,60563,776
-Maryland,Cecil County,2010,101199,0.0,62427,780
-Maryland,Cecil County,2011,101694,0.0,61686,730
-Maryland,Cecil County,2012,101696,0.0,63036,720
-Maryland,Cecil County,2013,101913,0.0,66090,798
-Maryland,Cecil County,2014,102383,0.0,61940,814
-Maryland,Cecil County,2015,102382,0.0,70676,870
-Maryland,Cecil County,2016,102603,0.0,74221,922
-Maryland,Cecil County,2017,102746,0.0,74912,866
-Maryland,Cecil County,2018,102826,0.0,74452,948
-Maryland,Cecil County,2019,102855,0.0,76441,1010
-Maryland,Cecil County,2021,103905,0.0,75692,1011
-Maryland,Cecil County,2022,104942,0.0,86292,1169
-Maryland,Charles County,2005,137341,0.0,69573,849
+Maryland,Carroll County,2019,168447,,103014,912
+Maryland,Carroll County,2021,173873,,102476,1136
+Maryland,Carroll County,2022,175305,,104942,1090
+Maryland,Cecil County,2005,96309,,59137,637
+Maryland,Cecil County,2006,99506,,56509,659
+Maryland,Cecil County,2007,99695,,63159,726
+Maryland,Cecil County,2008,99926,,68338,727
+Maryland,Cecil County,2009,100796,,60563,776
+Maryland,Cecil County,2010,101199,,62427,780
+Maryland,Cecil County,2011,101694,,61686,730
+Maryland,Cecil County,2012,101696,,63036,720
+Maryland,Cecil County,2013,101913,,66090,798
+Maryland,Cecil County,2014,102383,,61940,814
+Maryland,Cecil County,2015,102382,,70676,870
+Maryland,Cecil County,2016,102603,,74221,922
+Maryland,Cecil County,2017,102746,,74912,866
+Maryland,Cecil County,2018,102826,,74452,948
+Maryland,Cecil County,2019,102855,,76441,1010
+Maryland,Cecil County,2021,103905,,75692,1011
+Maryland,Cecil County,2022,104942,,86292,1169
+Maryland,Charles County,2005,137341,,69573,849
 Maryland,Charles County,2006,140416,2421.0,80179,954
 Maryland,Charles County,2007,140444,1857.0,83412,976
 Maryland,Charles County,2008,140764,1817.0,87030,1045
@@ -4953,7 +4953,7 @@ Maryland,Charles County,2016,157705,1784.0,95735,1349
 Maryland,Charles County,2017,159700,4250.0,97986,1565
 Maryland,Charles County,2018,161503,3471.0,94368,1498
 Maryland,Charles County,2019,163257,3847.0,103932,1484
-Maryland,Charles County,2021,168698,0.0,105493,1609
+Maryland,Charles County,2021,168698,,105493,1609
 Maryland,Charles County,2022,170102,13121.0,115880,1628
 Maryland,Frederick County,2005,215877,4228.0,73149,829
 Maryland,Frederick County,2006,222938,4151.0,74029,909
@@ -4972,7 +4972,7 @@ Maryland,Frederick County,2018,255648,8602.0,95850,1261
 Maryland,Frederick County,2019,259547,10937.0,103516,1306
 Maryland,Frederick County,2021,279835,36762.0,104780,1382
 Maryland,Frederick County,2022,287079,33610.0,119122,1541
-Maryland,Harford County,2005,237644,0.0,65343,705
+Maryland,Harford County,2005,237644,,65343,705
 Maryland,Harford County,2006,241402,4867.0,69549,710
 Maryland,Harford County,2007,239993,3748.0,72372,791
 Maryland,Harford County,2008,240351,4192.0,77085,849
@@ -4987,7 +4987,7 @@ Maryland,Harford County,2016,251032,6060.0,84175,1023
 Maryland,Harford County,2017,252160,5837.0,80476,1037
 Maryland,Harford County,2018,253956,6683.0,88603,1077
 Maryland,Harford County,2019,255441,6896.0,92331,1132
-Maryland,Harford County,2021,262977,0.0,96328,1237
+Maryland,Harford County,2021,262977,,96328,1237
 Maryland,Harford County,2022,263867,20962.0,100915,1310
 Maryland,Howard County,2005,265755,6530.0,91184,1007
 Maryland,Howard County,2006,272452,8531.0,94260,1146
@@ -5004,7 +5004,7 @@ Maryland,Howard County,2016,317233,10019.0,120941,1482
 Maryland,Howard County,2017,321113,11942.0,111473,1491
 Maryland,Howard County,2018,323196,11028.0,116984,1470
 Maryland,Howard County,2019,325690,13668.0,121618,1599
-Maryland,Howard County,2021,334529,0.0,133267,1659
+Maryland,Howard County,2021,334529,,133267,1659
 Maryland,Howard County,2022,335411,44504.0,133438,1797
 Maryland,Montgomery County,2005,918046,22816.0,82187,1111
 Maryland,Montgomery County,2006,932131,25593.0,87624,1164
@@ -5040,24 +5040,24 @@ Maryland,Prince George's County,2018,909308,17272.0,83034,1348
 Maryland,Prince George's County,2019,909327,17682.0,86290,1370
 Maryland,Prince George's County,2021,955306,110253.0,90182,1450
 Maryland,Prince George's County,2022,946971,87338.0,94441,1501
-Maryland,St. Mary's County,2005,93301,0.0,62939,733
-Maryland,St. Mary's County,2006,98854,0.0,71158,776
-Maryland,St. Mary's County,2007,100378,0.0,75769,964
-Maryland,St. Mary's County,2008,101578,0.0,80624,1049
-Maryland,St. Mary's County,2009,102999,0.0,72474,909
-Maryland,St. Mary's County,2010,105786,0.0,88444,1025
-Maryland,St. Mary's County,2011,107484,0.0,81657,1081
-Maryland,St. Mary's County,2012,108987,0.0,86358,1102
-Maryland,St. Mary's County,2013,109633,0.0,78233,935
-Maryland,St. Mary's County,2014,110382,0.0,86417,1041
-Maryland,St. Mary's County,2015,111413,0.0,85163,1153
-Maryland,St. Mary's County,2016,112587,0.0,78195,1205
-Maryland,St. Mary's County,2017,112667,0.0,81495,1065
-Maryland,St. Mary's County,2018,112664,0.0,92250,1162
-Maryland,St. Mary's County,2019,113510,0.0,87947,1170
-Maryland,St. Mary's County,2021,114468,0.0,108397,1280
-Maryland,St. Mary's County,2022,114877,0.0,113717,1385
-Maryland,Washington County,2005,132574,0.0,47771,528
+Maryland,St. Mary's County,2005,93301,,62939,733
+Maryland,St. Mary's County,2006,98854,,71158,776
+Maryland,St. Mary's County,2007,100378,,75769,964
+Maryland,St. Mary's County,2008,101578,,80624,1049
+Maryland,St. Mary's County,2009,102999,,72474,909
+Maryland,St. Mary's County,2010,105786,,88444,1025
+Maryland,St. Mary's County,2011,107484,,81657,1081
+Maryland,St. Mary's County,2012,108987,,86358,1102
+Maryland,St. Mary's County,2013,109633,,78233,935
+Maryland,St. Mary's County,2014,110382,,86417,1041
+Maryland,St. Mary's County,2015,111413,,85163,1153
+Maryland,St. Mary's County,2016,112587,,78195,1205
+Maryland,St. Mary's County,2017,112667,,81495,1065
+Maryland,St. Mary's County,2018,112664,,92250,1162
+Maryland,St. Mary's County,2019,113510,,87947,1170
+Maryland,St. Mary's County,2021,114468,,108397,1280
+Maryland,St. Mary's County,2022,114877,,113717,1385
+Maryland,Washington County,2005,132574,,47771,528
 Maryland,Washington County,2006,143748,2534.0,52349,586
 Maryland,Washington County,2007,145113,1418.0,50320,624
 Maryland,Washington County,2008,145384,2854.0,51503,641
@@ -5066,30 +5066,30 @@ Maryland,Washington County,2010,147558,1913.0,52857,650
 Maryland,Washington County,2011,148203,2675.0,52653,673
 Maryland,Washington County,2012,149180,3413.0,53167,725
 Maryland,Washington County,2013,149588,2727.0,57615,783
-Maryland,Washington County,2014,149573,0.0,55471,669
+Maryland,Washington County,2014,149573,,55471,669
 Maryland,Washington County,2015,149585,3544.0,55979,755
 Maryland,Washington County,2016,150292,2685.0,54250,725
 Maryland,Washington County,2017,150578,3353.0,60385,743
 Maryland,Washington County,2018,150926,3479.0,63126,770
-Maryland,Washington County,2019,151049,0.0,59140,789
-Maryland,Washington County,2021,154937,0.0,65367,820
-Maryland,Washington County,2022,155590,0.0,69244,824
-Maryland,Wicomico County,2005,87334,0.0,45581,609
-Maryland,Wicomico County,2006,91987,0.0,47540,619
+Maryland,Washington County,2019,151049,,59140,789
+Maryland,Washington County,2021,154937,,65367,820
+Maryland,Washington County,2022,155590,,69244,824
+Maryland,Wicomico County,2005,87334,,45581,609
+Maryland,Wicomico County,2006,91987,,47540,619
 Maryland,Wicomico County,2007,93600,1011.0,52132,701
-Maryland,Wicomico County,2008,94046,0.0,49186,685
-Maryland,Wicomico County,2009,94222,0.0,47280,770
-Maryland,Wicomico County,2010,98843,0.0,49913,711
-Maryland,Wicomico County,2011,99190,0.0,46990,780
-Maryland,Wicomico County,2012,100647,0.0,51451,728
-Maryland,Wicomico County,2013,100896,0.0,48897,761
-Maryland,Wicomico County,2014,101539,0.0,53432,810
-Maryland,Wicomico County,2015,102370,0.0,54781,807
-Maryland,Wicomico County,2016,102577,0.0,50844,798
-Maryland,Wicomico County,2017,102923,0.0,54080,762
-Maryland,Wicomico County,2018,103195,0.0,57249,840
-Maryland,Wicomico County,2019,103609,0.0,54402,853
-Maryland,Wicomico County,2021,103980,0.0,63333,908
+Maryland,Wicomico County,2008,94046,,49186,685
+Maryland,Wicomico County,2009,94222,,47280,770
+Maryland,Wicomico County,2010,98843,,49913,711
+Maryland,Wicomico County,2011,99190,,46990,780
+Maryland,Wicomico County,2012,100647,,51451,728
+Maryland,Wicomico County,2013,100896,,48897,761
+Maryland,Wicomico County,2014,101539,,53432,810
+Maryland,Wicomico County,2015,102370,,54781,807
+Maryland,Wicomico County,2016,102577,,50844,798
+Maryland,Wicomico County,2017,102923,,54080,762
+Maryland,Wicomico County,2018,103195,,57249,840
+Maryland,Wicomico County,2019,103609,,54402,853
+Maryland,Wicomico County,2021,103980,,63333,908
 Maryland,Wicomico County,2022,104664,4253.0,72198,1052
 Maryland,Baltimore city,2005,608481,6233.0,32456,538
 Maryland,Baltimore city,2006,631366,5946.0,36031,595
@@ -5108,7 +5108,7 @@ Maryland,Baltimore city,2018,602495,11914.0,51000,877
 Maryland,Baltimore city,2019,593490,12470.0,50177,923
 Maryland,Baltimore city,2021,576498,63694.0,54652,990
 Maryland,Baltimore city,2022,569931,48227.0,55198,1043
-Massachusetts,Barnstable County,2005,220838,0.0,54439,887
+Massachusetts,Barnstable County,2005,220838,,54439,887
 Massachusetts,Barnstable County,2006,224816,5099.0,56974,886
 Massachusetts,Barnstable County,2007,222175,5549.0,60015,908
 Massachusetts,Barnstable County,2008,221049,5770.0,57314,894
@@ -5125,23 +5125,23 @@ Massachusetts,Barnstable County,2018,213413,7099.0,68902,1112
 Massachusetts,Barnstable County,2019,212990,7952.0,85042,1131
 Massachusetts,Barnstable County,2021,232411,20241.0,83537,1340
 Massachusetts,Barnstable County,2022,232457,15765.0,91438,1440
-Massachusetts,Berkshire County,2005,125654,0.0,48570,484
-Massachusetts,Berkshire County,2006,131117,0.0,47562,518
-Massachusetts,Berkshire County,2007,129798,0.0,47302,562
+Massachusetts,Berkshire County,2005,125654,,48570,484
+Massachusetts,Berkshire County,2006,131117,,47562,518
+Massachusetts,Berkshire County,2007,129798,,47302,562
 Massachusetts,Berkshire County,2008,129395,2499.0,44797,590
 Massachusetts,Berkshire County,2009,129288,2321.0,42290,625
-Massachusetts,Berkshire County,2010,131144,0.0,44190,618
+Massachusetts,Berkshire County,2010,131144,,44190,618
 Massachusetts,Berkshire County,2011,130458,2682.0,42969,616
 Massachusetts,Berkshire County,2012,130016,3367.0,46509,651
-Massachusetts,Berkshire County,2013,129585,0.0,52514,641
-Massachusetts,Berkshire County,2014,128715,0.0,50211,626
+Massachusetts,Berkshire County,2013,129585,,52514,641
+Massachusetts,Berkshire County,2014,128715,,50211,626
 Massachusetts,Berkshire County,2015,127828,4274.0,50765,698
-Massachusetts,Berkshire County,2016,126903,0.0,58418,718
-Massachusetts,Berkshire County,2017,126313,0.0,57054,721
+Massachusetts,Berkshire County,2016,126903,,58418,718
+Massachusetts,Berkshire County,2017,126313,,57054,721
 Massachusetts,Berkshire County,2018,126348,3184.0,60476,737
 Massachusetts,Berkshire County,2019,124944,3717.0,58895,741
-Massachusetts,Berkshire County,2021,128657,0.0,60749,794
-Massachusetts,Berkshire County,2022,127859,0.0,74176,825
+Massachusetts,Berkshire County,2021,128657,,60749,794
+Massachusetts,Berkshire County,2022,127859,,74176,825
 Massachusetts,Bristol County,2005,533310,5485.0,51132,595
 Massachusetts,Bristol County,2006,545379,6389.0,51769,609
 Massachusetts,Bristol County,2007,543024,8402.0,54895,629
@@ -5176,24 +5176,24 @@ Massachusetts,Essex County,2018,790638,21529.0,76604,1115
 Massachusetts,Essex County,2019,789034,20253.0,83810,1186
 Massachusetts,Essex County,2021,807074,81042.0,87433,1311
 Massachusetts,Essex County,2022,806765,68221.0,92413,1498
-Massachusetts,Franklin County,2005,70928,0.0,47252,605
-Massachusetts,Franklin County,2006,72183,0.0,51871,590
-Massachusetts,Franklin County,2007,71602,0.0,52270,673
-Massachusetts,Franklin County,2008,71735,0.0,52667,678
-Massachusetts,Franklin County,2009,71778,0.0,49050,697
-Massachusetts,Franklin County,2010,71369,0.0,50001,731
-Massachusetts,Franklin County,2011,71599,0.0,50361,710
-Massachusetts,Franklin County,2012,71540,0.0,55416,685
-Massachusetts,Franklin County,2013,71221,0.0,52339,750
-Massachusetts,Franklin County,2014,70862,0.0,55572,680
-Massachusetts,Franklin County,2015,70601,0.0,58613,857
-Massachusetts,Franklin County,2016,70382,0.0,57106,765
-Massachusetts,Franklin County,2017,70702,0.0,58824,808
-Massachusetts,Franklin County,2018,70963,0.0,59248,754
-Massachusetts,Franklin County,2019,70180,0.0,60018,847
-Massachusetts,Franklin County,2021,71015,0.0,69771,903
-Massachusetts,Franklin County,2022,70894,0.0,70306,848
-Massachusetts,Hampden County,2005,447309,0.0,41789,536
+Massachusetts,Franklin County,2005,70928,,47252,605
+Massachusetts,Franklin County,2006,72183,,51871,590
+Massachusetts,Franklin County,2007,71602,,52270,673
+Massachusetts,Franklin County,2008,71735,,52667,678
+Massachusetts,Franklin County,2009,71778,,49050,697
+Massachusetts,Franklin County,2010,71369,,50001,731
+Massachusetts,Franklin County,2011,71599,,50361,710
+Massachusetts,Franklin County,2012,71540,,55416,685
+Massachusetts,Franklin County,2013,71221,,52339,750
+Massachusetts,Franklin County,2014,70862,,55572,680
+Massachusetts,Franklin County,2015,70601,,58613,857
+Massachusetts,Franklin County,2016,70382,,57106,765
+Massachusetts,Franklin County,2017,70702,,58824,808
+Massachusetts,Franklin County,2018,70963,,59248,754
+Massachusetts,Franklin County,2019,70180,,60018,847
+Massachusetts,Franklin County,2021,71015,,69771,903
+Massachusetts,Franklin County,2022,70894,,70306,848
+Massachusetts,Hampden County,2005,447309,,41789,536
 Massachusetts,Hampden County,2006,460520,4809.0,44765,572
 Massachusetts,Hampden County,2007,457908,5576.0,45834,608
 Massachusetts,Hampden County,2008,460840,5115.0,48583,619
@@ -5210,8 +5210,8 @@ Massachusetts,Hampden County,2018,470406,8008.0,52372,763
 Massachusetts,Hampden County,2019,466372,9599.0,60161,811
 Massachusetts,Hampden County,2021,462718,26139.0,61747,856
 Massachusetts,Hampden County,2022,461041,20308.0,63866,856
-Massachusetts,Hampshire County,2005,135676,0.0,48401,704
-Massachusetts,Hampshire County,2006,153471,0.0,52349,688
+Massachusetts,Hampshire County,2005,135676,,48401,704
+Massachusetts,Hampshire County,2006,153471,,52349,688
 Massachusetts,Hampshire County,2007,153147,3889.0,55623,679
 Massachusetts,Hampshire County,2008,154983,6418.0,63732,753
 Massachusetts,Hampshire County,2009,156044,4218.0,56661,728
@@ -5219,14 +5219,14 @@ Massachusetts,Hampshire County,2010,158094,7947.0,58449,763
 Massachusetts,Hampshire County,2011,157822,8404.0,54179,787
 Massachusetts,Hampshire County,2012,159795,5956.0,59065,760
 Massachusetts,Hampshire County,2013,159596,5646.0,65190,875
-Massachusetts,Hampshire County,2014,160939,0.0,56079,842
+Massachusetts,Hampshire County,2014,160939,,56079,842
 Massachusetts,Hampshire County,2015,161292,5520.0,60583,907
-Massachusetts,Hampshire County,2016,161816,0.0,64354,903
+Massachusetts,Hampshire County,2016,161816,,64354,903
 Massachusetts,Hampshire County,2017,161834,6912.0,67989,983
 Massachusetts,Hampshire County,2018,161355,6767.0,76966,956
 Massachusetts,Hampshire County,2019,160830,4643.0,74778,974
-Massachusetts,Hampshire County,2021,161572,0.0,77495,1155
-Massachusetts,Hampshire County,2022,162588,0.0,82078,1175
+Massachusetts,Hampshire County,2021,161572,,77495,1155
+Massachusetts,Hampshire County,2022,162588,,82078,1175
 Massachusetts,Middlesex County,2005,1405511,25974.0,69045,983
 Massachusetts,Middlesex County,2006,1467016,28509.0,70954,1027
 Massachusetts,Middlesex County,2007,1473416,37330.0,74700,1026
@@ -5312,109 +5312,109 @@ Massachusetts,Worcester County,2018,830839,23042.0,71853,922
 Massachusetts,Worcester County,2019,830622,28780.0,78345,943
 Massachusetts,Worcester County,2021,862029,79026.0,84952,1053
 Massachusetts,Worcester County,2022,862927,69994.0,86258,1118
-Michigan,Allegan County,2005,111257,0.0,46672,507
-Michigan,Allegan County,2006,113501,0.0,50558,481
+Michigan,Allegan County,2005,111257,,46672,507
+Michigan,Allegan County,2006,113501,,50558,481
 Michigan,Allegan County,2007,112761,2103.0,50730,531
-Michigan,Allegan County,2008,112975,0.0,49201,541
-Michigan,Allegan County,2009,113449,0.0,50316,547
-Michigan,Allegan County,2010,111503,0.0,44847,578
-Michigan,Allegan County,2011,111234,0.0,50508,596
-Michigan,Allegan County,2012,112039,0.0,50078,620
+Michigan,Allegan County,2008,112975,,49201,541
+Michigan,Allegan County,2009,113449,,50316,547
+Michigan,Allegan County,2010,111503,,44847,578
+Michigan,Allegan County,2011,111234,,50508,596
+Michigan,Allegan County,2012,112039,,50078,620
 Michigan,Allegan County,2013,112531,2163.0,56077,606
-Michigan,Allegan County,2014,113847,0.0,53796,621
-Michigan,Allegan County,2015,114625,0.0,55250,669
-Michigan,Allegan County,2016,115548,0.0,57846,640
-Michigan,Allegan County,2017,116447,0.0,62853,670
-Michigan,Allegan County,2018,117327,0.0,61353,719
-Michigan,Allegan County,2019,118081,0.0,66278,703
-Michigan,Allegan County,2021,120950,0.0,74371,851
+Michigan,Allegan County,2014,113847,,53796,621
+Michigan,Allegan County,2015,114625,,55250,669
+Michigan,Allegan County,2016,115548,,57846,640
+Michigan,Allegan County,2017,116447,,62853,670
+Michigan,Allegan County,2018,117327,,61353,719
+Michigan,Allegan County,2019,118081,,66278,703
+Michigan,Allegan County,2021,120950,,74371,851
 Michigan,Allegan County,2022,121210,4878.0,75901,802
-Michigan,Bay County,2005,107256,0.0,41384,442
-Michigan,Bay County,2006,108390,0.0,41774,456
-Michigan,Bay County,2007,107517,0.0,42375,472
+Michigan,Bay County,2005,107256,,41384,442
+Michigan,Bay County,2006,108390,,41774,456
+Michigan,Bay County,2007,107517,,42375,472
 Michigan,Bay County,2008,107495,1261.0,45913,468
-Michigan,Bay County,2009,107434,0.0,44029,494
-Michigan,Bay County,2010,107703,0.0,45451,454
-Michigan,Bay County,2011,107110,0.0,43361,494
+Michigan,Bay County,2009,107434,,44029,494
+Michigan,Bay County,2010,107703,,45451,454
+Michigan,Bay County,2011,107110,,43361,494
 Michigan,Bay County,2012,106935,848.0,44548,532
 Michigan,Bay County,2013,106832,1296.0,41281,520
-Michigan,Bay County,2014,106179,0.0,46844,519
-Michigan,Bay County,2015,105659,0.0,46560,515
-Michigan,Bay County,2016,104747,0.0,44756,512
-Michigan,Bay County,2017,104239,0.0,44770,533
-Michigan,Bay County,2018,103923,0.0,50606,575
-Michigan,Bay County,2019,103126,0.0,49610,583
-Michigan,Bay County,2021,102985,0.0,56911,573
-Michigan,Bay County,2022,102821,0.0,55134,638
-Michigan,Berrien County,2005,158224,0.0,39419,439
+Michigan,Bay County,2014,106179,,46844,519
+Michigan,Bay County,2015,105659,,46560,515
+Michigan,Bay County,2016,104747,,44756,512
+Michigan,Bay County,2017,104239,,44770,533
+Michigan,Bay County,2018,103923,,50606,575
+Michigan,Bay County,2019,103126,,49610,583
+Michigan,Bay County,2021,102985,,56911,573
+Michigan,Bay County,2022,102821,,55134,638
+Michigan,Berrien County,2005,158224,,39419,439
 Michigan,Berrien County,2006,161705,2485.0,41875,467
-Michigan,Berrien County,2007,159589,0.0,42079,464
+Michigan,Berrien County,2007,159589,,42079,464
 Michigan,Berrien County,2008,159481,3007.0,42512,504
-Michigan,Berrien County,2009,160472,0.0,39508,469
-Michigan,Berrien County,2010,156805,0.0,40329,495
-Michigan,Berrien County,2011,156941,0.0,40831,516
+Michigan,Berrien County,2009,160472,,39508,469
+Michigan,Berrien County,2010,156805,,40329,495
+Michigan,Berrien County,2011,156941,,40831,516
 Michigan,Berrien County,2012,156067,2806.0,43526,535
 Michigan,Berrien County,2013,155252,2876.0,44747,529
 Michigan,Berrien County,2014,155233,4711.0,44031,538
 Michigan,Berrien County,2015,154636,2895.0,46649,586
 Michigan,Berrien County,2016,154010,2442.0,47083,575
-Michigan,Berrien County,2017,154259,0.0,48629,601
+Michigan,Berrien County,2017,154259,,48629,601
 Michigan,Berrien County,2018,154141,2242.0,51262,580
 Michigan,Berrien County,2019,153401,2869.0,50153,626
-Michigan,Berrien County,2021,153101,0.0,57535,665
+Michigan,Berrien County,2021,153101,,57535,665
 Michigan,Berrien County,2022,152900,7547.0,61333,707
-Michigan,Calhoun County,2005,134628,0.0,40223,464
+Michigan,Calhoun County,2005,134628,,40223,464
 Michigan,Calhoun County,2006,137991,1889.0,43421,498
 Michigan,Calhoun County,2007,136615,1412.0,41150,500
-Michigan,Calhoun County,2008,135861,0.0,41181,501
-Michigan,Calhoun County,2009,135616,0.0,38507,523
-Michigan,Calhoun County,2010,136072,0.0,42921,516
-Michigan,Calhoun County,2011,135490,0.0,38666,527
+Michigan,Calhoun County,2008,135861,,41181,501
+Michigan,Calhoun County,2009,135616,,38507,523
+Michigan,Calhoun County,2010,136072,,42921,516
+Michigan,Calhoun County,2011,135490,,38666,527
 Michigan,Calhoun County,2012,135099,1350.0,39190,538
 Michigan,Calhoun County,2013,135012,2111.0,44520,546
-Michigan,Calhoun County,2014,134878,0.0,46088,565
+Michigan,Calhoun County,2014,134878,,46088,565
 Michigan,Calhoun County,2015,134314,3228.0,43084,568
 Michigan,Calhoun County,2016,134386,1389.0,45902,588
 Michigan,Calhoun County,2017,134128,1862.0,45386,567
-Michigan,Calhoun County,2018,134487,0.0,47204,593
+Michigan,Calhoun County,2018,134487,,47204,593
 Michigan,Calhoun County,2019,134159,2010.0,49055,631
-Michigan,Calhoun County,2021,133819,0.0,55192,645
-Michigan,Calhoun County,2022,133289,0.0,59522,703
-Michigan,Clinton County,2005,68524,0.0,59495,504
-Michigan,Clinton County,2006,69909,0.0,56637,603
-Michigan,Clinton County,2007,69755,0.0,55353,579
-Michigan,Clinton County,2008,69726,0.0,50808,530
-Michigan,Clinton County,2009,69893,0.0,58041,581
-Michigan,Clinton County,2010,75426,0.0,58288,682
-Michigan,Clinton County,2011,75469,0.0,57289,607
-Michigan,Clinton County,2012,76001,0.0,57330,575
+Michigan,Calhoun County,2021,133819,,55192,645
+Michigan,Calhoun County,2022,133289,,59522,703
+Michigan,Clinton County,2005,68524,,59495,504
+Michigan,Clinton County,2006,69909,,56637,603
+Michigan,Clinton County,2007,69755,,55353,579
+Michigan,Clinton County,2008,69726,,50808,530
+Michigan,Clinton County,2009,69893,,58041,581
+Michigan,Clinton County,2010,75426,,58288,682
+Michigan,Clinton County,2011,75469,,57289,607
+Michigan,Clinton County,2012,76001,,57330,575
 Michigan,Clinton County,2013,76739,1630.0,59569,674
-Michigan,Clinton County,2014,77297,0.0,58453,625
+Michigan,Clinton County,2014,77297,,58453,625
 Michigan,Clinton County,2015,77390,1379.0,63764,630
-Michigan,Clinton County,2016,77888,0.0,65730,628
-Michigan,Clinton County,2017,78443,0.0,62175,663
+Michigan,Clinton County,2016,77888,,65730,628
+Michigan,Clinton County,2017,78443,,62175,663
 Michigan,Clinton County,2018,79332,2015.0,69522,699
-Michigan,Clinton County,2019,79595,0.0,69651,717
-Michigan,Clinton County,2021,79426,0.0,76534,799
-Michigan,Clinton County,2022,79748,0.0,78702,803
-Michigan,Eaton County,2005,105632,0.0,47335,569
-Michigan,Eaton County,2006,107237,0.0,54153,578
-Michigan,Eaton County,2007,107390,0.0,50384,577
-Michigan,Eaton County,2008,106781,0.0,57335,590
-Michigan,Eaton County,2009,106077,0.0,51167,629
-Michigan,Eaton County,2010,107838,0.0,52042,628
-Michigan,Eaton County,2011,108056,0.0,50822,613
+Michigan,Clinton County,2019,79595,,69651,717
+Michigan,Clinton County,2021,79426,,76534,799
+Michigan,Clinton County,2022,79748,,78702,803
+Michigan,Eaton County,2005,105632,,47335,569
+Michigan,Eaton County,2006,107237,,54153,578
+Michigan,Eaton County,2007,107390,,50384,577
+Michigan,Eaton County,2008,106781,,57335,590
+Michigan,Eaton County,2009,106077,,51167,629
+Michigan,Eaton County,2010,107838,,52042,628
+Michigan,Eaton County,2011,108056,,50822,613
 Michigan,Eaton County,2012,108008,1482.0,55199,645
-Michigan,Eaton County,2013,108348,0.0,53328,674
+Michigan,Eaton County,2013,108348,,53328,674
 Michigan,Eaton County,2014,108579,1999.0,57087,652
 Michigan,Eaton County,2015,108801,1291.0,56005,653
-Michigan,Eaton County,2016,109160,0.0,56211,712
+Michigan,Eaton County,2016,109160,,56211,712
 Michigan,Eaton County,2017,109027,1576.0,64522,719
-Michigan,Eaton County,2018,109826,0.0,67195,757
-Michigan,Eaton County,2019,110268,0.0,65409,727
-Michigan,Eaton County,2021,108944,0.0,70133,832
-Michigan,Eaton County,2022,108992,0.0,71013,860
-Michigan,Genesee County,2005,438589,0.0,42473,458
+Michigan,Eaton County,2018,109826,,67195,757
+Michigan,Eaton County,2019,110268,,65409,727
+Michigan,Eaton County,2021,108944,,70133,832
+Michigan,Eaton County,2022,108992,,71013,860
+Michigan,Genesee County,2005,438589,,42473,458
 Michigan,Genesee County,2006,441966,5961.0,41778,476
 Michigan,Genesee County,2007,434715,4667.0,43112,496
 Michigan,Genesee County,2008,428790,5060.0,44611,497
@@ -5431,24 +5431,24 @@ Michigan,Genesee County,2018,406892,5726.0,48127,593
 Michigan,Genesee County,2019,405813,8853.0,50389,613
 Michigan,Genesee County,2021,404208,18627.0,52025,641
 Michigan,Genesee County,2022,401983,20430.0,57003,677
-Michigan,Grand Traverse County,2005,81174,0.0,47572,703
-Michigan,Grand Traverse County,2006,84952,0.0,49305,608
-Michigan,Grand Traverse County,2007,85479,0.0,45258,686
-Michigan,Grand Traverse County,2008,86071,0.0,48509,705
-Michigan,Grand Traverse County,2009,86333,0.0,49573,674
+Michigan,Grand Traverse County,2005,81174,,47572,703
+Michigan,Grand Traverse County,2006,84952,,49305,608
+Michigan,Grand Traverse County,2007,85479,,45258,686
+Michigan,Grand Traverse County,2008,86071,,48509,705
+Michigan,Grand Traverse County,2009,86333,,49573,674
 Michigan,Grand Traverse County,2010,87043,1422.0,47389,695
-Michigan,Grand Traverse County,2011,88349,0.0,46330,704
-Michigan,Grand Traverse County,2012,89112,0.0,51635,668
-Michigan,Grand Traverse County,2013,89987,0.0,50830,724
-Michigan,Grand Traverse County,2014,90782,0.0,57312,769
-Michigan,Grand Traverse County,2015,91636,0.0,55013,788
-Michigan,Grand Traverse County,2016,92084,0.0,58532,767
-Michigan,Grand Traverse County,2017,91807,0.0,60601,836
-Michigan,Grand Traverse County,2018,92573,0.0,66163,851
+Michigan,Grand Traverse County,2011,88349,,46330,704
+Michigan,Grand Traverse County,2012,89112,,51635,668
+Michigan,Grand Traverse County,2013,89987,,50830,724
+Michigan,Grand Traverse County,2014,90782,,57312,769
+Michigan,Grand Traverse County,2015,91636,,55013,788
+Michigan,Grand Traverse County,2016,92084,,58532,767
+Michigan,Grand Traverse County,2017,91807,,60601,836
+Michigan,Grand Traverse County,2018,92573,,66163,851
 Michigan,Grand Traverse County,2019,93088,3708.0,65266,894
-Michigan,Grand Traverse County,2021,95860,0.0,65651,1020
+Michigan,Grand Traverse County,2021,95860,,65651,1020
 Michigan,Grand Traverse County,2022,96464,7380.0,74344,1122
-Michigan,Ingham County,2005,261476,0.0,42502,598
+Michigan,Ingham County,2005,261476,,42502,598
 Michigan,Ingham County,2006,276898,4012.0,43135,594
 Michigan,Ingham County,2007,279295,4845.0,45204,613
 Michigan,Ingham County,2008,277528,3621.0,45287,610
@@ -5465,26 +5465,26 @@ Michigan,Ingham County,2018,292735,4242.0,52691,739
 Michigan,Ingham County,2019,292406,6050.0,54395,749
 Michigan,Ingham County,2021,284034,31222.0,57226,787
 Michigan,Ingham County,2022,284108,22864.0,59823,812
-Michigan,Ionia County,2021,67197,0.0,65729,657
-Michigan,Ionia County,2022,66809,0.0,75865,738
-Michigan,Jackson County,2005,152954,0.0,47053,546
-Michigan,Jackson County,2006,163851,0.0,42912,572
+Michigan,Ionia County,2021,67197,,65729,657
+Michigan,Ionia County,2022,66809,,75865,738
+Michigan,Jackson County,2005,152954,,47053,546
+Michigan,Jackson County,2006,163851,,42912,572
 Michigan,Jackson County,2007,163006,2252.0,43328,552
 Michigan,Jackson County,2008,160180,2069.0,46896,535
-Michigan,Jackson County,2009,159828,0.0,46650,554
-Michigan,Jackson County,2010,160201,0.0,42862,542
+Michigan,Jackson County,2009,159828,,46650,554
+Michigan,Jackson County,2010,160201,,42862,542
 Michigan,Jackson County,2011,159748,1407.0,41686,619
 Michigan,Jackson County,2012,160309,1977.0,42653,581
 Michigan,Jackson County,2013,160369,2543.0,43668,570
-Michigan,Jackson County,2014,159741,0.0,45371,584
-Michigan,Jackson County,2015,159494,0.0,50783,594
+Michigan,Jackson County,2014,159741,,45371,584
+Michigan,Jackson County,2015,159494,,50783,594
 Michigan,Jackson County,2016,158460,2080.0,50009,601
-Michigan,Jackson County,2017,158640,0.0,50258,621
-Michigan,Jackson County,2018,158823,0.0,51031,634
-Michigan,Jackson County,2019,158510,0.0,55124,641
-Michigan,Jackson County,2021,160050,0.0,58254,690
-Michigan,Jackson County,2022,160066,0.0,59059,748
-Michigan,Kalamazoo County,2005,230457,0.0,44166,571
+Michigan,Jackson County,2017,158640,,50258,621
+Michigan,Jackson County,2018,158823,,51031,634
+Michigan,Jackson County,2019,158510,,55124,641
+Michigan,Jackson County,2021,160050,,58254,690
+Michigan,Jackson County,2022,160066,,59059,748
+Michigan,Kalamazoo County,2005,230457,,44166,571
 Michigan,Kalamazoo County,2006,240720,3879.0,44237,551
 Michigan,Kalamazoo County,2007,245333,2990.0,43861,572
 Michigan,Kalamazoo County,2008,245912,3876.0,46432,587
@@ -5518,56 +5518,56 @@ Michigan,Kent County,2018,653786,13648.0,61537,781
 Michigan,Kent County,2019,656955,16861.0,66532,847
 Michigan,Kent County,2021,658046,54412.0,72021,922
 Michigan,Kent County,2022,659083,49138.0,77028,1071
-Michigan,Lapeer County,2005,91256,0.0,50703,564
-Michigan,Lapeer County,2006,93761,0.0,55287,599
-Michigan,Lapeer County,2007,92012,0.0,57617,547
-Michigan,Lapeer County,2008,90875,0.0,52470,529
-Michigan,Lapeer County,2009,89974,0.0,50607,604
-Michigan,Lapeer County,2010,88210,0.0,49190,652
-Michigan,Lapeer County,2011,88082,0.0,49178,628
-Michigan,Lapeer County,2012,88173,0.0,51428,584
-Michigan,Lapeer County,2013,88389,0.0,52960,610
-Michigan,Lapeer County,2014,88153,0.0,50860,628
-Michigan,Lapeer County,2015,88373,0.0,57762,595
-Michigan,Lapeer County,2016,88340,0.0,54309,639
-Michigan,Lapeer County,2017,88174,0.0,55866,546
-Michigan,Lapeer County,2018,88028,0.0,65561,627
-Michigan,Lapeer County,2019,87607,0.0,66263,662
-Michigan,Lapeer County,2021,88513,0.0,71479,697
-Michigan,Lapeer County,2022,88780,0.0,71551,808
-Michigan,Lenawee County,2005,97102,0.0,48274,474
-Michigan,Lenawee County,2006,102191,0.0,46901,507
-Michigan,Lenawee County,2007,101243,0.0,50240,517
-Michigan,Lenawee County,2008,100801,0.0,50369,539
-Michigan,Lenawee County,2009,99837,0.0,45640,520
-Michigan,Lenawee County,2010,99763,0.0,45563,537
-Michigan,Lenawee County,2011,99440,0.0,44509,547
-Michigan,Lenawee County,2012,98987,0.0,48224,609
-Michigan,Lenawee County,2013,99188,0.0,45938,586
-Michigan,Lenawee County,2014,99047,0.0,46739,556
-Michigan,Lenawee County,2015,98573,0.0,48279,605
+Michigan,Lapeer County,2005,91256,,50703,564
+Michigan,Lapeer County,2006,93761,,55287,599
+Michigan,Lapeer County,2007,92012,,57617,547
+Michigan,Lapeer County,2008,90875,,52470,529
+Michigan,Lapeer County,2009,89974,,50607,604
+Michigan,Lapeer County,2010,88210,,49190,652
+Michigan,Lapeer County,2011,88082,,49178,628
+Michigan,Lapeer County,2012,88173,,51428,584
+Michigan,Lapeer County,2013,88389,,52960,610
+Michigan,Lapeer County,2014,88153,,50860,628
+Michigan,Lapeer County,2015,88373,,57762,595
+Michigan,Lapeer County,2016,88340,,54309,639
+Michigan,Lapeer County,2017,88174,,55866,546
+Michigan,Lapeer County,2018,88028,,65561,627
+Michigan,Lapeer County,2019,87607,,66263,662
+Michigan,Lapeer County,2021,88513,,71479,697
+Michigan,Lapeer County,2022,88780,,71551,808
+Michigan,Lenawee County,2005,97102,,48274,474
+Michigan,Lenawee County,2006,102191,,46901,507
+Michigan,Lenawee County,2007,101243,,50240,517
+Michigan,Lenawee County,2008,100801,,50369,539
+Michigan,Lenawee County,2009,99837,,45640,520
+Michigan,Lenawee County,2010,99763,,45563,537
+Michigan,Lenawee County,2011,99440,,44509,547
+Michigan,Lenawee County,2012,98987,,48224,609
+Michigan,Lenawee County,2013,99188,,45938,586
+Michigan,Lenawee County,2014,99047,,46739,556
+Michigan,Lenawee County,2015,98573,,48279,605
 Michigan,Lenawee County,2016,98504,1152.0,51918,605
-Michigan,Lenawee County,2017,98623,0.0,56515,610
-Michigan,Lenawee County,2018,98266,0.0,55378,673
-Michigan,Lenawee County,2019,98451,0.0,53865,628
-Michigan,Lenawee County,2021,98956,0.0,61257,736
-Michigan,Lenawee County,2022,98567,0.0,67267,695
-Michigan,Livingston County,2005,179897,0.0,71546,660
+Michigan,Lenawee County,2017,98623,,56515,610
+Michigan,Lenawee County,2018,98266,,55378,673
+Michigan,Lenawee County,2019,98451,,53865,628
+Michigan,Lenawee County,2021,98956,,61257,736
+Michigan,Lenawee County,2022,98567,,67267,695
+Michigan,Livingston County,2005,179897,,71546,660
 Michigan,Livingston County,2006,184511,2756.0,70629,692
 Michigan,Livingston County,2007,183194,2854.0,70735,734
-Michigan,Livingston County,2008,182575,0.0,71486,711
-Michigan,Livingston County,2009,183118,0.0,67296,760
+Michigan,Livingston County,2008,182575,,71486,711
+Michigan,Livingston County,2009,183118,,67296,760
 Michigan,Livingston County,2010,180972,3984.0,65197,693
 Michigan,Livingston County,2011,181722,4525.0,67441,778
 Michigan,Livingston County,2012,182838,4650.0,75719,751
 Michigan,Livingston County,2013,184443,4304.0,70707,724
 Michigan,Livingston County,2014,185596,2845.0,73819,772
-Michigan,Livingston County,2015,187316,0.0,76455,812
+Michigan,Livingston County,2015,187316,,76455,812
 Michigan,Livingston County,2016,188624,3930.0,78038,815
 Michigan,Livingston County,2017,189651,4925.0,80733,896
 Michigan,Livingston County,2018,191224,5025.0,82884,928
-Michigan,Livingston County,2019,191995,0.0,86512,877
-Michigan,Livingston County,2021,195014,0.0,91344,1085
+Michigan,Livingston County,2019,191995,,86512,877
+Michigan,Livingston County,2021,195014,,91344,1085
 Michigan,Livingston County,2022,196161,16475.0,100139,1057
 Michigan,Macomb County,2005,820599,8775.0,53321,603
 Michigan,Macomb County,2006,832861,9282.0,53477,619
@@ -5586,74 +5586,74 @@ Michigan,Macomb County,2018,874759,13550.0,62107,792
 Michigan,Macomb County,2019,873972,12515.0,64947,846
 Michigan,Macomb County,2021,876792,61926.0,67527,889
 Michigan,Macomb County,2022,874195,61935.0,73830,941
-Michigan,Marquette County,2007,65216,0.0,47303,415
-Michigan,Marquette County,2008,65492,0.0,43098,451
-Michigan,Marquette County,2009,65703,0.0,41275,471
-Michigan,Marquette County,2010,67131,0.0,44684,509
-Michigan,Marquette County,2011,67694,0.0,41130,501
+Michigan,Marquette County,2007,65216,,47303,415
+Michigan,Marquette County,2008,65492,,43098,451
+Michigan,Marquette County,2009,65703,,41275,471
+Michigan,Marquette County,2010,67131,,44684,509
+Michigan,Marquette County,2011,67694,,41130,501
 Michigan,Marquette County,2012,67906,880.0,45149,482
 Michigan,Marquette County,2013,67700,504.0,45011,487
-Michigan,Marquette County,2014,67676,0.0,44267,493
-Michigan,Marquette County,2015,67215,0.0,48259,586
-Michigan,Marquette County,2016,66435,0.0,51275,632
-Michigan,Marquette County,2017,66502,0.0,49008,571
-Michigan,Marquette County,2018,66516,0.0,54779,640
-Michigan,Marquette County,2019,66699,0.0,55148,691
-Michigan,Marquette County,2021,66103,0.0,55301,770
-Michigan,Marquette County,2022,66661,0.0,61474,753
-Michigan,Midland County,2005,82695,0.0,45912,483
-Michigan,Midland County,2006,83792,0.0,48360,494
-Michigan,Midland County,2007,82818,0.0,49453,488
-Michigan,Midland County,2008,82605,0.0,49239,557
-Michigan,Midland County,2009,82548,0.0,50053,516
-Michigan,Midland County,2010,83592,0.0,48706,593
-Michigan,Midland County,2011,84063,0.0,52591,556
-Michigan,Midland County,2012,83822,0.0,52356,620
-Michigan,Midland County,2013,83919,0.0,49913,561
-Michigan,Midland County,2014,83427,0.0,49194,598
-Michigan,Midland County,2015,83632,0.0,59292,633
-Michigan,Midland County,2016,83462,0.0,57269,655
-Michigan,Midland County,2017,83411,0.0,61624,654
-Michigan,Midland County,2018,83209,0.0,56091,589
-Michigan,Midland County,2019,83156,0.0,69872,672
-Michigan,Midland County,2021,83457,0.0,67707,741
-Michigan,Midland County,2022,83674,0.0,78487,845
-Michigan,Monroe County,2005,152392,0.0,55663,532
-Michigan,Monroe County,2006,155035,0.0,54444,547
-Michigan,Monroe County,2007,153608,0.0,53750,571
+Michigan,Marquette County,2014,67676,,44267,493
+Michigan,Marquette County,2015,67215,,48259,586
+Michigan,Marquette County,2016,66435,,51275,632
+Michigan,Marquette County,2017,66502,,49008,571
+Michigan,Marquette County,2018,66516,,54779,640
+Michigan,Marquette County,2019,66699,,55148,691
+Michigan,Marquette County,2021,66103,,55301,770
+Michigan,Marquette County,2022,66661,,61474,753
+Michigan,Midland County,2005,82695,,45912,483
+Michigan,Midland County,2006,83792,,48360,494
+Michigan,Midland County,2007,82818,,49453,488
+Michigan,Midland County,2008,82605,,49239,557
+Michigan,Midland County,2009,82548,,50053,516
+Michigan,Midland County,2010,83592,,48706,593
+Michigan,Midland County,2011,84063,,52591,556
+Michigan,Midland County,2012,83822,,52356,620
+Michigan,Midland County,2013,83919,,49913,561
+Michigan,Midland County,2014,83427,,49194,598
+Michigan,Midland County,2015,83632,,59292,633
+Michigan,Midland County,2016,83462,,57269,655
+Michigan,Midland County,2017,83411,,61624,654
+Michigan,Midland County,2018,83209,,56091,589
+Michigan,Midland County,2019,83156,,69872,672
+Michigan,Midland County,2021,83457,,67707,741
+Michigan,Midland County,2022,83674,,78487,845
+Michigan,Monroe County,2005,152392,,55663,532
+Michigan,Monroe County,2006,155035,,54444,547
+Michigan,Monroe County,2007,153608,,53750,571
 Michigan,Monroe County,2008,152949,1069.0,57157,576
-Michigan,Monroe County,2009,152721,0.0,52824,580
+Michigan,Monroe County,2009,152721,,52824,580
 Michigan,Monroe County,2010,151932,1923.0,50034,605
 Michigan,Monroe County,2011,151560,1866.0,53744,621
-Michigan,Monroe County,2012,151048,0.0,50675,633
+Michigan,Monroe County,2012,151048,,50675,633
 Michigan,Monroe County,2013,150376,1443.0,53561,609
-Michigan,Monroe County,2014,149824,0.0,57275,632
+Michigan,Monroe County,2014,149824,,57275,632
 Michigan,Monroe County,2015,149568,2659.0,54396,612
 Michigan,Monroe County,2016,149208,2596.0,60799,703
-Michigan,Monroe County,2017,149649,0.0,59290,669
-Michigan,Monroe County,2018,150439,0.0,61916,707
-Michigan,Monroe County,2019,150500,0.0,62839,686
-Michigan,Monroe County,2021,155274,0.0,65512,769
-Michigan,Monroe County,2022,155609,0.0,69563,872
-Michigan,Montcalm County,2021,67220,0.0,55832,547
-Michigan,Montcalm County,2022,67433,0.0,61967,599
-Michigan,Muskegon County,2005,169500,0.0,41911,430
-Michigan,Muskegon County,2006,175231,0.0,40883,466
+Michigan,Monroe County,2017,149649,,59290,669
+Michigan,Monroe County,2018,150439,,61916,707
+Michigan,Monroe County,2019,150500,,62839,686
+Michigan,Monroe County,2021,155274,,65512,769
+Michigan,Monroe County,2022,155609,,69563,872
+Michigan,Montcalm County,2021,67220,,55832,547
+Michigan,Montcalm County,2022,67433,,61967,599
+Michigan,Muskegon County,2005,169500,,41911,430
+Michigan,Muskegon County,2006,175231,,40883,466
 Michigan,Muskegon County,2007,174386,2357.0,39099,485
 Michigan,Muskegon County,2008,174344,3074.0,40827,514
-Michigan,Muskegon County,2009,173951,0.0,38274,510
-Michigan,Muskegon County,2010,172068,0.0,38621,507
+Michigan,Muskegon County,2009,173951,,38274,510
+Michigan,Muskegon County,2010,172068,,38621,507
 Michigan,Muskegon County,2011,171302,2408.0,37626,500
 Michigan,Muskegon County,2012,170182,2050.0,40535,522
 Michigan,Muskegon County,2013,171008,1711.0,41630,524
 Michigan,Muskegon County,2014,172344,2307.0,42600,537
 Michigan,Muskegon County,2015,172790,1836.0,47453,543
 Michigan,Muskegon County,2016,173408,2102.0,44264,570
-Michigan,Muskegon County,2017,173693,0.0,49229,592
-Michigan,Muskegon County,2018,173588,0.0,50080,607
+Michigan,Muskegon County,2017,173693,,49229,592
+Michigan,Muskegon County,2018,173588,,50080,607
 Michigan,Muskegon County,2019,173566,1655.0,50366,625
-Michigan,Muskegon County,2021,176511,0.0,55462,722
-Michigan,Muskegon County,2022,176565,0.0,58074,807
+Michigan,Muskegon County,2021,176511,,55462,722
+Michigan,Muskegon County,2022,176565,,58074,807
 Michigan,Oakland County,2005,1200531,20751.0,64022,721
 Michigan,Oakland County,2006,1214255,21146.0,66483,719
 Michigan,Oakland County,2007,1206089,18852.0,66483,726
@@ -5671,7 +5671,7 @@ Michigan,Oakland County,2018,1259201,34886.0,80193,903
 Michigan,Oakland County,2019,1257584,38076.0,81190,963
 Michigan,Oakland County,2021,1270017,170355.0,86523,1039
 Michigan,Oakland County,2022,1269431,141356.0,90594,1111
-Michigan,Ottawa County,2005,245075,0.0,56984,617
+Michigan,Ottawa County,2005,245075,,56984,617
 Michigan,Ottawa County,2006,257671,4010.0,56576,577
 Michigan,Ottawa County,2007,259206,4530.0,53881,599
 Michigan,Ottawa County,2008,260364,5311.0,55459,635
@@ -5688,32 +5688,32 @@ Michigan,Ottawa County,2018,290494,6574.0,69952,771
 Michigan,Ottawa County,2019,291830,6716.0,68817,847
 Michigan,Ottawa County,2021,299157,16093.0,79116,911
 Michigan,Ottawa County,2022,300873,14243.0,85652,1010
-Michigan,Saginaw County,2005,202037,0.0,39957,469
+Michigan,Saginaw County,2005,202037,,39957,469
 Michigan,Saginaw County,2006,206300,2451.0,38362,462
 Michigan,Saginaw County,2007,202268,2174.0,43051,480
 Michigan,Saginaw County,2008,200745,1822.0,41441,508
-Michigan,Saginaw County,2009,200050,0.0,39200,517
-Michigan,Saginaw County,2010,199911,0.0,41938,517
+Michigan,Saginaw County,2009,200050,,39200,517
+Michigan,Saginaw County,2010,199911,,41938,517
 Michigan,Saginaw County,2011,199088,2495.0,40434,530
 Michigan,Saginaw County,2012,198353,2305.0,40318,521
 Michigan,Saginaw County,2013,196542,2587.0,41548,537
 Michigan,Saginaw County,2014,195012,3286.0,44931,550
 Michigan,Saginaw County,2015,193307,2580.0,43383,551
-Michigan,Saginaw County,2016,192326,0.0,45849,552
+Michigan,Saginaw County,2016,192326,,45849,552
 Michigan,Saginaw County,2017,191934,3360.0,45331,573
 Michigan,Saginaw County,2018,190800,1833.0,48990,576
 Michigan,Saginaw County,2019,190539,3306.0,48303,569
-Michigan,Saginaw County,2021,189591,0.0,50606,617
-Michigan,Saginaw County,2022,188330,0.0,53646,662
-Michigan,St. Clair County,2005,169749,0.0,49708,540
-Michigan,St. Clair County,2006,171725,0.0,48354,494
+Michigan,Saginaw County,2021,189591,,50606,617
+Michigan,Saginaw County,2022,188330,,53646,662
+Michigan,St. Clair County,2005,169749,,49708,540
+Michigan,St. Clair County,2006,171725,,48354,494
 Michigan,St. Clair County,2007,170119,2162.0,45873,533
 Michigan,St. Clair County,2008,168894,1572.0,51573,553
-Michigan,St. Clair County,2009,167562,0.0,45377,571
+Michigan,St. Clair County,2009,167562,,45377,571
 Michigan,St. Clair County,2010,162789,1840.0,44369,540
 Michigan,St. Clair County,2011,161642,1527.0,45676,583
 Michigan,St. Clair County,2012,160644,2555.0,44518,536
-Michigan,St. Clair County,2013,160469,0.0,50285,549
+Michigan,St. Clair County,2013,160469,,50285,549
 Michigan,St. Clair County,2014,160078,1792.0,50319,623
 Michigan,St. Clair County,2015,159875,1715.0,51127,614
 Michigan,St. Clair County,2016,159587,1573.0,51864,642
@@ -5721,42 +5721,42 @@ Michigan,St. Clair County,2017,159350,1529.0,57362,613
 Michigan,St. Clair County,2018,159337,2319.0,56441,637
 Michigan,St. Clair County,2019,159128,3302.0,59837,674
 Michigan,St. Clair County,2021,160053,5808.0,60992,719
-Michigan,St. Clair County,2022,160151,0.0,63510,822
-Michigan,Shiawassee County,2005,72224,0.0,43011,467
-Michigan,Shiawassee County,2006,72912,0.0,41813,500
-Michigan,Shiawassee County,2007,71753,0.0,43127,496
-Michigan,Shiawassee County,2008,70880,0.0,45568,500
-Michigan,Shiawassee County,2009,70006,0.0,41083,525
-Michigan,Shiawassee County,2010,70606,0.0,46528,519
-Michigan,Shiawassee County,2011,69841,0.0,47775,531
-Michigan,Shiawassee County,2012,69232,0.0,41221,514
-Michigan,Shiawassee County,2013,68900,0.0,41892,521
-Michigan,Shiawassee County,2014,68933,0.0,48523,539
-Michigan,Shiawassee County,2015,68619,0.0,51839,572
-Michigan,Shiawassee County,2016,68554,0.0,53244,587
-Michigan,Shiawassee County,2017,68446,0.0,53361,558
-Michigan,Shiawassee County,2018,68192,0.0,54456,607
-Michigan,Shiawassee County,2019,68122,0.0,55249,591
-Michigan,Shiawassee County,2021,67877,0.0,51959,568
-Michigan,Shiawassee County,2022,68022,0.0,61564,642
-Michigan,Van Buren County,2005,76896,0.0,39783,418
-Michigan,Van Buren County,2006,79018,0.0,42360,429
-Michigan,Van Buren County,2007,77931,0.0,44812,438
-Michigan,Van Buren County,2008,77801,0.0,42430,449
-Michigan,Van Buren County,2009,78227,0.0,40025,468
-Michigan,Van Buren County,2010,76186,0.0,44242,466
-Michigan,Van Buren County,2011,76131,0.0,41379,515
-Michigan,Van Buren County,2012,75454,0.0,44456,519
-Michigan,Van Buren County,2013,75455,0.0,45081,495
-Michigan,Van Buren County,2014,75199,0.0,47435,530
-Michigan,Van Buren County,2015,75077,0.0,48034,516
-Michigan,Van Buren County,2016,75223,0.0,47917,561
-Michigan,Van Buren County,2017,75353,0.0,52971,537
-Michigan,Van Buren County,2018,75448,0.0,59295,538
-Michigan,Van Buren County,2019,75677,0.0,60549,560
-Michigan,Van Buren County,2021,75658,0.0,59081,555
-Michigan,Van Buren County,2022,75692,0.0,60182,678
-Michigan,Washtenaw County,2005,319791,0.0,53495,735
+Michigan,St. Clair County,2022,160151,,63510,822
+Michigan,Shiawassee County,2005,72224,,43011,467
+Michigan,Shiawassee County,2006,72912,,41813,500
+Michigan,Shiawassee County,2007,71753,,43127,496
+Michigan,Shiawassee County,2008,70880,,45568,500
+Michigan,Shiawassee County,2009,70006,,41083,525
+Michigan,Shiawassee County,2010,70606,,46528,519
+Michigan,Shiawassee County,2011,69841,,47775,531
+Michigan,Shiawassee County,2012,69232,,41221,514
+Michigan,Shiawassee County,2013,68900,,41892,521
+Michigan,Shiawassee County,2014,68933,,48523,539
+Michigan,Shiawassee County,2015,68619,,51839,572
+Michigan,Shiawassee County,2016,68554,,53244,587
+Michigan,Shiawassee County,2017,68446,,53361,558
+Michigan,Shiawassee County,2018,68192,,54456,607
+Michigan,Shiawassee County,2019,68122,,55249,591
+Michigan,Shiawassee County,2021,67877,,51959,568
+Michigan,Shiawassee County,2022,68022,,61564,642
+Michigan,Van Buren County,2005,76896,,39783,418
+Michigan,Van Buren County,2006,79018,,42360,429
+Michigan,Van Buren County,2007,77931,,44812,438
+Michigan,Van Buren County,2008,77801,,42430,449
+Michigan,Van Buren County,2009,78227,,40025,468
+Michigan,Van Buren County,2010,76186,,44242,466
+Michigan,Van Buren County,2011,76131,,41379,515
+Michigan,Van Buren County,2012,75454,,44456,519
+Michigan,Van Buren County,2013,75455,,45081,495
+Michigan,Van Buren County,2014,75199,,47435,530
+Michigan,Van Buren County,2015,75077,,48034,516
+Michigan,Van Buren County,2016,75223,,47917,561
+Michigan,Van Buren County,2017,75353,,52971,537
+Michigan,Van Buren County,2018,75448,,59295,538
+Michigan,Van Buren County,2019,75677,,60549,560
+Michigan,Van Buren County,2021,75658,,59081,555
+Michigan,Van Buren County,2022,75692,,60182,678
+Michigan,Washtenaw County,2005,319791,,53495,735
 Michigan,Washtenaw County,2006,344047,8022.0,56817,745
 Michigan,Washtenaw County,2007,350003,7529.0,61049,739
 Michigan,Washtenaw County,2008,347376,9447.0,57848,762
@@ -5790,7 +5790,7 @@ Michigan,Wayne County,2018,1753893,28362.0,46390,689
 Michigan,Wayne County,2019,1749343,30027.0,50753,719
 Michigan,Wayne County,2021,1774816,130407.0,52605,779
 Michigan,Wayne County,2022,1757043,105376.0,55867,816
-Minnesota,Anoka County,2005,320803,0.0,61634,747
+Minnesota,Anoka County,2005,320803,,61634,747
 Minnesota,Anoka County,2006,327005,6259.0,66315,738
 Minnesota,Anoka County,2007,326252,5426.0,65555,758
 Minnesota,Anoka County,2008,327090,5050.0,70049,795
@@ -5808,36 +5808,36 @@ Minnesota,Anoka County,2019,356921,11992.0,83353,1027
 Minnesota,Anoka County,2021,367018,39271.0,88410,1141
 Minnesota,Anoka County,2022,368864,33262.0,92133,1268
 Minnesota,Blue Earth County,2012,65091,1705.0,49266,640
-Minnesota,Blue Earth County,2013,65528,0.0,51858,595
-Minnesota,Blue Earth County,2014,65385,0.0,48850,696
-Minnesota,Blue Earth County,2015,65787,0.0,48350,675
-Minnesota,Blue Earth County,2016,66441,0.0,53869,771
+Minnesota,Blue Earth County,2013,65528,,51858,595
+Minnesota,Blue Earth County,2014,65385,,48850,696
+Minnesota,Blue Earth County,2015,65787,,48350,675
+Minnesota,Blue Earth County,2016,66441,,53869,771
 Minnesota,Blue Earth County,2017,66973,1933.0,56716,766
 Minnesota,Blue Earth County,2018,67427,2217.0,58616,767
-Minnesota,Blue Earth County,2019,67653,0.0,61133,769
-Minnesota,Blue Earth County,2021,69280,0.0,69858,865
-Minnesota,Blue Earth County,2022,69631,0.0,68104,822
-Minnesota,Carver County,2005,83783,0.0,72998,726
-Minnesota,Carver County,2006,87545,0.0,75856,845
-Minnesota,Carver County,2007,88459,0.0,78975,759
-Minnesota,Carver County,2008,90043,0.0,82987,795
-Minnesota,Carver County,2009,92107,0.0,72683,820
-Minnesota,Carver County,2010,91361,0.0,80173,843
+Minnesota,Blue Earth County,2019,67653,,61133,769
+Minnesota,Blue Earth County,2021,69280,,69858,865
+Minnesota,Blue Earth County,2022,69631,,68104,822
+Minnesota,Carver County,2005,83783,,72998,726
+Minnesota,Carver County,2006,87545,,75856,845
+Minnesota,Carver County,2007,88459,,78975,759
+Minnesota,Carver County,2008,90043,,82987,795
+Minnesota,Carver County,2009,92107,,72683,820
+Minnesota,Carver County,2010,91361,,80173,843
 Minnesota,Carver County,2011,92638,3420.0,83348,785
-Minnesota,Carver County,2012,93707,0.0,83194,822
+Minnesota,Carver County,2012,93707,,83194,822
 Minnesota,Carver County,2013,95562,3034.0,82333,908
 Minnesota,Carver County,2014,97338,3908.0,83594,857
-Minnesota,Carver County,2015,98741,0.0,92653,918
-Minnesota,Carver County,2016,100262,0.0,92455,944
-Minnesota,Carver County,2017,102119,0.0,101271,1039
-Minnesota,Carver County,2018,103551,0.0,100324,1092
-Minnesota,Carver County,2019,105089,0.0,101434,1125
-Minnesota,Carver County,2021,108626,0.0,102694,1210
-Minnesota,Carver County,2022,110034,0.0,116158,1222
-Minnesota,Clay County,2021,65574,0.0,67539,752
-Minnesota,Clay County,2022,65929,0.0,81386,824
-Minnesota,Crow Wing County,2019,65055,0.0,60534,728
-Minnesota,Crow Wing County,2021,67270,0.0,63921,738
+Minnesota,Carver County,2015,98741,,92653,918
+Minnesota,Carver County,2016,100262,,92455,944
+Minnesota,Carver County,2017,102119,,101271,1039
+Minnesota,Carver County,2018,103551,,100324,1092
+Minnesota,Carver County,2019,105089,,101434,1125
+Minnesota,Carver County,2021,108626,,102694,1210
+Minnesota,Carver County,2022,110034,,116158,1222
+Minnesota,Clay County,2021,65574,,67539,752
+Minnesota,Clay County,2022,65929,,81386,824
+Minnesota,Crow Wing County,2019,65055,,60534,728
+Minnesota,Crow Wing County,2021,67270,,63921,738
 Minnesota,Crow Wing County,2022,67948,3747.0,66568,764
 Minnesota,Dakota County,2005,381267,7459.0,66467,773
 Minnesota,Dakota County,2006,388001,7650.0,70502,760
@@ -5873,7 +5873,7 @@ Minnesota,Hennepin County,2018,1259428,44864.0,76052,1046
 Minnesota,Hennepin County,2019,1265843,48136.0,82369,1096
 Minnesota,Hennepin County,2021,1267416,211322.0,84244,1224
 Minnesota,Hennepin County,2022,1260121,168828.0,89399,1255
-Minnesota,Olmsted County,2005,132116,0.0,57667,604
+Minnesota,Olmsted County,2005,132116,,57667,604
 Minnesota,Olmsted County,2006,137521,2105.0,61124,561
 Minnesota,Olmsted County,2007,139747,2494.0,60108,616
 Minnesota,Olmsted County,2008,141360,3964.0,67363,656
@@ -5907,16 +5907,16 @@ Minnesota,Ramsey County,2018,550210,16516.0,62919,895
 Minnesota,Ramsey County,2019,550321,14214.0,68871,971
 Minnesota,Ramsey County,2021,543257,68609.0,70518,1051
 Minnesota,Ramsey County,2022,536413,52229.0,75113,1158
-Minnesota,Rice County,2013,65049,0.0,58584,642
+Minnesota,Rice County,2013,65049,,58584,642
 Minnesota,Rice County,2014,65151,4114.0,60527,637
-Minnesota,Rice County,2015,65400,0.0,57323,645
-Minnesota,Rice County,2016,65622,0.0,69135,778
+Minnesota,Rice County,2015,65400,,57323,645
+Minnesota,Rice County,2016,65622,,69135,778
 Minnesota,Rice County,2017,65968,4892.0,64014,760
-Minnesota,Rice County,2018,66523,0.0,65839,770
+Minnesota,Rice County,2018,66523,,65839,770
 Minnesota,Rice County,2019,66972,5084.0,72469,752
 Minnesota,Rice County,2021,67262,4703.0,67267,878
-Minnesota,Rice County,2022,67693,0.0,76319,805
-Minnesota,St. Louis County,2005,186225,0.0,39858,469
+Minnesota,Rice County,2022,67693,,76319,805
+Minnesota,St. Louis County,2005,186225,,39858,469
 Minnesota,St. Louis County,2006,196067,3290.0,43078,527
 Minnesota,St. Louis County,2007,196694,4031.0,42532,560
 Minnesota,St. Louis County,2008,196864,4483.0,43488,512
@@ -5933,41 +5933,41 @@ Minnesota,St. Louis County,2018,199754,3347.0,53550,708
 Minnesota,St. Louis County,2019,199070,4263.0,60434,709
 Minnesota,St. Louis County,2021,199182,13520.0,64959,835
 Minnesota,St. Louis County,2022,199532,9450.0,62704,844
-Minnesota,Scott County,2005,118822,0.0,78106,725
+Minnesota,Scott County,2005,118822,,78106,725
 Minnesota,Scott County,2006,124092,2236.0,79262,793
-Minnesota,Scott County,2007,126642,0.0,77678,724
-Minnesota,Scott County,2008,128937,0.0,79859,828
-Minnesota,Scott County,2009,131939,0.0,84035,912
+Minnesota,Scott County,2007,126642,,77678,724
+Minnesota,Scott County,2008,128937,,79859,828
+Minnesota,Scott County,2009,131939,,84035,912
 Minnesota,Scott County,2010,130487,3659.0,77314,816
-Minnesota,Scott County,2011,132556,0.0,80864,797
+Minnesota,Scott County,2011,132556,,80864,797
 Minnesota,Scott County,2012,135152,4873.0,85382,936
-Minnesota,Scott County,2013,137232,0.0,83173,952
+Minnesota,Scott County,2013,137232,,83173,952
 Minnesota,Scott County,2014,139672,3685.0,92107,907
 Minnesota,Scott County,2015,141660,3116.0,92506,944
-Minnesota,Scott County,2016,143680,0.0,88765,1058
-Minnesota,Scott County,2017,145827,0.0,98538,1052
-Minnesota,Scott County,2018,147381,0.0,100963,1047
-Minnesota,Scott County,2019,149013,0.0,108761,1082
-Minnesota,Scott County,2021,153268,0.0,106987,1184
+Minnesota,Scott County,2016,143680,,88765,1058
+Minnesota,Scott County,2017,145827,,98538,1052
+Minnesota,Scott County,2018,147381,,100963,1047
+Minnesota,Scott County,2019,149013,,108761,1082
+Minnesota,Scott County,2021,153268,,106987,1184
 Minnesota,Scott County,2022,154520,19074.0,113311,1386
-Minnesota,Sherburne County,2005,80003,0.0,61313,597
-Minnesota,Sherburne County,2006,84995,0.0,68008,714
-Minnesota,Sherburne County,2007,86287,0.0,67215,655
-Minnesota,Sherburne County,2008,87660,0.0,69284,759
-Minnesota,Sherburne County,2009,87832,0.0,72130,715
-Minnesota,Sherburne County,2010,88691,0.0,69971,759
-Minnesota,Sherburne County,2011,89319,0.0,67198,772
-Minnesota,Sherburne County,2012,89455,0.0,69140,888
-Minnesota,Sherburne County,2013,90158,0.0,76036,980
-Minnesota,Sherburne County,2014,91126,0.0,77532,839
-Minnesota,Sherburne County,2015,91705,0.0,80088,778
-Minnesota,Sherburne County,2016,93528,0.0,83675,774
-Minnesota,Sherburne County,2017,94570,0.0,87756,889
-Minnesota,Sherburne County,2018,96036,0.0,80643,894
-Minnesota,Sherburne County,2019,97238,0.0,96210,1053
-Minnesota,Sherburne County,2021,99074,0.0,90638,1011
-Minnesota,Sherburne County,2022,100824,0.0,96889,1109
-Minnesota,Stearns County,2005,135253,0.0,46912,589
+Minnesota,Sherburne County,2005,80003,,61313,597
+Minnesota,Sherburne County,2006,84995,,68008,714
+Minnesota,Sherburne County,2007,86287,,67215,655
+Minnesota,Sherburne County,2008,87660,,69284,759
+Minnesota,Sherburne County,2009,87832,,72130,715
+Minnesota,Sherburne County,2010,88691,,69971,759
+Minnesota,Sherburne County,2011,89319,,67198,772
+Minnesota,Sherburne County,2012,89455,,69140,888
+Minnesota,Sherburne County,2013,90158,,76036,980
+Minnesota,Sherburne County,2014,91126,,77532,839
+Minnesota,Sherburne County,2015,91705,,80088,778
+Minnesota,Sherburne County,2016,93528,,83675,774
+Minnesota,Sherburne County,2017,94570,,87756,889
+Minnesota,Sherburne County,2018,96036,,80643,894
+Minnesota,Sherburne County,2019,97238,,96210,1053
+Minnesota,Sherburne County,2021,99074,,90638,1011
+Minnesota,Sherburne County,2022,100824,,96889,1109
+Minnesota,Stearns County,2005,135253,,46912,589
 Minnesota,Stearns County,2006,144096,4424.0,48803,580
 Minnesota,Stearns County,2007,146051,4490.0,51658,606
 Minnesota,Stearns County,2008,147076,5975.0,51942,571
@@ -5984,7 +5984,7 @@ Minnesota,Stearns County,2018,159256,4061.0,60669,741
 Minnesota,Stearns County,2019,161075,4232.0,66558,784
 Minnesota,Stearns County,2021,158947,7878.0,65742,761
 Minnesota,Stearns County,2022,160405,9064.0,71880,897
-Minnesota,Washington County,2005,217021,0.0,73491,788
+Minnesota,Washington County,2005,217021,,73491,788
 Minnesota,Washington County,2006,225000,5299.0,76380,783
 Minnesota,Washington County,2007,226475,4977.0,77476,805
 Minnesota,Washington County,2008,229173,6155.0,79339,875
@@ -6001,75 +6001,75 @@ Minnesota,Washington County,2018,259201,8909.0,95124,1149
 Minnesota,Washington County,2019,262440,9486.0,100596,1270
 Minnesota,Washington County,2021,272256,45471.0,104935,1320
 Minnesota,Washington County,2022,275912,34654.0,106509,1468
-Minnesota,Wright County,2005,109836,0.0,59615,636
+Minnesota,Wright County,2005,109836,,59615,636
 Minnesota,Wright County,2006,114787,2994.0,61861,582
 Minnesota,Wright County,2007,117372,4077.0,67411,682
-Minnesota,Wright County,2008,119701,0.0,65165,634
+Minnesota,Wright County,2008,119701,,65165,634
 Minnesota,Wright County,2009,121907,2652.0,66648,739
-Minnesota,Wright County,2010,125118,0.0,66833,688
-Minnesota,Wright County,2011,126437,0.0,68242,738
+Minnesota,Wright County,2010,125118,,66833,688
+Minnesota,Wright County,2011,126437,,68242,738
 Minnesota,Wright County,2012,127336,3386.0,72467,815
-Minnesota,Wright County,2013,128470,0.0,71917,829
-Minnesota,Wright County,2014,129918,0.0,77442,790
+Minnesota,Wright County,2013,128470,,71917,829
+Minnesota,Wright County,2014,129918,,77442,790
 Minnesota,Wright County,2015,131311,3677.0,76306,811
 Minnesota,Wright County,2016,132550,3117.0,74190,824
-Minnesota,Wright County,2017,134286,0.0,79931,818
-Minnesota,Wright County,2018,136349,0.0,88359,845
+Minnesota,Wright County,2017,134286,,79931,818
+Minnesota,Wright County,2018,136349,,88359,845
 Minnesota,Wright County,2019,138377,4590.0,91707,1006
-Minnesota,Wright County,2021,144845,0.0,99964,944
-Minnesota,Wright County,2022,148003,0.0,93602,1080
-Mississippi,DeSoto County,2005,136353,0.0,50454,607
-Mississippi,DeSoto County,2006,144706,0.0,53139,682
-Mississippi,DeSoto County,2007,149393,0.0,58447,662
-Mississippi,DeSoto County,2008,154748,0.0,60076,738
-Mississippi,DeSoto County,2009,158719,0.0,54706,713
-Mississippi,DeSoto County,2010,161746,0.0,60385,690
-Mississippi,DeSoto County,2011,164053,0.0,53802,716
-Mississippi,DeSoto County,2012,166234,0.0,54102,798
-Mississippi,DeSoto County,2013,168240,0.0,58959,741
-Mississippi,DeSoto County,2014,170913,0.0,58073,758
-Mississippi,DeSoto County,2015,173323,0.0,60394,809
-Mississippi,DeSoto County,2016,175611,0.0,64505,830
-Mississippi,DeSoto County,2017,178751,0.0,66440,834
-Mississippi,DeSoto County,2018,182001,0.0,68385,832
-Mississippi,DeSoto County,2019,184945,0.0,66078,877
-Mississippi,DeSoto County,2021,188633,0.0,70490,1020
-Mississippi,DeSoto County,2022,191723,0.0,79747,1166
-Mississippi,Forrest County,2005,69608,0.0,29553,423
-Mississippi,Forrest County,2006,76372,0.0,32104,458
-Mississippi,Forrest County,2007,78241,0.0,32434,487
-Mississippi,Forrest County,2008,79425,0.0,32255,485
-Mississippi,Forrest County,2009,81078,0.0,37185,502
-Mississippi,Forrest County,2010,75113,0.0,31327,515
-Mississippi,Forrest County,2011,75842,0.0,35046,523
-Mississippi,Forrest County,2012,76894,0.0,31584,536
-Mississippi,Forrest County,2013,77059,0.0,35422,543
-Mississippi,Forrest County,2014,76330,0.0,38904,564
-Mississippi,Forrest County,2015,75944,0.0,33779,556
-Mississippi,Forrest County,2016,75979,0.0,37275,546
-Mississippi,Forrest County,2017,75471,0.0,42389,599
-Mississippi,Forrest County,2018,75036,0.0,38837,596
-Mississippi,Forrest County,2019,74897,0.0,39063,643
-Mississippi,Forrest County,2021,77875,0.0,46226,683
-Mississippi,Forrest County,2022,78110,0.0,53464,661
-Mississippi,Harrison County,2005,186530,0.0,39803,531
-Mississippi,Harrison County,2006,171875,0.0,44015,619
+Minnesota,Wright County,2021,144845,,99964,944
+Minnesota,Wright County,2022,148003,,93602,1080
+Mississippi,DeSoto County,2005,136353,,50454,607
+Mississippi,DeSoto County,2006,144706,,53139,682
+Mississippi,DeSoto County,2007,149393,,58447,662
+Mississippi,DeSoto County,2008,154748,,60076,738
+Mississippi,DeSoto County,2009,158719,,54706,713
+Mississippi,DeSoto County,2010,161746,,60385,690
+Mississippi,DeSoto County,2011,164053,,53802,716
+Mississippi,DeSoto County,2012,166234,,54102,798
+Mississippi,DeSoto County,2013,168240,,58959,741
+Mississippi,DeSoto County,2014,170913,,58073,758
+Mississippi,DeSoto County,2015,173323,,60394,809
+Mississippi,DeSoto County,2016,175611,,64505,830
+Mississippi,DeSoto County,2017,178751,,66440,834
+Mississippi,DeSoto County,2018,182001,,68385,832
+Mississippi,DeSoto County,2019,184945,,66078,877
+Mississippi,DeSoto County,2021,188633,,70490,1020
+Mississippi,DeSoto County,2022,191723,,79747,1166
+Mississippi,Forrest County,2005,69608,,29553,423
+Mississippi,Forrest County,2006,76372,,32104,458
+Mississippi,Forrest County,2007,78241,,32434,487
+Mississippi,Forrest County,2008,79425,,32255,485
+Mississippi,Forrest County,2009,81078,,37185,502
+Mississippi,Forrest County,2010,75113,,31327,515
+Mississippi,Forrest County,2011,75842,,35046,523
+Mississippi,Forrest County,2012,76894,,31584,536
+Mississippi,Forrest County,2013,77059,,35422,543
+Mississippi,Forrest County,2014,76330,,38904,564
+Mississippi,Forrest County,2015,75944,,33779,556
+Mississippi,Forrest County,2016,75979,,37275,546
+Mississippi,Forrest County,2017,75471,,42389,599
+Mississippi,Forrest County,2018,75036,,38837,596
+Mississippi,Forrest County,2019,74897,,39063,643
+Mississippi,Forrest County,2021,77875,,46226,683
+Mississippi,Forrest County,2022,78110,,53464,661
+Mississippi,Harrison County,2005,186530,,39803,531
+Mississippi,Harrison County,2006,171875,,44015,619
 Mississippi,Harrison County,2007,176105,2408.0,41449,687
-Mississippi,Harrison County,2008,178460,0.0,45243,696
+Mississippi,Harrison County,2008,178460,,45243,696
 Mississippi,Harrison County,2009,181191,3049.0,43107,720
-Mississippi,Harrison County,2010,187785,0.0,41970,666
+Mississippi,Harrison County,2010,187785,,41970,666
 Mississippi,Harrison County,2011,191040,1717.0,38645,647
-Mississippi,Harrison County,2012,194029,0.0,41098,667
+Mississippi,Harrison County,2012,194029,,41098,667
 Mississippi,Harrison County,2013,196500,1772.0,42070,676
-Mississippi,Harrison County,2014,199058,0.0,40846,646
-Mississippi,Harrison County,2015,201410,0.0,42297,661
+Mississippi,Harrison County,2014,199058,,40846,646
+Mississippi,Harrison County,2015,201410,,42297,661
 Mississippi,Harrison County,2016,203234,2358.0,42770,674
-Mississippi,Harrison County,2017,205027,0.0,47365,707
-Mississippi,Harrison County,2018,206650,0.0,45042,677
-Mississippi,Harrison County,2019,208080,0.0,50119,714
-Mississippi,Harrison County,2021,209396,0.0,55702,759
+Mississippi,Harrison County,2017,205027,,47365,707
+Mississippi,Harrison County,2018,206650,,45042,677
+Mississippi,Harrison County,2019,208080,,50119,714
+Mississippi,Harrison County,2021,209396,,55702,759
 Mississippi,Harrison County,2022,211044,5285.0,56041,847
-Mississippi,Hinds County,2005,239901,0.0,35387,495
+Mississippi,Hinds County,2005,239901,,35387,495
 Mississippi,Hinds County,2006,249012,2929.0,35801,514
 Mississippi,Hinds County,2007,249157,1930.0,38260,563
 Mississippi,Hinds County,2008,247650,4842.0,38605,533
@@ -6080,124 +6080,124 @@ Mississippi,Hinds County,2012,248643,2028.0,34581,572
 Mississippi,Hinds County,2013,244899,2269.0,33719,590
 Mississippi,Hinds County,2014,243729,2373.0,38543,599
 Mississippi,Hinds County,2015,242891,2595.0,39002,639
-Mississippi,Hinds County,2016,241229,0.0,43657,657
+Mississippi,Hinds County,2016,241229,,43657,657
 Mississippi,Hinds County,2017,239497,2089.0,45658,671
 Mississippi,Hinds County,2018,237085,3666.0,45459,671
 Mississippi,Hinds County,2019,231840,2968.0,44964,684
-Mississippi,Hinds County,2021,222679,0.0,40658,717
+Mississippi,Hinds County,2021,222679,,40658,717
 Mississippi,Hinds County,2022,217730,8045.0,46672,770
-Mississippi,Jackson County,2005,134249,0.0,41484,446
-Mississippi,Jackson County,2006,130577,0.0,42816,541
-Mississippi,Jackson County,2007,130098,0.0,42568,646
-Mississippi,Jackson County,2008,130694,0.0,51982,589
-Mississippi,Jackson County,2009,132922,0.0,48903,716
-Mississippi,Jackson County,2010,139698,0.0,44951,639
-Mississippi,Jackson County,2011,139901,0.0,47800,652
-Mississippi,Jackson County,2012,140298,0.0,44824,648
-Mississippi,Jackson County,2013,140450,0.0,47891,638
-Mississippi,Jackson County,2014,141137,0.0,47822,666
-Mississippi,Jackson County,2015,141425,0.0,45596,627
-Mississippi,Jackson County,2016,141241,0.0,54606,701
-Mississippi,Jackson County,2017,142152,0.0,48284,660
-Mississippi,Jackson County,2018,143277,0.0,50546,657
-Mississippi,Jackson County,2019,143617,0.0,52476,750
-Mississippi,Jackson County,2021,143987,0.0,57383,754
-Mississippi,Jackson County,2022,144975,0.0,60966,816
-Mississippi,Jones County,2005,66425,0.0,30088,324
-Mississippi,Jones County,2006,66022,0.0,31550,348
-Mississippi,Jones County,2007,68553,0.0,33771,440
-Mississippi,Jones County,2008,67764,0.0,36772,358
-Mississippi,Jones County,2009,67776,0.0,33137,371
-Mississippi,Jones County,2010,67870,0.0,35913,386
-Mississippi,Jones County,2011,68075,0.0,39709,501
-Mississippi,Jones County,2012,68641,0.0,34580,425
-Mississippi,Jones County,2013,68961,0.0,33915,423
-Mississippi,Jones County,2014,68290,0.0,36374,445
-Mississippi,Jones County,2015,68215,0.0,32856,436
-Mississippi,Jones County,2016,67953,0.0,43350,502
-Mississippi,Jones County,2017,67930,0.0,39310,525
-Mississippi,Jones County,2018,68461,0.0,49393,521
-Mississippi,Jones County,2019,68098,0.0,37594,501
-Mississippi,Jones County,2021,66744,0.0,40116,503
-Mississippi,Jones County,2022,66569,0.0,59815,536
-Mississippi,Lamar County,2021,65353,0.0,65334,823
-Mississippi,Lamar County,2022,65783,0.0,59560,784
-Mississippi,Lauderdale County,2005,73647,0.0,31177,372
-Mississippi,Lauderdale County,2006,76724,0.0,30401,396
-Mississippi,Lauderdale County,2007,77100,0.0,31054,402
-Mississippi,Lauderdale County,2008,78180,0.0,36886,426
-Mississippi,Lauderdale County,2009,79099,0.0,32524,454
-Mississippi,Lauderdale County,2010,80229,0.0,31334,417
-Mississippi,Lauderdale County,2011,80475,0.0,38573,475
-Mississippi,Lauderdale County,2012,80220,0.0,35255,451
-Mississippi,Lauderdale County,2013,80254,0.0,32217,464
-Mississippi,Lauderdale County,2014,79739,0.0,40333,515
-Mississippi,Lauderdale County,2015,78524,0.0,37676,530
-Mississippi,Lauderdale County,2016,77755,0.0,42364,487
-Mississippi,Lauderdale County,2017,76155,0.0,46983,519
-Mississippi,Lauderdale County,2018,75317,0.0,37971,564
-Mississippi,Lauderdale County,2019,74125,0.0,37497,566
-Mississippi,Lauderdale County,2021,72088,0.0,41174,616
-Mississippi,Lauderdale County,2022,70904,0.0,49904,656
-Mississippi,Lee County,2005,77438,0.0,34135,392
-Mississippi,Lee County,2006,79714,0.0,33213,402
-Mississippi,Lee County,2007,80349,0.0,43225,398
-Mississippi,Lee County,2008,81139,0.0,38739,401
-Mississippi,Lee County,2009,81913,0.0,37194,395
-Mississippi,Lee County,2010,83048,0.0,41260,456
-Mississippi,Lee County,2011,84156,0.0,40669,499
-Mississippi,Lee County,2012,85042,0.0,41202,485
-Mississippi,Lee County,2013,85340,0.0,42882,495
-Mississippi,Lee County,2014,85246,0.0,43204,503
-Mississippi,Lee County,2015,85300,0.0,39581,560
-Mississippi,Lee County,2016,85381,0.0,42235,554
-Mississippi,Lee County,2017,84933,0.0,55886,593
-Mississippi,Lee County,2018,85202,0.0,53062,649
-Mississippi,Lee County,2019,85436,0.0,49715,632
-Mississippi,Lee County,2021,82883,0.0,59274,662
-Mississippi,Lee County,2022,82959,0.0,57229,728
-Mississippi,Madison County,2005,82071,0.0,51473,612
-Mississippi,Madison County,2006,87419,0.0,57346,561
-Mississippi,Madison County,2007,89387,0.0,60845,654
-Mississippi,Madison County,2008,91369,0.0,69523,696
-Mississippi,Madison County,2009,93097,0.0,52632,645
-Mississippi,Madison County,2010,95552,0.0,55362,698
-Mississippi,Madison County,2011,96941,0.0,52898,657
-Mississippi,Madison County,2012,98468,0.0,60126,745
-Mississippi,Madison County,2013,100412,0.0,66400,775
-Mississippi,Madison County,2014,101688,0.0,67746,792
-Mississippi,Madison County,2015,103465,0.0,67907,751
-Mississippi,Madison County,2016,105114,0.0,64350,745
-Mississippi,Madison County,2017,104618,0.0,68336,766
-Mississippi,Madison County,2018,105630,0.0,75992,818
-Mississippi,Madison County,2019,106272,0.0,68171,729
-Mississippi,Madison County,2021,109813,0.0,75678,848
-Mississippi,Madison County,2022,111113,0.0,76446,919
-Mississippi,Rankin County,2005,126569,0.0,49103,587
-Mississippi,Rankin County,2006,135830,0.0,49527,614
-Mississippi,Rankin County,2007,138362,0.0,52568,542
-Mississippi,Rankin County,2008,140901,0.0,55460,652
-Mississippi,Rankin County,2009,143124,0.0,52189,692
-Mississippi,Rankin County,2010,142018,0.0,49293,647
-Mississippi,Rankin County,2011,143702,0.0,61423,668
-Mississippi,Rankin County,2012,145165,0.0,56437,672
-Mississippi,Rankin County,2013,146767,0.0,55209,765
-Mississippi,Rankin County,2014,148070,0.0,58755,703
-Mississippi,Rankin County,2015,149039,0.0,57500,720
-Mississippi,Rankin County,2016,150228,0.0,62332,708
-Mississippi,Rankin County,2017,152080,0.0,66054,877
-Mississippi,Rankin County,2018,153902,0.0,66480,868
-Mississippi,Rankin County,2019,155271,0.0,67012,813
-Mississippi,Rankin County,2021,158096,0.0,71241,824
-Mississippi,Rankin County,2022,158979,0.0,72034,982
-Missouri,Boone County,2005,134391,0.0,39453,511
+Mississippi,Jackson County,2005,134249,,41484,446
+Mississippi,Jackson County,2006,130577,,42816,541
+Mississippi,Jackson County,2007,130098,,42568,646
+Mississippi,Jackson County,2008,130694,,51982,589
+Mississippi,Jackson County,2009,132922,,48903,716
+Mississippi,Jackson County,2010,139698,,44951,639
+Mississippi,Jackson County,2011,139901,,47800,652
+Mississippi,Jackson County,2012,140298,,44824,648
+Mississippi,Jackson County,2013,140450,,47891,638
+Mississippi,Jackson County,2014,141137,,47822,666
+Mississippi,Jackson County,2015,141425,,45596,627
+Mississippi,Jackson County,2016,141241,,54606,701
+Mississippi,Jackson County,2017,142152,,48284,660
+Mississippi,Jackson County,2018,143277,,50546,657
+Mississippi,Jackson County,2019,143617,,52476,750
+Mississippi,Jackson County,2021,143987,,57383,754
+Mississippi,Jackson County,2022,144975,,60966,816
+Mississippi,Jones County,2005,66425,,30088,324
+Mississippi,Jones County,2006,66022,,31550,348
+Mississippi,Jones County,2007,68553,,33771,440
+Mississippi,Jones County,2008,67764,,36772,358
+Mississippi,Jones County,2009,67776,,33137,371
+Mississippi,Jones County,2010,67870,,35913,386
+Mississippi,Jones County,2011,68075,,39709,501
+Mississippi,Jones County,2012,68641,,34580,425
+Mississippi,Jones County,2013,68961,,33915,423
+Mississippi,Jones County,2014,68290,,36374,445
+Mississippi,Jones County,2015,68215,,32856,436
+Mississippi,Jones County,2016,67953,,43350,502
+Mississippi,Jones County,2017,67930,,39310,525
+Mississippi,Jones County,2018,68461,,49393,521
+Mississippi,Jones County,2019,68098,,37594,501
+Mississippi,Jones County,2021,66744,,40116,503
+Mississippi,Jones County,2022,66569,,59815,536
+Mississippi,Lamar County,2021,65353,,65334,823
+Mississippi,Lamar County,2022,65783,,59560,784
+Mississippi,Lauderdale County,2005,73647,,31177,372
+Mississippi,Lauderdale County,2006,76724,,30401,396
+Mississippi,Lauderdale County,2007,77100,,31054,402
+Mississippi,Lauderdale County,2008,78180,,36886,426
+Mississippi,Lauderdale County,2009,79099,,32524,454
+Mississippi,Lauderdale County,2010,80229,,31334,417
+Mississippi,Lauderdale County,2011,80475,,38573,475
+Mississippi,Lauderdale County,2012,80220,,35255,451
+Mississippi,Lauderdale County,2013,80254,,32217,464
+Mississippi,Lauderdale County,2014,79739,,40333,515
+Mississippi,Lauderdale County,2015,78524,,37676,530
+Mississippi,Lauderdale County,2016,77755,,42364,487
+Mississippi,Lauderdale County,2017,76155,,46983,519
+Mississippi,Lauderdale County,2018,75317,,37971,564
+Mississippi,Lauderdale County,2019,74125,,37497,566
+Mississippi,Lauderdale County,2021,72088,,41174,616
+Mississippi,Lauderdale County,2022,70904,,49904,656
+Mississippi,Lee County,2005,77438,,34135,392
+Mississippi,Lee County,2006,79714,,33213,402
+Mississippi,Lee County,2007,80349,,43225,398
+Mississippi,Lee County,2008,81139,,38739,401
+Mississippi,Lee County,2009,81913,,37194,395
+Mississippi,Lee County,2010,83048,,41260,456
+Mississippi,Lee County,2011,84156,,40669,499
+Mississippi,Lee County,2012,85042,,41202,485
+Mississippi,Lee County,2013,85340,,42882,495
+Mississippi,Lee County,2014,85246,,43204,503
+Mississippi,Lee County,2015,85300,,39581,560
+Mississippi,Lee County,2016,85381,,42235,554
+Mississippi,Lee County,2017,84933,,55886,593
+Mississippi,Lee County,2018,85202,,53062,649
+Mississippi,Lee County,2019,85436,,49715,632
+Mississippi,Lee County,2021,82883,,59274,662
+Mississippi,Lee County,2022,82959,,57229,728
+Mississippi,Madison County,2005,82071,,51473,612
+Mississippi,Madison County,2006,87419,,57346,561
+Mississippi,Madison County,2007,89387,,60845,654
+Mississippi,Madison County,2008,91369,,69523,696
+Mississippi,Madison County,2009,93097,,52632,645
+Mississippi,Madison County,2010,95552,,55362,698
+Mississippi,Madison County,2011,96941,,52898,657
+Mississippi,Madison County,2012,98468,,60126,745
+Mississippi,Madison County,2013,100412,,66400,775
+Mississippi,Madison County,2014,101688,,67746,792
+Mississippi,Madison County,2015,103465,,67907,751
+Mississippi,Madison County,2016,105114,,64350,745
+Mississippi,Madison County,2017,104618,,68336,766
+Mississippi,Madison County,2018,105630,,75992,818
+Mississippi,Madison County,2019,106272,,68171,729
+Mississippi,Madison County,2021,109813,,75678,848
+Mississippi,Madison County,2022,111113,,76446,919
+Mississippi,Rankin County,2005,126569,,49103,587
+Mississippi,Rankin County,2006,135830,,49527,614
+Mississippi,Rankin County,2007,138362,,52568,542
+Mississippi,Rankin County,2008,140901,,55460,652
+Mississippi,Rankin County,2009,143124,,52189,692
+Mississippi,Rankin County,2010,142018,,49293,647
+Mississippi,Rankin County,2011,143702,,61423,668
+Mississippi,Rankin County,2012,145165,,56437,672
+Mississippi,Rankin County,2013,146767,,55209,765
+Mississippi,Rankin County,2014,148070,,58755,703
+Mississippi,Rankin County,2015,149039,,57500,720
+Mississippi,Rankin County,2016,150228,,62332,708
+Mississippi,Rankin County,2017,152080,,66054,877
+Mississippi,Rankin County,2018,153902,,66480,868
+Mississippi,Rankin County,2019,155271,,67012,813
+Mississippi,Rankin County,2021,158096,,71241,824
+Mississippi,Rankin County,2022,158979,,72034,982
+Missouri,Boone County,2005,134391,,39453,511
 Missouri,Boone County,2006,146048,2796.0,42163,510
 Missouri,Boone County,2007,152435,2807.0,44438,561
 Missouri,Boone County,2008,154365,3038.0,47077,592
 Missouri,Boone County,2009,156377,2644.0,46880,589
-Missouri,Boone County,2010,163232,0.0,41006,597
+Missouri,Boone County,2010,163232,,41006,597
 Missouri,Boone County,2011,165627,3555.0,46596,566
-Missouri,Boone County,2012,168535,0.0,44201,625
+Missouri,Boone County,2012,168535,,44201,625
 Missouri,Boone County,2013,170773,2689.0,48953,621
 Missouri,Boone County,2014,172717,4953.0,50085,656
 Missouri,Boone County,2015,174974,3331.0,50520,630
@@ -6206,126 +6206,126 @@ Missouri,Boone County,2017,178271,5010.0,51340,695
 Missouri,Boone County,2018,180005,3888.0,54356,697
 Missouri,Boone County,2019,180463,4851.0,57013,722
 Missouri,Boone County,2021,185840,8529.0,62296,785
-Missouri,Boone County,2022,187690,0.0,62561,786
-Missouri,Buchanan County,2005,80196,0.0,34793,405
-Missouri,Buchanan County,2006,84955,0.0,41048,409
-Missouri,Buchanan County,2007,86485,0.0,39270,455
-Missouri,Buchanan County,2008,89408,0.0,42265,478
-Missouri,Buchanan County,2009,89856,0.0,42042,495
-Missouri,Buchanan County,2010,89144,0.0,41647,458
-Missouri,Buchanan County,2011,89666,0.0,42624,494
-Missouri,Buchanan County,2012,89706,0.0,41756,532
-Missouri,Buchanan County,2013,89631,0.0,43895,550
-Missouri,Buchanan County,2014,89486,0.0,46764,510
-Missouri,Buchanan County,2015,89100,0.0,49302,582
-Missouri,Buchanan County,2016,88938,0.0,48550,538
-Missouri,Buchanan County,2017,89065,0.0,46052,587
-Missouri,Buchanan County,2018,88571,0.0,55020,557
-Missouri,Buchanan County,2019,87364,0.0,46922,547
-Missouri,Buchanan County,2021,83853,0.0,50113,636
-Missouri,Buchanan County,2022,82911,0.0,56386,621
-Missouri,Cape Girardeau County,2005,67757,0.0,39017,398
-Missouri,Cape Girardeau County,2006,71892,0.0,38403,437
-Missouri,Cape Girardeau County,2007,72740,0.0,46120,448
-Missouri,Cape Girardeau County,2008,73243,0.0,45299,455
-Missouri,Cape Girardeau County,2009,73957,0.0,44576,433
-Missouri,Cape Girardeau County,2010,75895,0.0,44589,491
-Missouri,Cape Girardeau County,2011,76632,0.0,39977,496
-Missouri,Cape Girardeau County,2012,76950,0.0,46090,512
-Missouri,Cape Girardeau County,2013,77320,0.0,42760,512
-Missouri,Cape Girardeau County,2014,78043,0.0,47438,534
-Missouri,Cape Girardeau County,2015,78572,0.0,49731,513
-Missouri,Cape Girardeau County,2016,78913,0.0,50223,623
-Missouri,Cape Girardeau County,2017,78161,0.0,51140,641
-Missouri,Cape Girardeau County,2018,78753,0.0,49844,590
-Missouri,Cape Girardeau County,2019,78871,0.0,57908,632
-Missouri,Cape Girardeau County,2021,82113,0.0,61330,664
-Missouri,Cape Girardeau County,2022,82899,0.0,64679,641
-Missouri,Cass County,2005,93266,0.0,55582,562
-Missouri,Cass County,2006,95781,0.0,55223,660
-Missouri,Cass County,2007,97133,0.0,61553,635
-Missouri,Cass County,2008,98429,0.0,62297,669
-Missouri,Cass County,2009,100184,0.0,59382,669
-Missouri,Cass County,2010,99723,0.0,57100,671
-Missouri,Cass County,2011,100052,0.0,53936,641
-Missouri,Cass County,2012,100376,0.0,54690,668
-Missouri,Cass County,2013,100641,0.0,64144,728
-Missouri,Cass County,2014,100889,0.0,60849,687
-Missouri,Cass County,2015,101603,0.0,62561,719
-Missouri,Cass County,2016,102845,0.0,63420,692
-Missouri,Cass County,2017,103724,0.0,64595,675
-Missouri,Cass County,2018,104954,0.0,71114,742
-Missouri,Cass County,2019,105780,0.0,72819,788
-Missouri,Cass County,2021,109638,0.0,79554,850
-Missouri,Cass County,2022,110394,0.0,76601,872
-Missouri,Christian County,2005,66663,0.0,46595,483
-Missouri,Christian County,2006,70514,0.0,43360,480
-Missouri,Christian County,2007,73066,0.0,47372,504
-Missouri,Christian County,2008,75479,0.0,58297,546
-Missouri,Christian County,2009,77455,0.0,52858,594
-Missouri,Christian County,2010,77825,0.0,47671,526
-Missouri,Christian County,2011,78570,0.0,50876,545
-Missouri,Christian County,2012,79824,0.0,53013,644
-Missouri,Christian County,2013,80899,0.0,51342,576
-Missouri,Christian County,2014,82101,0.0,51692,543
-Missouri,Christian County,2015,83279,0.0,53730,582
-Missouri,Christian County,2016,84401,0.0,53172,592
-Missouri,Christian County,2017,85432,0.0,59161,566
-Missouri,Christian County,2018,86983,0.0,56717,591
-Missouri,Christian County,2019,88595,0.0,62765,642
-Missouri,Christian County,2021,91499,0.0,71343,696
-Missouri,Christian County,2022,93114,0.0,73047,682
-Missouri,Clay County,2005,199158,0.0,53762,576
+Missouri,Boone County,2022,187690,,62561,786
+Missouri,Buchanan County,2005,80196,,34793,405
+Missouri,Buchanan County,2006,84955,,41048,409
+Missouri,Buchanan County,2007,86485,,39270,455
+Missouri,Buchanan County,2008,89408,,42265,478
+Missouri,Buchanan County,2009,89856,,42042,495
+Missouri,Buchanan County,2010,89144,,41647,458
+Missouri,Buchanan County,2011,89666,,42624,494
+Missouri,Buchanan County,2012,89706,,41756,532
+Missouri,Buchanan County,2013,89631,,43895,550
+Missouri,Buchanan County,2014,89486,,46764,510
+Missouri,Buchanan County,2015,89100,,49302,582
+Missouri,Buchanan County,2016,88938,,48550,538
+Missouri,Buchanan County,2017,89065,,46052,587
+Missouri,Buchanan County,2018,88571,,55020,557
+Missouri,Buchanan County,2019,87364,,46922,547
+Missouri,Buchanan County,2021,83853,,50113,636
+Missouri,Buchanan County,2022,82911,,56386,621
+Missouri,Cape Girardeau County,2005,67757,,39017,398
+Missouri,Cape Girardeau County,2006,71892,,38403,437
+Missouri,Cape Girardeau County,2007,72740,,46120,448
+Missouri,Cape Girardeau County,2008,73243,,45299,455
+Missouri,Cape Girardeau County,2009,73957,,44576,433
+Missouri,Cape Girardeau County,2010,75895,,44589,491
+Missouri,Cape Girardeau County,2011,76632,,39977,496
+Missouri,Cape Girardeau County,2012,76950,,46090,512
+Missouri,Cape Girardeau County,2013,77320,,42760,512
+Missouri,Cape Girardeau County,2014,78043,,47438,534
+Missouri,Cape Girardeau County,2015,78572,,49731,513
+Missouri,Cape Girardeau County,2016,78913,,50223,623
+Missouri,Cape Girardeau County,2017,78161,,51140,641
+Missouri,Cape Girardeau County,2018,78753,,49844,590
+Missouri,Cape Girardeau County,2019,78871,,57908,632
+Missouri,Cape Girardeau County,2021,82113,,61330,664
+Missouri,Cape Girardeau County,2022,82899,,64679,641
+Missouri,Cass County,2005,93266,,55582,562
+Missouri,Cass County,2006,95781,,55223,660
+Missouri,Cass County,2007,97133,,61553,635
+Missouri,Cass County,2008,98429,,62297,669
+Missouri,Cass County,2009,100184,,59382,669
+Missouri,Cass County,2010,99723,,57100,671
+Missouri,Cass County,2011,100052,,53936,641
+Missouri,Cass County,2012,100376,,54690,668
+Missouri,Cass County,2013,100641,,64144,728
+Missouri,Cass County,2014,100889,,60849,687
+Missouri,Cass County,2015,101603,,62561,719
+Missouri,Cass County,2016,102845,,63420,692
+Missouri,Cass County,2017,103724,,64595,675
+Missouri,Cass County,2018,104954,,71114,742
+Missouri,Cass County,2019,105780,,72819,788
+Missouri,Cass County,2021,109638,,79554,850
+Missouri,Cass County,2022,110394,,76601,872
+Missouri,Christian County,2005,66663,,46595,483
+Missouri,Christian County,2006,70514,,43360,480
+Missouri,Christian County,2007,73066,,47372,504
+Missouri,Christian County,2008,75479,,58297,546
+Missouri,Christian County,2009,77455,,52858,594
+Missouri,Christian County,2010,77825,,47671,526
+Missouri,Christian County,2011,78570,,50876,545
+Missouri,Christian County,2012,79824,,53013,644
+Missouri,Christian County,2013,80899,,51342,576
+Missouri,Christian County,2014,82101,,51692,543
+Missouri,Christian County,2015,83279,,53730,582
+Missouri,Christian County,2016,84401,,53172,592
+Missouri,Christian County,2017,85432,,59161,566
+Missouri,Christian County,2018,86983,,56717,591
+Missouri,Christian County,2019,88595,,62765,642
+Missouri,Christian County,2021,91499,,71343,696
+Missouri,Christian County,2022,93114,,73047,682
+Missouri,Clay County,2005,199158,,53762,576
 Missouri,Clay County,2006,206957,2582.0,53448,575
 Missouri,Clay County,2007,211952,2987.0,58232,577
 Missouri,Clay County,2008,215707,2335.0,58694,603
 Missouri,Clay County,2009,228358,3437.0,57794,608
 Missouri,Clay County,2010,222718,3805.0,54884,619
-Missouri,Clay County,2011,225161,0.0,58830,636
-Missouri,Clay County,2012,227577,0.0,57002,630
+Missouri,Clay County,2011,225161,,58830,636
+Missouri,Clay County,2012,227577,,57002,630
 Missouri,Clay County,2013,230473,3816.0,60541,671
 Missouri,Clay County,2014,233682,6076.0,61384,660
-Missouri,Clay County,2015,235637,0.0,65090,687
+Missouri,Clay County,2015,235637,,65090,687
 Missouri,Clay County,2016,239085,6012.0,65430,718
-Missouri,Clay County,2017,242874,0.0,66938,783
+Missouri,Clay County,2017,242874,,66938,783
 Missouri,Clay County,2018,246365,6130.0,68269,771
-Missouri,Clay County,2019,249948,0.0,70253,821
+Missouri,Clay County,2019,249948,,70253,821
 Missouri,Clay County,2021,255518,22881.0,74728,852
 Missouri,Clay County,2022,257033,23544.0,77612,960
-Missouri,Cole County,2005,67706,0.0,45764,377
-Missouri,Cole County,2006,73296,0.0,48203,400
-Missouri,Cole County,2007,73698,0.0,45825,416
-Missouri,Cole County,2008,74313,0.0,56738,419
-Missouri,Cole County,2009,75018,0.0,53004,435
-Missouri,Cole County,2010,76182,0.0,53080,446
-Missouri,Cole County,2011,76448,0.0,55888,468
-Missouri,Cole County,2012,76363,0.0,50934,444
-Missouri,Cole County,2013,76699,0.0,50780,463
-Missouri,Cole County,2014,76557,0.0,51210,444
-Missouri,Cole County,2015,76720,0.0,56855,488
-Missouri,Cole County,2016,76631,0.0,55303,525
-Missouri,Cole County,2017,76708,0.0,52609,484
-Missouri,Cole County,2018,76796,0.0,63568,482
-Missouri,Cole County,2019,76745,0.0,61371,582
-Missouri,Cole County,2021,77205,0.0,63326,556
-Missouri,Cole County,2022,76969,0.0,70669,659
-Missouri,Franklin County,2005,98086,0.0,46185,458
-Missouri,Franklin County,2006,100067,0.0,43554,449
-Missouri,Franklin County,2007,100045,0.0,50503,439
-Missouri,Franklin County,2008,100898,0.0,48198,479
-Missouri,Franklin County,2009,101263,0.0,48754,513
-Missouri,Franklin County,2010,101508,0.0,42905,483
-Missouri,Franklin County,2011,101938,0.0,45951,530
-Missouri,Franklin County,2012,101412,0.0,42214,446
-Missouri,Franklin County,2013,101816,0.0,50502,506
-Missouri,Franklin County,2014,102084,0.0,51682,588
-Missouri,Franklin County,2015,102426,0.0,48694,535
-Missouri,Franklin County,2016,102838,0.0,55359,549
-Missouri,Franklin County,2017,103330,0.0,55290,573
-Missouri,Franklin County,2018,103670,0.0,58209,533
-Missouri,Franklin County,2019,103967,0.0,60953,591
-Missouri,Franklin County,2021,105231,0.0,68410,624
-Missouri,Franklin County,2022,105879,0.0,62694,626
+Missouri,Cole County,2005,67706,,45764,377
+Missouri,Cole County,2006,73296,,48203,400
+Missouri,Cole County,2007,73698,,45825,416
+Missouri,Cole County,2008,74313,,56738,419
+Missouri,Cole County,2009,75018,,53004,435
+Missouri,Cole County,2010,76182,,53080,446
+Missouri,Cole County,2011,76448,,55888,468
+Missouri,Cole County,2012,76363,,50934,444
+Missouri,Cole County,2013,76699,,50780,463
+Missouri,Cole County,2014,76557,,51210,444
+Missouri,Cole County,2015,76720,,56855,488
+Missouri,Cole County,2016,76631,,55303,525
+Missouri,Cole County,2017,76708,,52609,484
+Missouri,Cole County,2018,76796,,63568,482
+Missouri,Cole County,2019,76745,,61371,582
+Missouri,Cole County,2021,77205,,63326,556
+Missouri,Cole County,2022,76969,,70669,659
+Missouri,Franklin County,2005,98086,,46185,458
+Missouri,Franklin County,2006,100067,,43554,449
+Missouri,Franklin County,2007,100045,,50503,439
+Missouri,Franklin County,2008,100898,,48198,479
+Missouri,Franklin County,2009,101263,,48754,513
+Missouri,Franklin County,2010,101508,,42905,483
+Missouri,Franklin County,2011,101938,,45951,530
+Missouri,Franklin County,2012,101412,,42214,446
+Missouri,Franklin County,2013,101816,,50502,506
+Missouri,Franklin County,2014,102084,,51682,588
+Missouri,Franklin County,2015,102426,,48694,535
+Missouri,Franklin County,2016,102838,,55359,549
+Missouri,Franklin County,2017,103330,,55290,573
+Missouri,Franklin County,2018,103670,,58209,533
+Missouri,Franklin County,2019,103967,,60953,591
+Missouri,Franklin County,2021,105231,,68410,624
+Missouri,Franklin County,2022,105879,,62694,626
 Missouri,Greene County,2005,238898,3941.0,36494,464
 Missouri,Greene County,2006,254779,5650.0,39582,459
 Missouri,Greene County,2007,263980,4589.0,41162,490
@@ -6360,63 +6360,63 @@ Missouri,Jackson County,2018,700307,16902.0,55929,709
 Missouri,Jackson County,2019,703011,21654.0,57936,727
 Missouri,Jackson County,2021,716862,66799.0,63459,832
 Missouri,Jackson County,2022,716531,60174.0,62422,892
-Missouri,Jasper County,2005,107992,0.0,32732,400
-Missouri,Jasper County,2006,112505,0.0,33729,421
-Missouri,Jasper County,2007,115240,0.0,36998,417
-Missouri,Jasper County,2008,116813,0.0,37967,443
-Missouri,Jasper County,2009,118179,0.0,38665,437
-Missouri,Jasper County,2010,117770,0.0,37560,451
-Missouri,Jasper County,2011,118435,0.0,40308,451
-Missouri,Jasper County,2012,115258,0.0,37496,460
-Missouri,Jasper County,2013,116398,0.0,40967,499
-Missouri,Jasper County,2014,117543,0.0,39886,519
-Missouri,Jasper County,2015,118596,0.0,44314,559
-Missouri,Jasper County,2016,119111,0.0,45786,547
-Missouri,Jasper County,2017,120217,0.0,47981,550
-Missouri,Jasper County,2018,120636,0.0,46617,560
-Missouri,Jasper County,2019,121328,0.0,45010,552
-Missouri,Jasper County,2021,123155,0.0,52221,670
-Missouri,Jasper County,2022,124075,0.0,53486,638
-Missouri,Jefferson County,2005,211639,0.0,50850,484
+Missouri,Jasper County,2005,107992,,32732,400
+Missouri,Jasper County,2006,112505,,33729,421
+Missouri,Jasper County,2007,115240,,36998,417
+Missouri,Jasper County,2008,116813,,37967,443
+Missouri,Jasper County,2009,118179,,38665,437
+Missouri,Jasper County,2010,117770,,37560,451
+Missouri,Jasper County,2011,118435,,40308,451
+Missouri,Jasper County,2012,115258,,37496,460
+Missouri,Jasper County,2013,116398,,40967,499
+Missouri,Jasper County,2014,117543,,39886,519
+Missouri,Jasper County,2015,118596,,44314,559
+Missouri,Jasper County,2016,119111,,45786,547
+Missouri,Jasper County,2017,120217,,47981,550
+Missouri,Jasper County,2018,120636,,46617,560
+Missouri,Jasper County,2019,121328,,45010,552
+Missouri,Jasper County,2021,123155,,52221,670
+Missouri,Jasper County,2022,124075,,53486,638
+Missouri,Jefferson County,2005,211639,,50850,484
 Missouri,Jefferson County,2006,216469,3403.0,53434,512
 Missouri,Jefferson County,2007,216076,2366.0,57228,534
-Missouri,Jefferson County,2008,217679,0.0,58124,561
-Missouri,Jefferson County,2009,219046,0.0,53501,559
+Missouri,Jefferson County,2008,217679,,58124,561
+Missouri,Jefferson County,2009,219046,,53501,559
 Missouri,Jefferson County,2010,219084,2806.0,52627,516
-Missouri,Jefferson County,2011,219480,0.0,50491,604
-Missouri,Jefferson County,2012,220209,0.0,52545,549
+Missouri,Jefferson County,2011,219480,,50491,604
+Missouri,Jefferson County,2012,220209,,52545,549
 Missouri,Jefferson County,2013,221396,3959.0,55089,616
-Missouri,Jefferson County,2014,222716,0.0,59327,645
-Missouri,Jefferson County,2015,224124,0.0,58704,616
-Missouri,Jefferson County,2016,224226,0.0,61559,627
-Missouri,Jefferson County,2017,223810,0.0,62228,673
-Missouri,Jefferson County,2018,224347,0.0,65246,651
-Missouri,Jefferson County,2019,225081,0.0,69009,717
-Missouri,Jefferson County,2021,227771,0.0,67955,684
+Missouri,Jefferson County,2014,222716,,59327,645
+Missouri,Jefferson County,2015,224124,,58704,616
+Missouri,Jefferson County,2016,224226,,61559,627
+Missouri,Jefferson County,2017,223810,,62228,673
+Missouri,Jefferson County,2018,224347,,65246,651
+Missouri,Jefferson County,2019,225081,,69009,717
+Missouri,Jefferson County,2021,227771,,67955,684
 Missouri,Jefferson County,2022,229336,13059.0,78568,693
-Missouri,Platte County,2005,81241,0.0,60595,589
-Missouri,Platte County,2006,83061,0.0,62402,596
-Missouri,Platte County,2007,84881,0.0,60796,666
-Missouri,Platte County,2008,85896,0.0,65128,670
-Missouri,Platte County,2009,90688,0.0,64497,696
-Missouri,Platte County,2010,89677,0.0,67221,679
-Missouri,Platte County,2011,90903,0.0,61863,678
-Missouri,Platte County,2012,92054,0.0,65449,695
-Missouri,Platte County,2013,93310,0.0,63438,675
-Missouri,Platte County,2014,94788,0.0,69787,751
-Missouri,Platte County,2015,96096,0.0,70837,756
-Missouri,Platte County,2016,98309,0.0,77581,774
-Missouri,Platte County,2017,101187,0.0,74646,834
-Missouri,Platte County,2018,102985,0.0,80468,854
-Missouri,Platte County,2019,104418,0.0,81712,901
-Missouri,Platte County,2021,108569,0.0,85157,884
-Missouri,Platte County,2022,110534,0.0,92386,1036
-Missouri,St. Charles County,2005,326152,0.0,63132,653
+Missouri,Platte County,2005,81241,,60595,589
+Missouri,Platte County,2006,83061,,62402,596
+Missouri,Platte County,2007,84881,,60796,666
+Missouri,Platte County,2008,85896,,65128,670
+Missouri,Platte County,2009,90688,,64497,696
+Missouri,Platte County,2010,89677,,67221,679
+Missouri,Platte County,2011,90903,,61863,678
+Missouri,Platte County,2012,92054,,65449,695
+Missouri,Platte County,2013,93310,,63438,675
+Missouri,Platte County,2014,94788,,69787,751
+Missouri,Platte County,2015,96096,,70837,756
+Missouri,Platte County,2016,98309,,77581,774
+Missouri,Platte County,2017,101187,,74646,834
+Missouri,Platte County,2018,102985,,80468,854
+Missouri,Platte County,2019,104418,,81712,901
+Missouri,Platte County,2021,108569,,85157,884
+Missouri,Platte County,2022,110534,,92386,1036
+Missouri,St. Charles County,2005,326152,,63132,653
 Missouri,St. Charles County,2006,338719,6531.0,64567,645
 Missouri,St. Charles County,2007,343952,8352.0,67146,678
 Missouri,St. Charles County,2008,349407,7840.0,72365,681
 Missouri,St. Charles County,2009,355367,8349.0,68221,677
-Missouri,St. Charles County,2010,361602,0.0,64608,693
+Missouri,St. Charles County,2010,361602,,64608,693
 Missouri,St. Charles County,2011,365151,6977.0,66374,699
 Missouri,St. Charles County,2012,368666,10021.0,70230,730
 Missouri,St. Charles County,2013,373495,9826.0,70137,790
@@ -6427,19 +6427,19 @@ Missouri,St. Charles County,2017,395504,11343.0,81594,875
 Missouri,St. Charles County,2018,399182,10801.0,81663,858
 Missouri,St. Charles County,2019,402022,9995.0,89146,890
 Missouri,St. Charles County,2021,409981,48775.0,91601,976
-Missouri,St. Charles County,2022,413803,0.0,98831,1092
-Missouri,St. Francois County,2010,65498,0.0,33428,419
-Missouri,St. Francois County,2011,65578,0.0,34260,473
-Missouri,St. Francois County,2012,65917,0.0,34129,487
-Missouri,St. Francois County,2013,66215,0.0,37349,477
-Missouri,St. Francois County,2014,65960,0.0,41713,482
-Missouri,St. Francois County,2015,66520,0.0,42863,479
-Missouri,St. Francois County,2016,66627,0.0,45431,523
-Missouri,St. Francois County,2017,66705,0.0,39288,501
-Missouri,St. Francois County,2018,66692,0.0,46796,513
-Missouri,St. Francois County,2019,67215,0.0,42390,579
-Missouri,St. Francois County,2021,67541,0.0,47682,577
-Missouri,St. Francois County,2022,66969,0.0,46775,588
+Missouri,St. Charles County,2022,413803,,98831,1092
+Missouri,St. Francois County,2010,65498,,33428,419
+Missouri,St. Francois County,2011,65578,,34260,473
+Missouri,St. Francois County,2012,65917,,34129,487
+Missouri,St. Francois County,2013,66215,,37349,477
+Missouri,St. Francois County,2014,65960,,41713,482
+Missouri,St. Francois County,2015,66520,,42863,479
+Missouri,St. Francois County,2016,66627,,45431,523
+Missouri,St. Francois County,2017,66705,,39288,501
+Missouri,St. Francois County,2018,66692,,46796,513
+Missouri,St. Francois County,2019,67215,,42390,579
+Missouri,St. Francois County,2021,67541,,47682,577
+Missouri,St. Francois County,2022,66969,,46775,588
 Missouri,St. Louis County,2005,985393,15559.0,54268,592
 Missouri,St. Louis County,2006,1000510,17881.0,53186,592
 Missouri,St. Louis County,2007,995118,20516.0,56771,612
@@ -6457,7 +6457,7 @@ Missouri,St. Louis County,2018,996945,27670.0,66778,774
 Missouri,St. Louis County,2019,994205,31290.0,70022,792
 Missouri,St. Louis County,2021,997187,106831.0,72378,844
 Missouri,St. Louis County,2022,990414,89917.0,79440,951
-Missouri,St. Louis city,2005,333730,0.0,30874,438
+Missouri,St. Louis city,2005,333730,,30874,438
 Missouri,St. Louis city,2006,347181,2703.0,30936,444
 Missouri,St. Louis city,2007,350759,4464.0,34191,475
 Missouri,St. Louis city,2008,354361,5424.0,34078,490
@@ -6474,67 +6474,67 @@ Missouri,St. Louis city,2018,302838,5174.0,43889,645
 Missouri,St. Louis city,2019,300576,5892.0,47176,655
 Missouri,St. Louis city,2021,293310,28480.0,49965,683
 Missouri,St. Louis city,2022,286578,26543.0,52847,744
-Montana,Cascade County,2005,77462,0.0,38925,419
-Montana,Cascade County,2006,79385,0.0,39887,473
+Montana,Cascade County,2005,77462,,38925,419
+Montana,Cascade County,2006,79385,,39887,473
 Montana,Cascade County,2007,81775,1152.0,42952,397
-Montana,Cascade County,2008,82026,0.0,42750,448
-Montana,Cascade County,2009,82178,0.0,40518,435
-Montana,Cascade County,2010,81519,0.0,41871,515
+Montana,Cascade County,2008,82026,,42750,448
+Montana,Cascade County,2009,82178,,40518,435
+Montana,Cascade County,2010,81519,,41871,515
 Montana,Cascade County,2011,81837,783.0,42623,506
-Montana,Cascade County,2012,81723,0.0,41732,531
-Montana,Cascade County,2013,82384,0.0,43947,558
-Montana,Cascade County,2014,82344,0.0,42170,553
+Montana,Cascade County,2012,81723,,41732,531
+Montana,Cascade County,2013,82384,,43947,558
+Montana,Cascade County,2014,82344,,42170,553
 Montana,Cascade County,2015,82278,1197.0,45606,634
-Montana,Cascade County,2016,81755,0.0,45138,628
-Montana,Cascade County,2017,81654,0.0,47713,624
-Montana,Cascade County,2018,81643,0.0,49948,707
-Montana,Cascade County,2019,81366,0.0,51227,696
-Montana,Cascade County,2021,84511,0.0,57706,697
-Montana,Cascade County,2022,84864,0.0,58698,736
-Montana,Flathead County,2005,82027,0.0,39942,512
-Montana,Flathead County,2006,85314,0.0,45920,562
-Montana,Flathead County,2007,86844,0.0,45600,499
-Montana,Flathead County,2008,88473,0.0,41110,607
-Montana,Flathead County,2009,89624,0.0,46435,634
-Montana,Flathead County,2010,90901,0.0,41854,572
-Montana,Flathead County,2011,91301,0.0,44207,648
-Montana,Flathead County,2012,91633,0.0,46444,711
-Montana,Flathead County,2013,93068,0.0,47802,657
-Montana,Flathead County,2014,94924,0.0,47362,680
-Montana,Flathead County,2015,96165,0.0,46899,678
-Montana,Flathead County,2016,98082,0.0,50142,758
-Montana,Flathead County,2017,100000,0.0,59735,638
-Montana,Flathead County,2018,102106,0.0,53193,840
-Montana,Flathead County,2019,103806,0.0,62588,798
-Montana,Flathead County,2021,108454,0.0,66126,798
-Montana,Flathead County,2022,111814,0.0,65680,1038
-Montana,Gallatin County,2005,77543,0.0,45987,618
+Montana,Cascade County,2016,81755,,45138,628
+Montana,Cascade County,2017,81654,,47713,624
+Montana,Cascade County,2018,81643,,49948,707
+Montana,Cascade County,2019,81366,,51227,696
+Montana,Cascade County,2021,84511,,57706,697
+Montana,Cascade County,2022,84864,,58698,736
+Montana,Flathead County,2005,82027,,39942,512
+Montana,Flathead County,2006,85314,,45920,562
+Montana,Flathead County,2007,86844,,45600,499
+Montana,Flathead County,2008,88473,,41110,607
+Montana,Flathead County,2009,89624,,46435,634
+Montana,Flathead County,2010,90901,,41854,572
+Montana,Flathead County,2011,91301,,44207,648
+Montana,Flathead County,2012,91633,,46444,711
+Montana,Flathead County,2013,93068,,47802,657
+Montana,Flathead County,2014,94924,,47362,680
+Montana,Flathead County,2015,96165,,46899,678
+Montana,Flathead County,2016,98082,,50142,758
+Montana,Flathead County,2017,100000,,59735,638
+Montana,Flathead County,2018,102106,,53193,840
+Montana,Flathead County,2019,103806,,62588,798
+Montana,Flathead County,2021,108454,,66126,798
+Montana,Flathead County,2022,111814,,65680,1038
+Montana,Gallatin County,2005,77543,,45987,618
 Montana,Gallatin County,2006,81763,2804.0,47532,643
 Montana,Gallatin County,2007,89204,3465.0,51096,695
-Montana,Gallatin County,2008,91791,0.0,53081,750
+Montana,Gallatin County,2008,91791,,53081,750
 Montana,Gallatin County,2009,90343,3708.0,45607,638
 Montana,Gallatin County,2010,89658,2602.0,49506,704
-Montana,Gallatin County,2011,91377,0.0,50302,725
+Montana,Gallatin County,2011,91377,,50302,725
 Montana,Gallatin County,2012,92614,3675.0,52274,767
 Montana,Gallatin County,2013,94720,3846.0,58809,715
 Montana,Gallatin County,2014,97308,3713.0,50238,770
 Montana,Gallatin County,2015,100739,3216.0,57535,847
-Montana,Gallatin County,2016,104502,0.0,61211,839
+Montana,Gallatin County,2016,104502,,61211,839
 Montana,Gallatin County,2017,107810,4496.0,60901,934
 Montana,Gallatin County,2018,111876,6352.0,68266,1023
 Montana,Gallatin County,2019,114434,6208.0,75418,1102
-Montana,Gallatin County,2021,122713,0.0,80763,1186
+Montana,Gallatin County,2021,122713,,80763,1186
 Montana,Gallatin County,2022,124857,13218.0,83064,1468
-Montana,Lewis and Clark County,2013,65338,0.0,54954,696
-Montana,Lewis and Clark County,2014,65856,0.0,53435,666
-Montana,Lewis and Clark County,2015,66418,0.0,58796,749
-Montana,Lewis and Clark County,2016,67282,0.0,63475,698
-Montana,Lewis and Clark County,2017,67773,0.0,60404,716
-Montana,Lewis and Clark County,2018,68700,0.0,65241,726
-Montana,Lewis and Clark County,2019,69432,0.0,67616,766
-Montana,Lewis and Clark County,2021,72223,0.0,66686,801
-Montana,Lewis and Clark County,2022,73832,0.0,72250,948
-Montana,Missoula County,2005,96467,0.0,42612,551
+Montana,Lewis and Clark County,2013,65338,,54954,696
+Montana,Lewis and Clark County,2014,65856,,53435,666
+Montana,Lewis and Clark County,2015,66418,,58796,749
+Montana,Lewis and Clark County,2016,67282,,63475,698
+Montana,Lewis and Clark County,2017,67773,,60404,716
+Montana,Lewis and Clark County,2018,68700,,65241,726
+Montana,Lewis and Clark County,2019,69432,,67616,766
+Montana,Lewis and Clark County,2021,72223,,66686,801
+Montana,Lewis and Clark County,2022,73832,,72250,948
+Montana,Missoula County,2005,96467,,42612,551
 Montana,Missoula County,2006,101417,3211.0,38168,587
 Montana,Missoula County,2007,105650,4451.0,42798,580
 Montana,Missoula County,2008,107320,5647.0,42349,602
@@ -6549,24 +6549,24 @@ Montana,Missoula County,2016,116130,3792.0,46550,753
 Montana,Missoula County,2017,117441,3754.0,54311,733
 Montana,Missoula County,2018,118791,2980.0,56598,776
 Montana,Missoula County,2019,119600,3657.0,57347,828
-Montana,Missoula County,2021,119533,0.0,66803,912
+Montana,Missoula County,2021,119533,,66803,912
 Montana,Missoula County,2022,121041,9016.0,68305,977
-Montana,Yellowstone County,2005,133762,0.0,41084,475
+Montana,Yellowstone County,2005,133762,,41084,475
 Montana,Yellowstone County,2006,138213,2701.0,43377,490
-Montana,Yellowstone County,2007,139936,0.0,48304,511
+Montana,Yellowstone County,2007,139936,,48304,511
 Montana,Yellowstone County,2008,142348,2741.0,49541,584
 Montana,Yellowstone County,2009,144797,2456.0,47233,590
 Montana,Yellowstone County,2010,148432,3030.0,48153,573
-Montana,Yellowstone County,2011,150069,0.0,46975,573
+Montana,Yellowstone County,2011,150069,,46975,573
 Montana,Yellowstone County,2012,151882,2179.0,49482,650
 Montana,Yellowstone County,2013,154162,3602.0,52610,648
 Montana,Yellowstone County,2014,155634,3329.0,51508,672
 Montana,Yellowstone County,2015,157048,2811.0,58026,761
 Montana,Yellowstone County,2016,158437,2946.0,57945,737
-Montana,Yellowstone County,2017,158980,0.0,58156,733
+Montana,Yellowstone County,2017,158980,,58156,733
 Montana,Yellowstone County,2018,160137,2598.0,60079,787
 Montana,Yellowstone County,2019,161300,3314.0,61186,779
-Montana,Yellowstone County,2021,167146,0.0,69882,846
+Montana,Yellowstone County,2021,167146,,69882,846
 Montana,Yellowstone County,2022,169852,6133.0,79283,939
 Nebraska,Douglas County,2005,474913,7958.0,45794,536
 Nebraska,Douglas County,2006,492003,7530.0,48898,566
@@ -6602,18 +6602,18 @@ Nebraska,Lancaster County,2018,317272,7954.0,57650,724
 Nebraska,Lancaster County,2019,319090,5271.0,61175,753
 Nebraska,Lancaster County,2021,324514,24632.0,64980,790
 Nebraska,Lancaster County,2022,324756,20043.0,66289,875
-Nebraska,Sarpy County,2005,137891,0.0,59816,603
-Nebraska,Sarpy County,2006,142637,0.0,61961,645
-Nebraska,Sarpy County,2007,146756,0.0,62552,675
-Nebraska,Sarpy County,2008,150467,0.0,64049,673
-Nebraska,Sarpy County,2009,153504,0.0,67332,685
-Nebraska,Sarpy County,2010,159709,0.0,69538,726
-Nebraska,Sarpy County,2011,162561,0.0,64043,683
+Nebraska,Sarpy County,2005,137891,,59816,603
+Nebraska,Sarpy County,2006,142637,,61961,645
+Nebraska,Sarpy County,2007,146756,,62552,675
+Nebraska,Sarpy County,2008,150467,,64049,673
+Nebraska,Sarpy County,2009,153504,,67332,685
+Nebraska,Sarpy County,2010,159709,,69538,726
+Nebraska,Sarpy County,2011,162561,,64043,683
 Nebraska,Sarpy County,2012,165853,2373.0,66779,728
-Nebraska,Sarpy County,2013,169331,0.0,65706,733
-Nebraska,Sarpy County,2014,172193,0.0,73775,772
-Nebraska,Sarpy County,2015,175692,0.0,73518,783
-Nebraska,Sarpy County,2016,179023,0.0,73569,830
+Nebraska,Sarpy County,2013,169331,,65706,733
+Nebraska,Sarpy County,2014,172193,,73775,772
+Nebraska,Sarpy County,2015,175692,,73518,783
+Nebraska,Sarpy County,2016,179023,,73569,830
 Nebraska,Sarpy County,2017,181439,4638.0,80694,869
 Nebraska,Sarpy County,2018,184459,4194.0,77941,869
 Nebraska,Sarpy County,2019,187196,4220.0,83720,918
@@ -6653,40 +6653,40 @@ Nevada,Washoe County,2018,465735,10537.0,63310,993
 Nevada,Washoe County,2019,471519,12934.0,71881,1095
 Nevada,Washoe County,2021,493392,34984.0,76220,1233
 Nevada,Washoe County,2022,496745,27063.0,80125,1361
-New Hampshire,Cheshire County,2005,73019,0.0,53868,701
-New Hampshire,Cheshire County,2006,77393,0.0,48692,727
-New Hampshire,Cheshire County,2007,77725,0.0,54838,747
-New Hampshire,Cheshire County,2008,77170,0.0,53299,727
-New Hampshire,Cheshire County,2009,77045,0.0,52017,782
-New Hampshire,Cheshire County,2010,77049,0.0,48030,819
-New Hampshire,Cheshire County,2011,76918,0.0,54049,805
-New Hampshire,Cheshire County,2012,76851,0.0,56238,832
-New Hampshire,Cheshire County,2013,76610,0.0,51945,770
-New Hampshire,Cheshire County,2014,76115,0.0,56652,829
-New Hampshire,Cheshire County,2015,75909,0.0,61780,855
-New Hampshire,Cheshire County,2016,75774,0.0,56364,781
-New Hampshire,Cheshire County,2017,75960,0.0,61257,858
-New Hampshire,Cheshire County,2018,76493,0.0,59186,793
-New Hampshire,Cheshire County,2019,76085,0.0,66088,843
-New Hampshire,Cheshire County,2021,77329,0.0,67344,946
-New Hampshire,Cheshire County,2022,77350,0.0,77757,956
-New Hampshire,Grafton County,2005,77887,0.0,46564,623
+New Hampshire,Cheshire County,2005,73019,,53868,701
+New Hampshire,Cheshire County,2006,77393,,48692,727
+New Hampshire,Cheshire County,2007,77725,,54838,747
+New Hampshire,Cheshire County,2008,77170,,53299,727
+New Hampshire,Cheshire County,2009,77045,,52017,782
+New Hampshire,Cheshire County,2010,77049,,48030,819
+New Hampshire,Cheshire County,2011,76918,,54049,805
+New Hampshire,Cheshire County,2012,76851,,56238,832
+New Hampshire,Cheshire County,2013,76610,,51945,770
+New Hampshire,Cheshire County,2014,76115,,56652,829
+New Hampshire,Cheshire County,2015,75909,,61780,855
+New Hampshire,Cheshire County,2016,75774,,56364,781
+New Hampshire,Cheshire County,2017,75960,,61257,858
+New Hampshire,Cheshire County,2018,76493,,59186,793
+New Hampshire,Cheshire County,2019,76085,,66088,843
+New Hampshire,Cheshire County,2021,77329,,67344,946
+New Hampshire,Cheshire County,2022,77350,,77757,956
+New Hampshire,Grafton County,2005,77887,,46564,623
 New Hampshire,Grafton County,2006,85336,1691.0,53501,601
-New Hampshire,Grafton County,2007,85514,0.0,51827,699
+New Hampshire,Grafton County,2007,85514,,51827,699
 New Hampshire,Grafton County,2008,85921,1996.0,51770,794
-New Hampshire,Grafton County,2009,86291,0.0,52564,819
-New Hampshire,Grafton County,2010,89108,0.0,50738,782
+New Hampshire,Grafton County,2009,86291,,52564,819
+New Hampshire,Grafton County,2010,89108,,50738,782
 New Hampshire,Grafton County,2011,88923,2199.0,50811,789
-New Hampshire,Grafton County,2012,89181,0.0,52430,834
-New Hampshire,Grafton County,2013,89629,0.0,56370,768
-New Hampshire,Grafton County,2014,89658,0.0,57210,778
+New Hampshire,Grafton County,2012,89181,,52430,834
+New Hampshire,Grafton County,2013,89629,,56370,768
+New Hampshire,Grafton County,2014,89658,,57210,778
 New Hampshire,Grafton County,2015,89320,1731.0,58183,767
 New Hampshire,Grafton County,2016,88888,3052.0,61520,790
 New Hampshire,Grafton County,2017,89386,2785.0,64420,824
 New Hampshire,Grafton County,2018,89786,2933.0,66358,950
-New Hampshire,Grafton County,2019,89886,0.0,60588,920
-New Hampshire,Grafton County,2021,92201,0.0,80866,1021
-New Hampshire,Grafton County,2022,91126,0.0,82045,1071
+New Hampshire,Grafton County,2019,89886,,60588,920
+New Hampshire,Grafton County,2021,92201,,80866,1021
+New Hampshire,Grafton County,2022,91126,,82045,1071
 New Hampshire,Hillsborough County,2005,393207,8747.0,60913,835
 New Hampshire,Hillsborough County,2006,402789,8716.0,66382,840
 New Hampshire,Hillsborough County,2007,402302,9969.0,67667,868
@@ -6704,24 +6704,24 @@ New Hampshire,Hillsborough County,2018,415247,14478.0,78978,1010
 New Hampshire,Hillsborough County,2019,417025,15433.0,83626,1125
 New Hampshire,Hillsborough County,2021,424079,53035.0,91627,1234
 New Hampshire,Hillsborough County,2022,426594,44224.0,96921,1318
-New Hampshire,Merrimack County,2005,140311,0.0,53432,687
-New Hampshire,Merrimack County,2006,148085,0.0,55072,727
-New Hampshire,Merrimack County,2007,148274,0.0,59579,806
+New Hampshire,Merrimack County,2005,140311,,53432,687
+New Hampshire,Merrimack County,2006,148085,,55072,727
+New Hampshire,Merrimack County,2007,148274,,59579,806
 New Hampshire,Merrimack County,2008,148161,3208.0,66894,792
-New Hampshire,Merrimack County,2009,149071,0.0,63018,771
+New Hampshire,Merrimack County,2009,149071,,63018,771
 New Hampshire,Merrimack County,2010,146400,3959.0,61310,800
 New Hampshire,Merrimack County,2011,146579,4073.0,66221,776
-New Hampshire,Merrimack County,2012,146761,0.0,58742,789
+New Hampshire,Merrimack County,2012,146761,,58742,789
 New Hampshire,Merrimack County,2013,146849,4330.0,65662,852
-New Hampshire,Merrimack County,2014,147171,0.0,62418,866
-New Hampshire,Merrimack County,2015,147994,0.0,68566,832
+New Hampshire,Merrimack County,2014,147171,,62418,866
+New Hampshire,Merrimack County,2015,147994,,68566,832
 New Hampshire,Merrimack County,2016,148582,4533.0,69505,894
-New Hampshire,Merrimack County,2017,149216,0.0,70764,927
-New Hampshire,Merrimack County,2018,151132,0.0,75088,914
+New Hampshire,Merrimack County,2017,149216,,70764,927
+New Hampshire,Merrimack County,2018,151132,,75088,914
 New Hampshire,Merrimack County,2019,151391,6324.0,76218,924
-New Hampshire,Merrimack County,2021,155238,0.0,80918,1041
-New Hampshire,Merrimack County,2022,156020,0.0,84690,1126
-New Hampshire,Rockingham County,2005,292410,0.0,66190,853
+New Hampshire,Merrimack County,2021,155238,,80918,1041
+New Hampshire,Merrimack County,2022,156020,,84690,1126
+New Hampshire,Rockingham County,2005,292410,,66190,853
 New Hampshire,Rockingham County,2006,296267,6499.0,70781,880
 New Hampshire,Rockingham County,2007,296543,8259.0,75929,911
 New Hampshire,Rockingham County,2008,297350,8706.0,75914,927
@@ -6738,24 +6738,24 @@ New Hampshire,Rockingham County,2018,309176,12108.0,95160,1091
 New Hampshire,Rockingham County,2019,309769,14828.0,91249,1195
 New Hampshire,Rockingham County,2021,316947,36935.0,104664,1315
 New Hampshire,Rockingham County,2022,319424,35866.0,107442,1440
-New Hampshire,Strafford County,2005,113300,0.0,53094,769
+New Hampshire,Strafford County,2005,113300,,53094,769
 New Hampshire,Strafford County,2006,119990,2090.0,52612,729
 New Hampshire,Strafford County,2007,121581,2560.0,60788,786
 New Hampshire,Strafford County,2008,121914,2953.0,61401,785
-New Hampshire,Strafford County,2009,123589,0.0,56463,798
+New Hampshire,Strafford County,2009,123589,,56463,798
 New Hampshire,Strafford County,2010,123198,3224.0,52212,842
 New Hampshire,Strafford County,2011,123857,2846.0,55180,807
-New Hampshire,Strafford County,2012,124119,0.0,52227,833
+New Hampshire,Strafford County,2012,124119,,52227,833
 New Hampshire,Strafford County,2013,124593,1905.0,60692,889
-New Hampshire,Strafford County,2014,125604,0.0,58976,835
+New Hampshire,Strafford County,2014,125604,,58976,835
 New Hampshire,Strafford County,2015,126825,2877.0,61563,829
 New Hampshire,Strafford County,2016,127428,3248.0,71295,918
 New Hampshire,Strafford County,2017,128613,2085.0,71057,963
-New Hampshire,Strafford County,2018,130090,0.0,71528,935
+New Hampshire,Strafford County,2018,130090,,71528,935
 New Hampshire,Strafford County,2019,130633,4278.0,71765,978
-New Hampshire,Strafford County,2021,132416,0.0,95733,1207
-New Hampshire,Strafford County,2022,132275,0.0,83119,1318
-New Jersey,Atlantic County,2005,264403,0.0,50377,750
+New Hampshire,Strafford County,2021,132416,,95733,1207
+New Hampshire,Strafford County,2022,132275,,83119,1318
+New Jersey,Atlantic County,2005,264403,,50377,750
 New Jersey,Atlantic County,2006,271620,2519.0,52230,791
 New Jersey,Atlantic County,2007,270644,4053.0,55767,793
 New Jersey,Atlantic County,2008,270681,2805.0,52696,802
@@ -6823,24 +6823,24 @@ New Jersey,Camden County,2018,507078,10192.0,67523,937
 New Jersey,Camden County,2019,506471,9457.0,73672,967
 New Jersey,Camden County,2021,523771,47366.0,78347,1056
 New Jersey,Camden County,2022,524907,38053.0,81768,1105
-New Jersey,Cape May County,2005,96630,0.0,51744,711
+New Jersey,Cape May County,2005,96630,,51744,711
 New Jersey,Cape May County,2006,97724,1038.0,50024,769
-New Jersey,Cape May County,2007,96422,0.0,51995,881
-New Jersey,Cape May County,2008,95838,0.0,60176,840
-New Jersey,Cape May County,2009,96092,0.0,50184,789
-New Jersey,Cape May County,2010,97253,0.0,53392,837
-New Jersey,Cape May County,2011,96601,0.0,53256,865
-New Jersey,Cape May County,2012,96304,0.0,57001,865
+New Jersey,Cape May County,2007,96422,,51995,881
+New Jersey,Cape May County,2008,95838,,60176,840
+New Jersey,Cape May County,2009,96092,,50184,789
+New Jersey,Cape May County,2010,97253,,53392,837
+New Jersey,Cape May County,2011,96601,,53256,865
+New Jersey,Cape May County,2012,96304,,57001,865
 New Jersey,Cape May County,2013,95897,1762.0,60560,829
-New Jersey,Cape May County,2014,95344,0.0,56899,938
+New Jersey,Cape May County,2014,95344,,56899,938
 New Jersey,Cape May County,2015,94727,1854.0,57116,920
 New Jersey,Cape May County,2016,94430,2047.0,62548,913
-New Jersey,Cape May County,2017,93553,0.0,66953,930
+New Jersey,Cape May County,2017,93553,,66953,930
 New Jersey,Cape May County,2018,92560,1016.0,67007,949
-New Jersey,Cape May County,2019,92039,0.0,69980,1041
-New Jersey,Cape May County,2021,95661,0.0,78657,874
-New Jersey,Cape May County,2022,95634,0.0,84870,1185
-New Jersey,Cumberland County,2005,139968,0.0,46064,579
+New Jersey,Cape May County,2019,92039,,69980,1041
+New Jersey,Cape May County,2021,95661,,78657,874
+New Jersey,Cape May County,2022,95634,,84870,1185
+New Jersey,Cumberland County,2005,139968,,46064,579
 New Jersey,Cumberland County,2006,154823,1416.0,47443,608
 New Jersey,Cumberland County,2007,155544,912.0,47883,647
 New Jersey,Cumberland County,2008,156830,1448.0,50833,702
@@ -6854,9 +6854,9 @@ New Jersey,Cumberland County,2015,155854,1333.0,51315,798
 New Jersey,Cumberland County,2016,153797,685.0,49110,814
 New Jersey,Cumberland County,2017,152538,1586.0,52627,824
 New Jersey,Cumberland County,2018,150972,1827.0,52795,848
-New Jersey,Cumberland County,2019,149527,0.0,54587,926
-New Jersey,Cumberland County,2021,153627,0.0,58389,926
-New Jersey,Cumberland County,2022,151356,0.0,60755,930
+New Jersey,Cumberland County,2019,149527,,54587,926
+New Jersey,Cumberland County,2021,153627,,58389,926
+New Jersey,Cumberland County,2022,151356,,60755,930
 New Jersey,Essex County,2005,769628,10467.0,49460,768
 New Jersey,Essex County,2006,786147,11423.0,51879,770
 New Jersey,Essex County,2007,776087,8558.0,53499,826
@@ -6874,7 +6874,7 @@ New Jersey,Essex County,2018,799767,16593.0,63368,1056
 New Jersey,Essex County,2019,798975,18400.0,64626,1115
 New Jersey,Essex County,2021,854917,85223.0,66198,1160
 New Jersey,Essex County,2022,849477,62459.0,74994,1209
-New Jersey,Gloucester County,2005,271709,0.0,64484,687
+New Jersey,Gloucester County,2005,271709,,64484,687
 New Jersey,Gloucester County,2006,282031,3552.0,66759,712
 New Jersey,Gloucester County,2007,285753,5012.0,70881,761
 New Jersey,Gloucester County,2008,287860,4224.0,70837,811
@@ -6908,23 +6908,23 @@ New Jersey,Hudson County,2018,676061,12353.0,74414,1290
 New Jersey,Hudson County,2019,672391,14021.0,78808,1340
 New Jersey,Hudson County,2021,702463,103355.0,80329,1529
 New Jersey,Hudson County,2022,703366,76149.0,83056,1619
-New Jersey,Hunterdon County,2005,126116,0.0,93342,955
+New Jersey,Hunterdon County,2005,126116,,93342,955
 New Jersey,Hunterdon County,2006,130783,4657.0,93297,938
 New Jersey,Hunterdon County,2007,129348,3967.0,100327,921
 New Jersey,Hunterdon County,2008,129031,4854.0,102683,923
-New Jersey,Hunterdon County,2009,130034,0.0,100729,1062
+New Jersey,Hunterdon County,2009,130034,,100729,1062
 New Jersey,Hunterdon County,2010,128373,4306.0,97874,1054
 New Jersey,Hunterdon County,2011,128038,5056.0,99099,1121
 New Jersey,Hunterdon County,2012,127050,5111.0,105186,1117
 New Jersey,Hunterdon County,2013,126250,4250.0,110457,1241
-New Jersey,Hunterdon County,2014,126067,0.0,103605,1243
+New Jersey,Hunterdon County,2014,126067,,103605,1243
 New Jersey,Hunterdon County,2015,125488,5008.0,102122,1163
 New Jersey,Hunterdon County,2016,124676,6169.0,113684,1193
 New Jersey,Hunterdon County,2017,125059,7108.0,112038,1290
-New Jersey,Hunterdon County,2018,124714,0.0,111269,1185
+New Jersey,Hunterdon County,2018,124714,,111269,1185
 New Jersey,Hunterdon County,2019,124371,5420.0,116155,1326
-New Jersey,Hunterdon County,2021,129924,0.0,121982,1385
-New Jersey,Hunterdon County,2022,129777,0.0,142518,1483
+New Jersey,Hunterdon County,2021,129924,,121982,1385
+New Jersey,Hunterdon County,2022,129777,,142518,1483
 New Jersey,Mercer County,2005,345118,5316.0,64657,809
 New Jersey,Mercer County,2006,367605,5910.0,65305,867
 New Jersey,Mercer County,2007,365449,6108.0,70258,864
@@ -7027,23 +7027,23 @@ New Jersey,Passaic County,2018,503310,8066.0,75259,1132
 New Jersey,Passaic County,2019,501826,9715.0,77040,1166
 New Jersey,Passaic County,2021,518117,34228.0,75430,1231
 New Jersey,Passaic County,2022,513936,28090.0,79955,1310
-New Jersey,Salem County,2005,65124,0.0,53139,641
-New Jersey,Salem County,2006,66595,0.0,58164,659
-New Jersey,Salem County,2007,66016,0.0,54992,704
-New Jersey,Salem County,2008,66141,0.0,60200,646
-New Jersey,Salem County,2009,66342,0.0,51907,749
-New Jersey,Salem County,2010,66058,0.0,56357,791
-New Jersey,Salem County,2011,65902,0.0,53926,767
-New Jersey,Salem County,2012,65774,0.0,60360,750
-New Jersey,Salem County,2013,65166,0.0,61943,776
-New Jersey,Salem County,2014,64715,0.0,57377,773
-New Jersey,Salem County,2015,64180,0.0,68830,802
-New Jersey,Salem County,2016,63436,0.0,53662,825
-New Jersey,Salem County,2017,62792,0.0,61250,839
-New Jersey,Salem County,2018,62607,0.0,65733,885
-New Jersey,Salem County,2019,62385,0.0,68531,806
-New Jersey,Salem County,2021,65046,0.0,69886,915
-New Jersey,Salem County,2022,65117,0.0,77898,1035
+New Jersey,Salem County,2005,65124,,53139,641
+New Jersey,Salem County,2006,66595,,58164,659
+New Jersey,Salem County,2007,66016,,54992,704
+New Jersey,Salem County,2008,66141,,60200,646
+New Jersey,Salem County,2009,66342,,51907,749
+New Jersey,Salem County,2010,66058,,56357,791
+New Jersey,Salem County,2011,65902,,53926,767
+New Jersey,Salem County,2012,65774,,60360,750
+New Jersey,Salem County,2013,65166,,61943,776
+New Jersey,Salem County,2014,64715,,57377,773
+New Jersey,Salem County,2015,64180,,68830,802
+New Jersey,Salem County,2016,63436,,53662,825
+New Jersey,Salem County,2017,62792,,61250,839
+New Jersey,Salem County,2018,62607,,65733,885
+New Jersey,Salem County,2019,62385,,68531,806
+New Jersey,Salem County,2021,65046,,69886,915
+New Jersey,Salem County,2022,65117,,77898,1035
 New Jersey,Somerset County,2005,314960,5842.0,88532,961
 New Jersey,Somerset County,2006,324186,5456.0,91688,1033
 New Jersey,Somerset County,2007,323552,6814.0,97658,1112
@@ -7061,13 +7061,13 @@ New Jersey,Somerset County,2018,331164,9592.0,121378,1478
 New Jersey,Somerset County,2019,328934,11544.0,111587,1479
 New Jersey,Somerset County,2021,345647,56185.0,124764,1620
 New Jersey,Somerset County,2022,346875,44446.0,135577,1689
-New Jersey,Sussex County,2005,151443,0.0,74420,867
+New Jersey,Sussex County,2005,151443,,74420,867
 New Jersey,Sussex County,2006,153384,4556.0,78488,886
 New Jersey,Sussex County,2007,151478,3290.0,78558,940
 New Jersey,Sussex County,2008,150909,3455.0,79058,947
 New Jersey,Sussex County,2009,151118,4465.0,80120,870
 New Jersey,Sussex County,2010,149239,4167.0,84115,992
-New Jersey,Sussex County,2011,148517,0.0,83839,986
+New Jersey,Sussex County,2011,148517,,83839,986
 New Jersey,Sussex County,2012,147442,4473.0,86625,970
 New Jersey,Sussex County,2013,145992,3932.0,88407,1029
 New Jersey,Sussex County,2014,144909,4188.0,82075,1040
@@ -7075,9 +7075,9 @@ New Jersey,Sussex County,2015,143673,3152.0,85086,1024
 New Jersey,Sussex County,2016,142522,4301.0,87829,1149
 New Jersey,Sussex County,2017,141682,4479.0,90026,1170
 New Jersey,Sussex County,2018,140799,4816.0,92818,1227
-New Jersey,Sussex County,2019,140488,0.0,101130,1151
-New Jersey,Sussex County,2021,145543,0.0,99904,1226
-New Jersey,Sussex County,2022,146084,0.0,113640,1359
+New Jersey,Sussex County,2019,140488,,101130,1151
+New Jersey,Sussex County,2021,145543,,99904,1226
+New Jersey,Sussex County,2022,146084,,113640,1359
 New Jersey,Union County,2005,523649,5581.0,62591,846
 New Jersey,Union County,2006,531088,6768.0,62260,897
 New Jersey,Union County,2007,524658,6541.0,61553,899
@@ -7095,23 +7095,23 @@ New Jersey,Union County,2018,558067,12243.0,82186,1166
 New Jersey,Union County,2019,556341,12072.0,80339,1216
 New Jersey,Union County,2021,572114,50563.0,86764,1300
 New Jersey,Union County,2022,569815,39600.0,98028,1434
-New Jersey,Warren County,2005,108910,0.0,60825,697
+New Jersey,Warren County,2005,108910,,60825,697
 New Jersey,Warren County,2006,110919,3483.0,62087,787
 New Jersey,Warren County,2007,109737,2493.0,65930,783
-New Jersey,Warren County,2008,109876,0.0,76368,866
-New Jersey,Warren County,2009,109638,0.0,71162,829
-New Jersey,Warren County,2010,108714,0.0,71832,799
+New Jersey,Warren County,2008,109876,,76368,866
+New Jersey,Warren County,2009,109638,,71162,829
+New Jersey,Warren County,2010,108714,,71832,799
 New Jersey,Warren County,2011,108339,2876.0,66594,821
-New Jersey,Warren County,2012,107653,0.0,71086,873
-New Jersey,Warren County,2013,107379,0.0,67208,931
-New Jersey,Warren County,2014,106917,0.0,71444,934
-New Jersey,Warren County,2015,106869,0.0,71277,971
-New Jersey,Warren County,2016,106617,0.0,74867,936
+New Jersey,Warren County,2012,107653,,71086,873
+New Jersey,Warren County,2013,107379,,67208,931
+New Jersey,Warren County,2014,106917,,71444,934
+New Jersey,Warren County,2015,106869,,71277,971
+New Jersey,Warren County,2016,106617,,74867,936
 New Jersey,Warren County,2017,106798,2562.0,80657,914
 New Jersey,Warren County,2018,105779,2233.0,77452,985
-New Jersey,Warren County,2019,105267,0.0,84479,1081
-New Jersey,Warren County,2021,110731,0.0,81159,1073
-New Jersey,Warren County,2022,110926,0.0,98867,1225
+New Jersey,Warren County,2019,105267,,84479,1081
+New Jersey,Warren County,2021,110731,,81159,1073
+New Jersey,Warren County,2022,110926,,98867,1225
 New Mexico,Bernalillo County,2005,592570,10408.0,42540,553
 New Mexico,Bernalillo County,2006,615099,9750.0,43717,572
 New Mexico,Bernalillo County,2007,629292,11342.0,44952,599
@@ -7129,7 +7129,7 @@ New Mexico,Bernalillo County,2018,678701,16586.0,51208,764
 New Mexico,Bernalillo County,2019,679121,13605.0,56115,812
 New Mexico,Bernalillo County,2021,674393,59915.0,59640,836
 New Mexico,Bernalillo County,2022,672508,48381.0,65075,914
-New Mexico,Dona Ana County,2005,184089,0.0,29630,439
+New Mexico,Dona Ana County,2005,184089,,29630,439
 New Mexico,Dona Ana County,2006,193888,2811.0,33952,476
 New Mexico,Dona Ana County,2007,198791,4360.0,35334,484
 New Mexico,Dona Ana County,2008,201603,3085.0,36035,553
@@ -7138,7 +7138,7 @@ New Mexico,Do?a Ana County,2010,210538,3739.0,35230,553
 New Mexico,Do?a Ana County,2011,213598,2483.0,36101,540
 New Mexico,Doña Ana County,2012,214445,4736.0,37566,585
 New Mexico,Doña Ana County,2013,213460,2582.0,36343,562
-New Mexico,Doña Ana County,2014,213676,0.0,39502,613
+New Mexico,Doña Ana County,2014,213676,,39502,613
 New Mexico,Doña Ana County,2015,214295,2848.0,39902,619
 New Mexico,Doña Ana County,2016,214207,4206.0,37496,621
 New Mexico,Doña Ana County,2017,215579,4777.0,37144,591
@@ -7146,46 +7146,46 @@ New Mexico,Doña Ana County,2018,217522,3475.0,35262,568
 New Mexico,Doña Ana County,2019,218195,4551.0,43038,656
 New Mexico,Doña Ana County,2021,221508,9858.0,45178,642
 New Mexico,Doña Ana County,2022,223337,8102.0,51967,684
-New Mexico,Lea County,2011,65423,0.0,50758,547
-New Mexico,Lea County,2012,66338,0.0,51504,564
-New Mexico,Lea County,2013,68062,0.0,56191,671
-New Mexico,Lea County,2014,69999,0.0,61351,637
-New Mexico,Lea County,2015,71180,0.0,56260,695
-New Mexico,Lea County,2016,69749,0.0,55636,695
-New Mexico,Lea County,2017,68759,0.0,55952,640
-New Mexico,Lea County,2018,69611,0.0,50871,737
-New Mexico,Lea County,2019,71070,0.0,68457,903
-New Mexico,Lea County,2021,73004,0.0,50725,904
-New Mexico,Lea County,2022,72452,0.0,58150,759
-New Mexico,McKinley County,2005,71059,0.0,28721,312
-New Mexico,McKinley County,2006,71875,0.0,27261,316
-New Mexico,McKinley County,2007,70059,0.0,42558,257
-New Mexico,McKinley County,2008,70724,0.0,30899,369
-New Mexico,McKinley County,2009,70513,0.0,34948,282
-New Mexico,McKinley County,2010,71797,0.0,29369,367
-New Mexico,McKinley County,2011,73664,0.0,28983,374
-New Mexico,McKinley County,2012,73016,0.0,29696,370
-New Mexico,McKinley County,2013,73308,0.0,24945,426
-New Mexico,McKinley County,2014,74098,0.0,27041,415
-New Mexico,McKinley County,2015,76708,0.0,28212,583
-New Mexico,McKinley County,2016,74923,0.0,31526,588
+New Mexico,Lea County,2011,65423,,50758,547
+New Mexico,Lea County,2012,66338,,51504,564
+New Mexico,Lea County,2013,68062,,56191,671
+New Mexico,Lea County,2014,69999,,61351,637
+New Mexico,Lea County,2015,71180,,56260,695
+New Mexico,Lea County,2016,69749,,55636,695
+New Mexico,Lea County,2017,68759,,55952,640
+New Mexico,Lea County,2018,69611,,50871,737
+New Mexico,Lea County,2019,71070,,68457,903
+New Mexico,Lea County,2021,73004,,50725,904
+New Mexico,Lea County,2022,72452,,58150,759
+New Mexico,McKinley County,2005,71059,,28721,312
+New Mexico,McKinley County,2006,71875,,27261,316
+New Mexico,McKinley County,2007,70059,,42558,257
+New Mexico,McKinley County,2008,70724,,30899,369
+New Mexico,McKinley County,2009,70513,,34948,282
+New Mexico,McKinley County,2010,71797,,29369,367
+New Mexico,McKinley County,2011,73664,,28983,374
+New Mexico,McKinley County,2012,73016,,29696,370
+New Mexico,McKinley County,2013,73308,,24945,426
+New Mexico,McKinley County,2014,74098,,27041,415
+New Mexico,McKinley County,2015,76708,,28212,583
+New Mexico,McKinley County,2016,74923,,31526,588
 New Mexico,McKinley County,2017,72564,2375.0,31565,466
-New Mexico,McKinley County,2018,72290,0.0,34080,520
-New Mexico,McKinley County,2019,71367,0.0,37153,475
-New Mexico,McKinley County,2021,71780,0.0,41643,674
-New Mexico,McKinley County,2022,69830,0.0,45636,588
-New Mexico,Otero County,2011,65703,0.0,35308,522
-New Mexico,Otero County,2012,66041,0.0,40583,627
-New Mexico,Otero County,2013,65616,0.0,44102,752
-New Mexico,Otero County,2014,65082,0.0,42603,700
-New Mexico,Otero County,2015,64362,0.0,36142,558
-New Mexico,Otero County,2016,65410,0.0,43646,700
-New Mexico,Otero County,2017,65817,0.0,43887,568
-New Mexico,Otero County,2018,66781,0.0,42591,735
-New Mexico,Otero County,2019,67490,0.0,39371,605
-New Mexico,Otero County,2021,68537,0.0,51214,672
-New Mexico,Otero County,2022,68823,0.0,54093,674
-New Mexico,Sandoval County,2005,106765,0.0,47330,709
+New Mexico,McKinley County,2018,72290,,34080,520
+New Mexico,McKinley County,2019,71367,,37153,475
+New Mexico,McKinley County,2021,71780,,41643,674
+New Mexico,McKinley County,2022,69830,,45636,588
+New Mexico,Otero County,2011,65703,,35308,522
+New Mexico,Otero County,2012,66041,,40583,627
+New Mexico,Otero County,2013,65616,,44102,752
+New Mexico,Otero County,2014,65082,,42603,700
+New Mexico,Otero County,2015,64362,,36142,558
+New Mexico,Otero County,2016,65410,,43646,700
+New Mexico,Otero County,2017,65817,,43887,568
+New Mexico,Otero County,2018,66781,,42591,735
+New Mexico,Otero County,2019,67490,,39371,605
+New Mexico,Otero County,2021,68537,,51214,672
+New Mexico,Otero County,2022,68823,,54093,674
+New Mexico,Sandoval County,2005,106765,,47330,709
 New Mexico,Sandoval County,2006,113772,3122.0,54747,722
 New Mexico,Sandoval County,2007,117866,3212.0,55089,720
 New Mexico,Sandoval County,2008,122298,2202.0,56411,765
@@ -7193,32 +7193,32 @@ New Mexico,Sandoval County,2009,125988,3882.0,59326,807
 New Mexico,Sandoval County,2010,132330,2894.0,51959,820
 New Mexico,Sandoval County,2011,134259,3889.0,53214,771
 New Mexico,Sandoval County,2012,135588,3061.0,57754,859
-New Mexico,Sandoval County,2013,136575,0.0,55825,838
-New Mexico,Sandoval County,2014,137608,0.0,55398,818
-New Mexico,Sandoval County,2015,139394,0.0,63598,950
+New Mexico,Sandoval County,2013,136575,,55825,838
+New Mexico,Sandoval County,2014,137608,,55398,818
+New Mexico,Sandoval County,2015,139394,,63598,950
 New Mexico,Sandoval County,2016,142025,3647.0,57158,852
 New Mexico,Sandoval County,2017,142507,3888.0,54296,895
-New Mexico,Sandoval County,2018,145179,0.0,54338,865
+New Mexico,Sandoval County,2018,145179,,54338,865
 New Mexico,Sandoval County,2019,146748,4138.0,71997,998
-New Mexico,Sandoval County,2021,151369,0.0,72151,967
-New Mexico,Sandoval County,2022,153501,0.0,83639,1156
-New Mexico,San Juan County,2005,124994,0.0,36047,501
-New Mexico,San Juan County,2006,126473,0.0,40517,481
-New Mexico,San Juan County,2007,122427,0.0,43690,519
-New Mexico,San Juan County,2008,122500,0.0,47096,518
-New Mexico,San Juan County,2009,124131,0.0,47075,539
-New Mexico,San Juan County,2010,130145,0.0,45127,597
-New Mexico,San Juan County,2011,128200,0.0,51728,606
+New Mexico,Sandoval County,2021,151369,,72151,967
+New Mexico,Sandoval County,2022,153501,,83639,1156
+New Mexico,San Juan County,2005,124994,,36047,501
+New Mexico,San Juan County,2006,126473,,40517,481
+New Mexico,San Juan County,2007,122427,,43690,519
+New Mexico,San Juan County,2008,122500,,47096,518
+New Mexico,San Juan County,2009,124131,,47075,539
+New Mexico,San Juan County,2010,130145,,45127,597
+New Mexico,San Juan County,2011,128200,,51728,606
 New Mexico,San Juan County,2012,128529,1343.0,46385,589
-New Mexico,San Juan County,2013,126503,0.0,43787,603
+New Mexico,San Juan County,2013,126503,,43787,603
 New Mexico,San Juan County,2014,123785,1295.0,48773,610
 New Mexico,San Juan County,2015,118737,1867.0,49613,643
-New Mexico,San Juan County,2016,115079,0.0,52003,660
-New Mexico,San Juan County,2017,126926,0.0,45942,647
-New Mexico,San Juan County,2018,125043,0.0,44841,707
-New Mexico,San Juan County,2019,123958,0.0,44321,651
-New Mexico,San Juan County,2021,120993,0.0,47819,706
-New Mexico,San Juan County,2022,120418,0.0,50264,647
+New Mexico,San Juan County,2016,115079,,52003,660
+New Mexico,San Juan County,2017,126926,,45942,647
+New Mexico,San Juan County,2018,125043,,44841,707
+New Mexico,San Juan County,2019,123958,,44321,651
+New Mexico,San Juan County,2021,120993,,47819,706
+New Mexico,San Juan County,2022,120418,,50264,647
 New Mexico,Santa Fe County,2005,137758,4704.0,45304,716
 New Mexico,Santa Fe County,2006,142407,7123.0,50437,764
 New Mexico,Santa Fe County,2007,142955,7146.0,51413,771
@@ -7236,24 +7236,24 @@ New Mexico,Santa Fe County,2018,150056,6783.0,60193,928
 New Mexico,Santa Fe County,2019,150358,6351.0,61298,891
 New Mexico,Santa Fe County,2021,155201,16962.0,67341,975
 New Mexico,Santa Fe County,2022,155664,14071.0,72544,1146
-New Mexico,Valencia County,2005,67135,0.0,40379,518
-New Mexico,Valencia County,2006,68427,0.0,41753,574
-New Mexico,Valencia County,2007,67998,0.0,35649,484
-New Mexico,Valencia County,2008,67893,0.0,41596,548
-New Mexico,Valencia County,2009,72913,0.0,41853,503
-New Mexico,Valencia County,2010,76759,0.0,39241,527
-New Mexico,Valencia County,2011,77070,0.0,42802,609
-New Mexico,Valencia County,2012,76631,0.0,38243,577
-New Mexico,Valencia County,2013,76284,0.0,40075,604
-New Mexico,Valencia County,2014,75817,0.0,37628,587
-New Mexico,Valencia County,2015,75737,0.0,42092,661
-New Mexico,Valencia County,2016,75626,0.0,43700,641
-New Mexico,Valencia County,2017,75940,0.0,47409,683
-New Mexico,Valencia County,2018,76456,0.0,46493,603
-New Mexico,Valencia County,2019,76688,0.0,60601,745
-New Mexico,Valencia County,2021,77190,0.0,48188,702
-New Mexico,Valencia County,2022,78080,0.0,48638,690
-New York,Albany County,2005,280570,0.0,50054,611
+New Mexico,Valencia County,2005,67135,,40379,518
+New Mexico,Valencia County,2006,68427,,41753,574
+New Mexico,Valencia County,2007,67998,,35649,484
+New Mexico,Valencia County,2008,67893,,41596,548
+New Mexico,Valencia County,2009,72913,,41853,503
+New Mexico,Valencia County,2010,76759,,39241,527
+New Mexico,Valencia County,2011,77070,,42802,609
+New Mexico,Valencia County,2012,76631,,38243,577
+New Mexico,Valencia County,2013,76284,,40075,604
+New Mexico,Valencia County,2014,75817,,37628,587
+New Mexico,Valencia County,2015,75737,,42092,661
+New Mexico,Valencia County,2016,75626,,43700,641
+New Mexico,Valencia County,2017,75940,,47409,683
+New Mexico,Valencia County,2018,76456,,46493,603
+New Mexico,Valencia County,2019,76688,,60601,745
+New Mexico,Valencia County,2021,77190,,48188,702
+New Mexico,Valencia County,2022,78080,,48638,690
+New York,Albany County,2005,280570,,50054,611
 New York,Albany County,2006,297556,4036.0,51042,631
 New York,Albany County,2007,299307,4844.0,53012,672
 New York,Albany County,2008,298130,6727.0,60156,694
@@ -7287,7 +7287,7 @@ New York,Bronx County,2018,1432132,19619.0,38467,1088
 New York,Bronx County,2019,1418207,15549.0,41432,1122
 New York,Bronx County,2021,1424948,62426.0,43011,1174
 New York,Bronx County,2022,1379946,42453.0,45517,1203
-New York,Broome County,2005,186680,0.0,36394,438
+New York,Broome County,2005,186680,,36394,438
 New York,Broome County,2006,196269,3792.0,41545,443
 New York,Broome County,2007,195973,3367.0,44017,479
 New York,Broome County,2008,195018,4534.0,42574,507
@@ -7304,91 +7304,91 @@ New York,Broome County,2018,191659,2713.0,51125,656
 New York,Broome County,2019,190488,2342.0,52010,676
 New York,Broome County,2021,197240,11369.0,55591,718
 New York,Broome County,2022,197117,7657.0,60616,743
-New York,Cattaraugus County,2005,79201,0.0,37580,387
-New York,Cattaraugus County,2006,81534,0.0,39066,385
-New York,Cattaraugus County,2007,80087,0.0,41060,416
+New York,Cattaraugus County,2005,79201,,37580,387
+New York,Cattaraugus County,2006,81534,,39066,385
+New York,Cattaraugus County,2007,80087,,41060,416
 New York,Cattaraugus County,2008,79688,1133.0,43495,420
-New York,Cattaraugus County,2009,79689,0.0,38551,409
+New York,Cattaraugus County,2009,79689,,38551,409
 New York,Cattaraugus County,2010,80229,1297.0,41578,434
 New York,Cattaraugus County,2011,79832,1235.0,38932,448
-New York,Cattaraugus County,2012,79458,0.0,43468,462
+New York,Cattaraugus County,2012,79458,,43468,462
 New York,Cattaraugus County,2013,78892,984.0,40362,448
-New York,Cattaraugus County,2014,78600,0.0,44320,469
-New York,Cattaraugus County,2015,77922,0.0,40016,472
-New York,Cattaraugus County,2016,77677,0.0,46842,500
-New York,Cattaraugus County,2017,77348,0.0,48484,494
-New York,Cattaraugus County,2018,76840,0.0,48179,518
-New York,Cattaraugus County,2019,76117,0.0,50912,558
-New York,Cattaraugus County,2021,76426,0.0,55153,541
+New York,Cattaraugus County,2014,78600,,44320,469
+New York,Cattaraugus County,2015,77922,,40016,472
+New York,Cattaraugus County,2016,77677,,46842,500
+New York,Cattaraugus County,2017,77348,,48484,494
+New York,Cattaraugus County,2018,76840,,48179,518
+New York,Cattaraugus County,2019,76117,,50912,558
+New York,Cattaraugus County,2021,76426,,55153,541
 New York,Cattaraugus County,2022,76439,2183.0,50508,564
-New York,Cayuga County,2005,77016,0.0,42057,439
-New York,Cayuga County,2006,81243,0.0,45139,436
-New York,Cayuga County,2007,80066,0.0,45595,475
-New York,Cayuga County,2008,79823,0.0,48495,450
-New York,Cayuga County,2009,79526,0.0,49543,528
-New York,Cayuga County,2010,79978,0.0,49136,484
-New York,Cayuga County,2011,79738,0.0,49256,492
-New York,Cayuga County,2012,79552,0.0,50073,522
-New York,Cayuga County,2013,79477,0.0,50154,562
-New York,Cayuga County,2014,78823,0.0,53780,563
-New York,Cayuga County,2015,78288,0.0,53146,580
-New York,Cayuga County,2016,77861,0.0,54995,614
-New York,Cayuga County,2017,77603,0.0,56599,644
-New York,Cayuga County,2018,77145,0.0,52376,639
-New York,Cayuga County,2019,76576,0.0,58665,656
-New York,Cayuga County,2021,75880,0.0,63511,695
-New York,Cayuga County,2022,74998,0.0,64031,723
-New York,Chautauqua County,2005,129887,0.0,35495,361
+New York,Cayuga County,2005,77016,,42057,439
+New York,Cayuga County,2006,81243,,45139,436
+New York,Cayuga County,2007,80066,,45595,475
+New York,Cayuga County,2008,79823,,48495,450
+New York,Cayuga County,2009,79526,,49543,528
+New York,Cayuga County,2010,79978,,49136,484
+New York,Cayuga County,2011,79738,,49256,492
+New York,Cayuga County,2012,79552,,50073,522
+New York,Cayuga County,2013,79477,,50154,562
+New York,Cayuga County,2014,78823,,53780,563
+New York,Cayuga County,2015,78288,,53146,580
+New York,Cayuga County,2016,77861,,54995,614
+New York,Cayuga County,2017,77603,,56599,644
+New York,Cayuga County,2018,77145,,52376,639
+New York,Cayuga County,2019,76576,,58665,656
+New York,Cayuga County,2021,75880,,63511,695
+New York,Cayuga County,2022,74998,,64031,723
+New York,Chautauqua County,2005,129887,,35495,361
 New York,Chautauqua County,2006,135357,2407.0,37950,416
 New York,Chautauqua County,2007,133945,1846.0,38942,399
-New York,Chautauqua County,2008,133789,0.0,39904,415
+New York,Chautauqua County,2008,133789,,39904,415
 New York,Chautauqua County,2009,133503,2256.0,37849,451
 New York,Chautauqua County,2010,134768,2060.0,40443,423
-New York,Chautauqua County,2011,134368,0.0,40927,464
-New York,Chautauqua County,2012,133539,0.0,41376,480
-New York,Chautauqua County,2013,133080,0.0,40413,453
+New York,Chautauqua County,2011,134368,,40927,464
+New York,Chautauqua County,2012,133539,,41376,480
+New York,Chautauqua County,2013,133080,,40413,453
 New York,Chautauqua County,2014,132053,2090.0,41808,469
-New York,Chautauqua County,2015,130779,0.0,44460,481
+New York,Chautauqua County,2015,130779,,44460,481
 New York,Chautauqua County,2016,129504,2476.0,42204,522
 New York,Chautauqua County,2017,129046,1991.0,46079,534
 New York,Chautauqua County,2018,127939,2503.0,45479,541
 New York,Chautauqua County,2019,126903,1377.0,50272,533
-New York,Chautauqua County,2021,126807,0.0,46661,559
+New York,Chautauqua County,2021,126807,,46661,559
 New York,Chautauqua County,2022,126027,4355.0,55457,609
-New York,Chemung County,2005,84117,0.0,37418,435
-New York,Chemung County,2006,88641,0.0,39683,459
-New York,Chemung County,2007,88015,0.0,39836,482
-New York,Chemung County,2008,87813,0.0,41607,468
-New York,Chemung County,2009,88331,0.0,43727,531
-New York,Chemung County,2010,88824,0.0,47643,539
-New York,Chemung County,2011,88840,0.0,50120,557
-New York,Chemung County,2012,88911,0.0,45974,547
-New York,Chemung County,2013,88506,0.0,45237,584
-New York,Chemung County,2014,87770,0.0,50232,653
+New York,Chemung County,2005,84117,,37418,435
+New York,Chemung County,2006,88641,,39683,459
+New York,Chemung County,2007,88015,,39836,482
+New York,Chemung County,2008,87813,,41607,468
+New York,Chemung County,2009,88331,,43727,531
+New York,Chemung County,2010,88824,,47643,539
+New York,Chemung County,2011,88840,,50120,557
+New York,Chemung County,2012,88911,,45974,547
+New York,Chemung County,2013,88506,,45237,584
+New York,Chemung County,2014,87770,,50232,653
 New York,Chemung County,2015,87071,829.0,53119,637
-New York,Chemung County,2016,86322,0.0,51269,638
-New York,Chemung County,2017,85557,0.0,51194,700
-New York,Chemung County,2018,84254,0.0,53005,655
+New York,Chemung County,2016,86322,,51269,638
+New York,Chemung County,2017,85557,,51194,700
+New York,Chemung County,2018,84254,,53005,655
 New York,Chemung County,2019,83456,940.0,60782,641
-New York,Chemung County,2021,83045,0.0,60219,712
-New York,Chemung County,2022,81426,0.0,55845,764
-New York,Clinton County,2005,75053,0.0,44757,507
-New York,Clinton County,2006,82166,0.0,42406,511
-New York,Clinton County,2007,82215,0.0,46439,498
+New York,Chemung County,2021,83045,,60219,712
+New York,Chemung County,2022,81426,,55845,764
+New York,Clinton County,2005,75053,,44757,507
+New York,Clinton County,2006,82166,,42406,511
+New York,Clinton County,2007,82215,,46439,498
 New York,Clinton County,2008,81947,1645.0,50960,538
-New York,Clinton County,2009,81618,0.0,46660,573
-New York,Clinton County,2010,82115,0.0,43600,571
+New York,Clinton County,2009,81618,,46660,573
+New York,Clinton County,2010,82115,,43600,571
 New York,Clinton County,2011,81945,1163.0,50872,630
-New York,Clinton County,2012,81654,0.0,52161,621
-New York,Clinton County,2013,81591,0.0,43892,633
-New York,Clinton County,2014,81632,0.0,53575,653
-New York,Clinton County,2015,81251,0.0,45377,670
-New York,Clinton County,2016,81073,0.0,55316,662
+New York,Clinton County,2012,81654,,52161,621
+New York,Clinton County,2013,81591,,43892,633
+New York,Clinton County,2014,81632,,53575,653
+New York,Clinton County,2015,81251,,45377,670
+New York,Clinton County,2016,81073,,55316,662
 New York,Clinton County,2017,80980,1217.0,58234,675
-New York,Clinton County,2018,80695,0.0,56704,713
-New York,Clinton County,2019,80485,0.0,60198,689
-New York,Clinton County,2021,79596,0.0,60285,763
-New York,Clinton County,2022,78753,0.0,66152,774
+New York,Clinton County,2018,80695,,56704,713
+New York,Clinton County,2019,80485,,60198,689
+New York,Clinton County,2021,79596,,60285,763
+New York,Clinton County,2022,78753,,66152,774
 New York,Dutchess County,2005,276889,5541.0,61889,842
 New York,Dutchess County,2006,295146,5602.0,65965,840
 New York,Dutchess County,2007,292746,6596.0,66135,888
@@ -7423,23 +7423,23 @@ New York,Erie County,2018,919719,16360.0,56369,712
 New York,Erie County,2019,918702,15789.0,60652,752
 New York,Erie County,2021,950683,67278.0,63035,804
 New York,Erie County,2022,950312,62493.0,70044,872
-New York,Jefferson County,2005,107710,0.0,41011,442
-New York,Jefferson County,2006,114264,0.0,38195,461
-New York,Jefferson County,2007,117201,0.0,43725,488
-New York,Jefferson County,2008,118046,0.0,45465,534
-New York,Jefferson County,2009,118719,0.0,43080,623
-New York,Jefferson County,2010,116582,0.0,43557,664
-New York,Jefferson County,2011,117910,0.0,45500,728
+New York,Jefferson County,2005,107710,,41011,442
+New York,Jefferson County,2006,114264,,38195,461
+New York,Jefferson County,2007,117201,,43725,488
+New York,Jefferson County,2008,118046,,45465,534
+New York,Jefferson County,2009,118719,,43080,623
+New York,Jefferson County,2010,116582,,43557,664
+New York,Jefferson County,2011,117910,,45500,728
 New York,Jefferson County,2012,120262,1742.0,46558,726
-New York,Jefferson County,2013,119504,0.0,46683,770
-New York,Jefferson County,2014,119103,0.0,51086,784
-New York,Jefferson County,2015,117635,0.0,51107,767
-New York,Jefferson County,2016,114006,0.0,45624,814
-New York,Jefferson County,2017,114187,0.0,47101,855
-New York,Jefferson County,2018,111755,0.0,53146,824
+New York,Jefferson County,2013,119504,,46683,770
+New York,Jefferson County,2014,119103,,51086,784
+New York,Jefferson County,2015,117635,,51107,767
+New York,Jefferson County,2016,114006,,45624,814
+New York,Jefferson County,2017,114187,,47101,855
+New York,Jefferson County,2018,111755,,53146,824
 New York,Jefferson County,2019,109834,2736.0,53917,880
-New York,Jefferson County,2021,116295,0.0,60398,889
-New York,Jefferson County,2022,116637,0.0,56423,1046
+New York,Jefferson County,2021,116295,,60398,889
+New York,Jefferson County,2022,116637,,56423,1046
 New York,Kings County,2005,2446016,32984.0,37332,788
 New York,Kings County,2006,2508820,34513.0,40393,817
 New York,Kings County,2007,2528050,37860.0,41406,856
@@ -7457,23 +7457,23 @@ New York,Kings County,2018,2582830,56179.0,61220,1331
 New York,Kings County,2019,2559903,58837.0,66937,1389
 New York,Kings County,2021,2641052,325362.0,67567,1525
 New York,Kings County,2022,2590516,229179.0,73951,1578
-New York,Madison County,2005,65407,0.0,45298,470
-New York,Madison County,2006,70197,0.0,47841,491
-New York,Madison County,2007,69829,0.0,53601,512
+New York,Madison County,2005,65407,,45298,470
+New York,Madison County,2006,70197,,47841,491
+New York,Madison County,2007,69829,,53601,512
 New York,Madison County,2008,69766,1588.0,51166,525
-New York,Madison County,2009,69954,0.0,52717,544
-New York,Madison County,2010,73439,0.0,53006,560
-New York,Madison County,2011,73365,0.0,50173,526
-New York,Madison County,2012,72382,0.0,47989,591
-New York,Madison County,2013,72382,0.0,52300,539
-New York,Madison County,2014,72369,0.0,51873,614
-New York,Madison County,2015,71849,0.0,60286,614
-New York,Madison County,2016,71329,0.0,60630,563
-New York,Madison County,2017,70965,0.0,57069,627
-New York,Madison County,2018,70795,0.0,59678,623
-New York,Madison County,2019,70941,0.0,62918,733
-New York,Madison County,2021,67658,0.0,67495,670
-New York,Madison County,2022,67097,0.0,69986,763
+New York,Madison County,2009,69954,,52717,544
+New York,Madison County,2010,73439,,53006,560
+New York,Madison County,2011,73365,,50173,526
+New York,Madison County,2012,72382,,47989,591
+New York,Madison County,2013,72382,,52300,539
+New York,Madison County,2014,72369,,51873,614
+New York,Madison County,2015,71849,,60286,614
+New York,Madison County,2016,71329,,60630,563
+New York,Madison County,2017,70965,,57069,627
+New York,Madison County,2018,70795,,59678,623
+New York,Madison County,2019,70941,,62918,733
+New York,Madison County,2021,67658,,67495,670
+New York,Madison County,2022,67097,,69986,763
 New York,Monroe County,2005,704993,7925.0,45748,594
 New York,Monroe County,2006,730807,9353.0,47339,602
 New York,Monroe County,2007,729681,10047.0,49967,620
@@ -7525,7 +7525,7 @@ New York,New York County,2018,1628701,65548.0,85066,1673
 New York,New York County,2019,1628706,69449.0,93651,1679
 New York,New York County,2021,1576876,289199.0,84435,1789
 New York,New York County,2022,1596273,210805.0,95866,1929
-New York,Niagara County,2005,212573,0.0,44172,444
+New York,Niagara County,2005,212573,,44172,444
 New York,Niagara County,2006,216130,2072.0,44197,444
 New York,Niagara County,2007,214845,2863.0,44027,445
 New York,Niagara County,2008,214464,2175.0,45575,473
@@ -7542,7 +7542,7 @@ New York,Niagara County,2018,210433,2772.0,55306,578
 New York,Niagara County,2019,209281,3501.0,56304,589
 New York,Niagara County,2021,211653,10248.0,61340,660
 New York,Niagara County,2022,210880,9637.0,63441,681
-New York,Oneida County,2005,219249,0.0,37658,426
+New York,Oneida County,2005,219249,,37658,426
 New York,Oneida County,2006,233954,3897.0,40466,438
 New York,Oneida County,2007,232304,3583.0,44636,463
 New York,Oneida County,2008,231590,4419.0,45572,478
@@ -7576,23 +7576,23 @@ New York,Onondaga County,2018,461809,9980.0,59883,763
 New York,Onondaga County,2019,460528,10728.0,61577,777
 New York,Onondaga County,2021,473236,32155.0,65541,832
 New York,Onondaga County,2022,468249,29549.0,70968,863
-New York,Ontario County,2005,101340,0.0,47242,530
+New York,Ontario County,2005,101340,,47242,530
 New York,Ontario County,2006,104353,2263.0,51237,576
-New York,Ontario County,2007,103956,0.0,54531,564
-New York,Ontario County,2008,104475,0.0,56049,595
-New York,Ontario County,2009,105650,0.0,52875,589
+New York,Ontario County,2007,103956,,54531,564
+New York,Ontario County,2008,104475,,56049,595
+New York,Ontario County,2009,105650,,52875,589
 New York,Ontario County,2010,108116,2534.0,53567,610
-New York,Ontario County,2011,108525,0.0,52162,642
-New York,Ontario County,2012,108519,0.0,52338,668
+New York,Ontario County,2011,108525,,52162,642
+New York,Ontario County,2012,108519,,52338,668
 New York,Ontario County,2013,109103,2421.0,58165,680
-New York,Ontario County,2014,109707,0.0,59093,669
-New York,Ontario County,2015,109561,0.0,57711,733
-New York,Ontario County,2016,109828,0.0,57448,719
-New York,Ontario County,2017,109899,0.0,66004,726
-New York,Ontario County,2018,109864,0.0,62522,780
-New York,Ontario County,2019,109777,0.0,66568,766
+New York,Ontario County,2014,109707,,59093,669
+New York,Ontario County,2015,109561,,57711,733
+New York,Ontario County,2016,109828,,57448,719
+New York,Ontario County,2017,109899,,66004,726
+New York,Ontario County,2018,109864,,62522,780
+New York,Ontario County,2019,109777,,66568,766
 New York,Ontario County,2021,112508,7049.0,77972,894
-New York,Ontario County,2022,112707,0.0,76424,838
+New York,Ontario County,2022,112707,,76424,838
 New York,Orange County,2005,359089,4147.0,62951,799
 New York,Orange County,2006,376392,9017.0,64947,796
 New York,Orange County,2007,377169,9108.0,65775,848
@@ -7610,40 +7610,40 @@ New York,Orange County,2018,381951,9286.0,75825,1098
 New York,Orange County,2019,384940,10695.0,84458,1154
 New York,Orange County,2021,404525,29176.0,90405,1232
 New York,Orange County,2022,405941,22052.0,89037,1351
-New York,Oswego County,2005,118560,0.0,42731,440
-New York,Oswego County,2006,123077,0.0,38264,467
-New York,Oswego County,2007,121454,0.0,45446,483
+New York,Oswego County,2005,118560,,42731,440
+New York,Oswego County,2006,123077,,38264,467
+New York,Oswego County,2007,121454,,45446,483
 New York,Oswego County,2008,121395,1040.0,42072,492
 New York,Oswego County,2009,121377,2286.0,47082,496
-New York,Oswego County,2010,122114,0.0,44643,500
-New York,Oswego County,2011,122228,0.0,43372,535
-New York,Oswego County,2012,121700,0.0,46961,546
-New York,Oswego County,2013,121165,0.0,46533,555
-New York,Oswego County,2014,120913,0.0,47013,543
-New York,Oswego County,2015,120146,0.0,49767,578
+New York,Oswego County,2010,122114,,44643,500
+New York,Oswego County,2011,122228,,43372,535
+New York,Oswego County,2012,121700,,46961,546
+New York,Oswego County,2013,121165,,46533,555
+New York,Oswego County,2014,120913,,47013,543
+New York,Oswego County,2015,120146,,49767,578
 New York,Oswego County,2016,118987,1682.0,53562,605
-New York,Oswego County,2017,118478,0.0,53406,611
-New York,Oswego County,2018,117898,0.0,54264,630
-New York,Oswego County,2019,117124,0.0,58459,656
-New York,Oswego County,2021,117387,0.0,59423,719
+New York,Oswego County,2017,118478,,53406,611
+New York,Oswego County,2018,117898,,54264,630
+New York,Oswego County,2019,117124,,58459,656
+New York,Oswego County,2021,117387,,59423,719
 New York,Oswego County,2022,118287,3770.0,58984,678
-New York,Putnam County,2005,98303,0.0,81076,1108
-New York,Putnam County,2006,100603,0.0,81907,936
+New York,Putnam County,2005,98303,,81076,1108
+New York,Putnam County,2006,100603,,81907,936
 New York,Putnam County,2007,99489,2435.0,84624,1127
 New York,Putnam County,2008,99244,2732.0,89928,1087
 New York,Putnam County,2009,99265,2016.0,82121,1137
-New York,Putnam County,2010,99713,0.0,81233,1067
+New York,Putnam County,2010,99713,,81233,1067
 New York,Putnam County,2011,99933,2104.0,90735,1069
-New York,Putnam County,2012,99607,0.0,96223,1178
-New York,Putnam County,2013,99645,0.0,93746,1113
-New York,Putnam County,2014,99487,0.0,97483,1093
-New York,Putnam County,2015,99042,0.0,90538,1157
-New York,Putnam County,2016,98900,0.0,96992,1235
-New York,Putnam County,2017,99323,0.0,99479,1290
-New York,Putnam County,2018,98892,0.0,102525,1229
-New York,Putnam County,2019,98320,0.0,106204,1599
+New York,Putnam County,2012,99607,,96223,1178
+New York,Putnam County,2013,99645,,93746,1113
+New York,Putnam County,2014,99487,,97483,1093
+New York,Putnam County,2015,99042,,90538,1157
+New York,Putnam County,2016,98900,,96992,1235
+New York,Putnam County,2017,99323,,99479,1290
+New York,Putnam County,2018,98892,,102525,1229
+New York,Putnam County,2019,98320,,106204,1599
 New York,Putnam County,2021,97936,7426.0,106871,1532
-New York,Putnam County,2022,98045,0.0,111102,1681
+New York,Putnam County,2022,98045,,111102,1681
 New York,Queens County,2005,2215339,25459.0,48093,942
 New York,Queens County,2006,2255175,29615.0,51190,983
 New York,Queens County,2007,2270338,26844.0,53171,1007
@@ -7661,22 +7661,22 @@ New York,Queens County,2018,2278906,32088.0,69320,1482
 New York,Queens County,2019,2253858,35527.0,73696,1558
 New York,Queens County,2021,2331143,179285.0,73262,1630
 New York,Queens County,2022,2278029,129055.0,80557,1683
-New York,Rensselaer County,2005,150163,0.0,47689,529
+New York,Rensselaer County,2005,150163,,47689,529
 New York,Rensselaer County,2006,155292,1889.0,53016,565
 New York,Rensselaer County,2007,155318,2859.0,50850,588
 New York,Rensselaer County,2008,155261,2679.0,55069,608
 New York,Rensselaer County,2009,155541,2971.0,55651,672
-New York,Rensselaer County,2010,159428,0.0,51653,669
-New York,Rensselaer County,2011,159395,0.0,58943,684
-New York,Rensselaer County,2012,159835,0.0,60653,712
+New York,Rensselaer County,2010,159428,,51653,669
+New York,Rensselaer County,2011,159395,,58943,684
+New York,Rensselaer County,2012,159835,,60653,712
 New York,Rensselaer County,2013,159918,3223.0,57438,709
 New York,Rensselaer County,2014,159774,2364.0,61457,768
 New York,Rensselaer County,2015,160266,2640.0,60810,731
 New York,Rensselaer County,2016,160070,2625.0,65965,753
-New York,Rensselaer County,2017,159722,0.0,64050,808
+New York,Rensselaer County,2017,159722,,64050,808
 New York,Rensselaer County,2018,159442,3580.0,71648,844
 New York,Rensselaer County,2019,158714,3208.0,71574,894
-New York,Rensselaer County,2021,160232,0.0,75676,881
+New York,Rensselaer County,2021,160232,,75676,881
 New York,Rensselaer County,2022,159853,11590.0,83109,938
 New York,Richmond County,2005,455344,3995.0,63023,864
 New York,Richmond County,2006,477377,6496.0,68620,879
@@ -7712,24 +7712,24 @@ New York,Rockland County,2018,325695,7224.0,89812,1307
 New York,Rockland County,2019,325789,9180.0,100916,1338
 New York,Rockland County,2021,339227,22750.0,99087,1580
 New York,Rockland County,2022,339022,22597.0,100397,1550
-New York,St. Lawrence County,2005,100042,0.0,37542,432
+New York,St. Lawrence County,2005,100042,,37542,432
 New York,St. Lawrence County,2006,111284,1986.0,38566,418
-New York,St. Lawrence County,2007,109809,0.0,39443,423
-New York,St. Lawrence County,2008,109701,0.0,41963,434
-New York,St. Lawrence County,2009,109715,0.0,42654,493
-New York,St. Lawrence County,2010,111894,0.0,40163,529
-New York,St. Lawrence County,2011,111690,0.0,43578,565
+New York,St. Lawrence County,2007,109809,,39443,423
+New York,St. Lawrence County,2008,109701,,41963,434
+New York,St. Lawrence County,2009,109715,,42654,493
+New York,St. Lawrence County,2010,111894,,40163,529
+New York,St. Lawrence County,2011,111690,,43578,565
 New York,St. Lawrence County,2012,112232,1948.0,42010,510
 New York,St. Lawrence County,2013,111963,2001.0,45157,528
-New York,St. Lawrence County,2014,111400,0.0,43758,532
-New York,St. Lawrence County,2015,111007,0.0,42144,612
+New York,St. Lawrence County,2014,111400,,43758,532
+New York,St. Lawrence County,2015,111007,,42144,612
 New York,St. Lawrence County,2016,110038,2199.0,51592,568
 New York,St. Lawrence County,2017,109623,3142.0,50325,632
 New York,St. Lawrence County,2018,108047,1237.0,49681,585
-New York,St. Lawrence County,2019,107740,0.0,52108,591
-New York,St. Lawrence County,2021,108051,0.0,55775,640
-New York,St. Lawrence County,2022,107733,0.0,59683,659
-New York,Saratoga County,2005,210554,0.0,59651,634
+New York,St. Lawrence County,2019,107740,,52108,591
+New York,St. Lawrence County,2021,108051,,55775,640
+New York,St. Lawrence County,2022,107733,,59683,659
+New York,Saratoga County,2005,210554,,59651,634
 New York,Saratoga County,2006,215473,5007.0,57374,672
 New York,Saratoga County,2007,215852,5099.0,62749,676
 New York,Saratoga County,2008,217191,3763.0,64000,723
@@ -7737,40 +7737,40 @@ New York,Saratoga County,2009,220069,6468.0,67906,722
 New York,Saratoga County,2010,219960,4864.0,66212,745
 New York,Saratoga County,2011,220882,5694.0,64250,774
 New York,Saratoga County,2012,222133,5012.0,66757,837
-New York,Saratoga County,2013,223865,0.0,70673,848
+New York,Saratoga County,2013,223865,,70673,848
 New York,Saratoga County,2014,224921,6871.0,72354,844
 New York,Saratoga County,2015,226249,7012.0,75761,890
-New York,Saratoga County,2016,227053,0.0,76097,912
+New York,Saratoga County,2016,227053,,76097,912
 New York,Saratoga County,2017,229869,7878.0,83726,903
-New York,Saratoga County,2018,230163,0.0,83765,993
-New York,Saratoga County,2019,229863,0.0,89932,1064
-New York,Saratoga County,2021,237359,0.0,86804,1066
+New York,Saratoga County,2018,230163,,83765,993
+New York,Saratoga County,2019,229863,,89932,1064
+New York,Saratoga County,2021,237359,,86804,1066
 New York,Saratoga County,2022,238797,21346.0,93301,1096
-New York,Schenectady County,2005,144344,0.0,45212,539
+New York,Schenectady County,2005,144344,,45212,539
 New York,Schenectady County,2006,150440,2443.0,51584,571
-New York,Schenectady County,2007,150818,0.0,54949,611
+New York,Schenectady County,2007,150818,,54949,611
 New York,Schenectady County,2008,151427,1827.0,53788,621
 New York,Schenectady County,2009,152169,2955.0,53400,639
-New York,Schenectady County,2010,154889,0.0,52331,634
-New York,Schenectady County,2011,155058,0.0,52505,679
-New York,Schenectady County,2012,155124,0.0,56293,664
+New York,Schenectady County,2010,154889,,52331,634
+New York,Schenectady County,2011,155058,,52505,679
+New York,Schenectady County,2012,155124,,56293,664
 New York,Schenectady County,2013,155333,2037.0,54293,680
-New York,Schenectady County,2014,155735,0.0,57587,717
+New York,Schenectady County,2014,155735,,57587,717
 New York,Schenectady County,2015,154604,1953.0,61108,729
 New York,Schenectady County,2016,154553,2325.0,58331,765
-New York,Schenectady County,2017,155565,0.0,62514,769
+New York,Schenectady County,2017,155565,,62514,769
 New York,Schenectady County,2018,155350,2900.0,64847,804
-New York,Schenectady County,2019,155299,0.0,65773,839
-New York,Schenectady County,2021,158089,0.0,75284,875
+New York,Schenectady County,2019,155299,,65773,839
+New York,Schenectady County,2021,158089,,75284,875
 New York,Schenectady County,2022,160093,10302.0,74765,915
-New York,Steuben County,2005,97041,0.0,38635,407
+New York,Steuben County,2005,97041,,38635,407
 New York,Steuben County,2006,98236,1964.0,41541,428
 New York,Steuben County,2007,96874,1979.0,41015,430
 New York,Steuben County,2008,96573,1728.0,43397,441
 New York,Steuben County,2009,96552,2048.0,42635,465
-New York,Steuben County,2010,98930,0.0,45995,460
+New York,Steuben County,2010,98930,,45995,460
 New York,Steuben County,2011,99033,1203.0,43457,490
-New York,Steuben County,2012,99063,0.0,46445,484
+New York,Steuben County,2012,99063,,46445,484
 New York,Steuben County,2013,98650,984.0,47046,517
 New York,Steuben County,2014,98394,1895.0,46889,551
 New York,Steuben County,2015,97631,1474.0,47146,519
@@ -7778,7 +7778,7 @@ New York,Steuben County,2016,96940,1171.0,50575,570
 New York,Steuben County,2017,96281,1649.0,50930,568
 New York,Steuben County,2018,95796,1131.0,55569,537
 New York,Steuben County,2019,95379,2617.0,52951,589
-New York,Steuben County,2021,92948,0.0,57378,673
+New York,Steuben County,2021,92948,,57378,673
 New York,Steuben County,2022,92599,3450.0,60204,710
 New York,Suffolk County,2005,1444642,22475.0,77109,1153
 New York,Suffolk County,2006,1469715,22326.0,76847,1175
@@ -7797,37 +7797,37 @@ New York,Suffolk County,2018,1481093,29265.0,100468,1618
 New York,Suffolk County,2019,1476601,29174.0,106228,1677
 New York,Suffolk County,2021,1526344,117239.0,113683,1847
 New York,Suffolk County,2022,1525465,98557.0,119838,1986
-New York,Sullivan County,2005,71914,0.0,48210,578
-New York,Sullivan County,2006,76588,0.0,46789,642
-New York,Sullivan County,2007,76303,0.0,47089,601
-New York,Sullivan County,2008,76189,0.0,46553,623
-New York,Sullivan County,2009,75828,0.0,42781,673
-New York,Sullivan County,2010,77500,0.0,43578,683
+New York,Sullivan County,2005,71914,,48210,578
+New York,Sullivan County,2006,76588,,46789,642
+New York,Sullivan County,2007,76303,,47089,601
+New York,Sullivan County,2008,76189,,46553,623
+New York,Sullivan County,2009,75828,,42781,673
+New York,Sullivan County,2010,77500,,43578,683
 New York,Sullivan County,2011,76900,1701.0,47978,666
-New York,Sullivan County,2012,76793,0.0,46796,711
-New York,Sullivan County,2013,76665,0.0,47805,682
-New York,Sullivan County,2014,75943,0.0,53219,673
+New York,Sullivan County,2012,76793,,46796,711
+New York,Sullivan County,2013,76665,,47805,682
+New York,Sullivan County,2014,75943,,53219,673
 New York,Sullivan County,2015,74877,1196.0,51761,723
-New York,Sullivan County,2016,74801,0.0,50652,707
-New York,Sullivan County,2017,75485,0.0,55309,716
-New York,Sullivan County,2018,75498,0.0,52274,786
-New York,Sullivan County,2019,75432,0.0,60137,699
-New York,Sullivan County,2021,79806,0.0,54276,840
-New York,Sullivan County,2022,79658,0.0,63777,811
-New York,Tompkins County,2005,87080,0.0,43306,680
+New York,Sullivan County,2016,74801,,50652,707
+New York,Sullivan County,2017,75485,,55309,716
+New York,Sullivan County,2018,75498,,52274,786
+New York,Sullivan County,2019,75432,,60137,699
+New York,Sullivan County,2021,79806,,54276,840
+New York,Sullivan County,2022,79658,,63777,811
+New York,Tompkins County,2005,87080,,43306,680
 New York,Tompkins County,2006,100407,2393.0,45534,693
-New York,Tompkins County,2007,101055,0.0,43392,735
+New York,Tompkins County,2007,101055,,43392,735
 New York,Tompkins County,2008,101136,4669.0,48567,736
 New York,Tompkins County,2009,101779,3139.0,45010,777
 New York,Tompkins County,2010,101620,3048.0,52064,784
 New York,Tompkins County,2011,101723,3361.0,51586,851
-New York,Tompkins County,2012,102554,0.0,49930,890
-New York,Tompkins County,2013,103617,0.0,48516,844
-New York,Tompkins County,2014,104691,0.0,52885,928
+New York,Tompkins County,2012,102554,,49930,890
+New York,Tompkins County,2013,103617,,48516,844
+New York,Tompkins County,2014,104691,,52885,928
 New York,Tompkins County,2015,104926,3659.0,58084,1022
 New York,Tompkins County,2016,104871,2802.0,56349,932
-New York,Tompkins County,2017,104802,0.0,56672,1015
-New York,Tompkins County,2018,102793,0.0,57276,1073
+New York,Tompkins County,2017,104802,,56672,1015
+New York,Tompkins County,2018,102793,,57276,1073
 New York,Tompkins County,2019,102180,3755.0,58626,1159
 New York,Tompkins County,2021,105162,11332.0,66441,1203
 New York,Tompkins County,2022,104777,7870.0,74034,1074
@@ -7848,40 +7848,40 @@ New York,Ulster County,2018,178599,8232.0,63889,997
 New York,Ulster County,2019,177573,8554.0,64087,923
 New York,Ulster County,2021,182951,17571.0,78938,1089
 New York,Ulster County,2022,182319,15029.0,80372,1187
-New York,Warren County,2005,64276,0.0,49097,570
-New York,Warren County,2006,66087,0.0,46410,580
-New York,Warren County,2007,66143,0.0,47344,612
-New York,Warren County,2008,65971,0.0,49781,617
-New York,Warren County,2009,66021,0.0,52924,659
-New York,Warren County,2010,65697,0.0,52715,659
-New York,Warren County,2011,65831,0.0,53110,662
-New York,Warren County,2012,65538,0.0,54184,727
-New York,Warren County,2013,65337,0.0,55593,730
-New York,Warren County,2014,64973,0.0,57294,665
-New York,Warren County,2015,64688,0.0,57541,745
-New York,Warren County,2016,64567,0.0,58061,749
-New York,Warren County,2017,64532,0.0,60541,746
-New York,Warren County,2018,64265,0.0,56482,767
-New York,Warren County,2019,63944,0.0,64985,789
-New York,Warren County,2021,65618,0.0,73028,863
-New York,Warren County,2022,65599,0.0,69865,886
-New York,Wayne County,2005,91951,0.0,50085,462
-New York,Wayne County,2006,92889,0.0,47607,473
-New York,Wayne County,2007,91291,0.0,52265,475
+New York,Warren County,2005,64276,,49097,570
+New York,Warren County,2006,66087,,46410,580
+New York,Warren County,2007,66143,,47344,612
+New York,Warren County,2008,65971,,49781,617
+New York,Warren County,2009,66021,,52924,659
+New York,Warren County,2010,65697,,52715,659
+New York,Warren County,2011,65831,,53110,662
+New York,Warren County,2012,65538,,54184,727
+New York,Warren County,2013,65337,,55593,730
+New York,Warren County,2014,64973,,57294,665
+New York,Warren County,2015,64688,,57541,745
+New York,Warren County,2016,64567,,58061,749
+New York,Warren County,2017,64532,,60541,746
+New York,Warren County,2018,64265,,56482,767
+New York,Warren County,2019,63944,,64985,789
+New York,Warren County,2021,65618,,73028,863
+New York,Warren County,2022,65599,,69865,886
+New York,Wayne County,2005,91951,,50085,462
+New York,Wayne County,2006,92889,,47607,473
+New York,Wayne County,2007,91291,,52265,475
 New York,Wayne County,2008,91564,1528.0,55431,509
-New York,Wayne County,2009,91291,0.0,49632,509
-New York,Wayne County,2010,93753,0.0,50363,552
-New York,Wayne County,2011,93436,0.0,52597,530
-New York,Wayne County,2012,92962,0.0,48036,512
-New York,Wayne County,2013,92473,0.0,50242,560
-New York,Wayne County,2014,92051,0.0,45951,607
-New York,Wayne County,2015,91446,0.0,50561,585
-New York,Wayne County,2016,90798,0.0,59538,638
-New York,Wayne County,2017,90670,0.0,51326,566
-New York,Wayne County,2018,90064,0.0,61515,606
-New York,Wayne County,2019,89918,0.0,61730,656
-New York,Wayne County,2021,90923,0.0,64993,652
-New York,Wayne County,2022,91125,0.0,71079,719
+New York,Wayne County,2009,91291,,49632,509
+New York,Wayne County,2010,93753,,50363,552
+New York,Wayne County,2011,93436,,52597,530
+New York,Wayne County,2012,92962,,48036,512
+New York,Wayne County,2013,92473,,50242,560
+New York,Wayne County,2014,92051,,45951,607
+New York,Wayne County,2015,91446,,50561,585
+New York,Wayne County,2016,90798,,59538,638
+New York,Wayne County,2017,90670,,51326,566
+New York,Wayne County,2018,90064,,61515,606
+New York,Wayne County,2019,89918,,61730,656
+New York,Wayne County,2021,90923,,64993,652
+New York,Wayne County,2022,91125,,71079,719
 New York,Westchester County,2005,915916,24560.0,71800,970
 New York,Westchester County,2006,949355,21988.0,75472,1018
 New York,Westchester County,2007,951325,20687.0,77220,1059
@@ -7899,41 +7899,41 @@ New York,Westchester County,2018,967612,25481.0,94811,1368
 New York,Westchester County,2019,967506,27062.0,101908,1476
 New York,Westchester County,2021,997895,130547.0,110705,1604
 New York,Westchester County,2022,990427,87877.0,108144,1629
-North Carolina,Alamance County,2005,136552,0.0,40365,494
+North Carolina,Alamance County,2005,136552,,40365,494
 North Carolina,Alamance County,2006,142661,994.0,40934,506
-North Carolina,Alamance County,2007,145360,0.0,41502,552
-North Carolina,Alamance County,2008,148053,0.0,42822,542
-North Carolina,Alamance County,2009,150358,0.0,42739,556
-North Carolina,Alamance County,2010,151528,0.0,41058,502
-North Carolina,Alamance County,2011,153291,0.0,40699,519
-North Carolina,Alamance County,2012,153920,0.0,39782,534
-North Carolina,Alamance County,2013,154378,0.0,42512,574
+North Carolina,Alamance County,2007,145360,,41502,552
+North Carolina,Alamance County,2008,148053,,42822,542
+North Carolina,Alamance County,2009,150358,,42739,556
+North Carolina,Alamance County,2010,151528,,41058,502
+North Carolina,Alamance County,2011,153291,,40699,519
+North Carolina,Alamance County,2012,153920,,39782,534
+North Carolina,Alamance County,2013,154378,,42512,574
 North Carolina,Alamance County,2014,155792,1880.0,39576,579
-North Carolina,Alamance County,2015,158276,0.0,39541,571
-North Carolina,Alamance County,2016,159688,0.0,45100,559
-North Carolina,Alamance County,2017,162391,0.0,45150,612
-North Carolina,Alamance County,2018,166436,0.0,49979,655
-North Carolina,Alamance County,2019,169509,0.0,58490,643
-North Carolina,Alamance County,2021,173877,0.0,58400,745
-North Carolina,Alamance County,2022,176353,0.0,59919,801
-North Carolina,Brunswick County,2005,88396,0.0,36946,501
-North Carolina,Brunswick County,2006,94945,0.0,46520,535
-North Carolina,Brunswick County,2007,99214,0.0,39668,541
-North Carolina,Brunswick County,2008,103160,0.0,46179,547
-North Carolina,Brunswick County,2009,107062,0.0,44146,665
-North Carolina,Brunswick County,2010,107992,0.0,43884,623
-North Carolina,Brunswick County,2011,110097,0.0,38584,611
-North Carolina,Brunswick County,2012,112257,0.0,49124,652
-North Carolina,Brunswick County,2013,115301,0.0,47334,667
-North Carolina,Brunswick County,2014,118836,0.0,46721,673
-North Carolina,Brunswick County,2015,122765,0.0,46640,644
-North Carolina,Brunswick County,2016,126953,0.0,50692,718
-North Carolina,Brunswick County,2017,130897,0.0,56181,733
-North Carolina,Brunswick County,2018,136744,0.0,60496,898
-North Carolina,Brunswick County,2019,142820,0.0,63668,866
-North Carolina,Brunswick County,2021,144215,0.0,65374,983
-North Carolina,Brunswick County,2022,153064,0.0,72820,1074
-North Carolina,Buncombe County,2005,211759,0.0,40513,534
+North Carolina,Alamance County,2015,158276,,39541,571
+North Carolina,Alamance County,2016,159688,,45100,559
+North Carolina,Alamance County,2017,162391,,45150,612
+North Carolina,Alamance County,2018,166436,,49979,655
+North Carolina,Alamance County,2019,169509,,58490,643
+North Carolina,Alamance County,2021,173877,,58400,745
+North Carolina,Alamance County,2022,176353,,59919,801
+North Carolina,Brunswick County,2005,88396,,36946,501
+North Carolina,Brunswick County,2006,94945,,46520,535
+North Carolina,Brunswick County,2007,99214,,39668,541
+North Carolina,Brunswick County,2008,103160,,46179,547
+North Carolina,Brunswick County,2009,107062,,44146,665
+North Carolina,Brunswick County,2010,107992,,43884,623
+North Carolina,Brunswick County,2011,110097,,38584,611
+North Carolina,Brunswick County,2012,112257,,49124,652
+North Carolina,Brunswick County,2013,115301,,47334,667
+North Carolina,Brunswick County,2014,118836,,46721,673
+North Carolina,Brunswick County,2015,122765,,46640,644
+North Carolina,Brunswick County,2016,126953,,50692,718
+North Carolina,Brunswick County,2017,130897,,56181,733
+North Carolina,Brunswick County,2018,136744,,60496,898
+North Carolina,Brunswick County,2019,142820,,63668,866
+North Carolina,Brunswick County,2021,144215,,65374,983
+North Carolina,Brunswick County,2022,153064,,72820,1074
+North Carolina,Buncombe County,2005,211759,,40513,534
 North Carolina,Buncombe County,2006,222174,5339.0,41735,582
 North Carolina,Buncombe County,2007,226771,5470.0,43462,596
 North Carolina,Buncombe County,2008,229047,7475.0,43640,606
@@ -7950,131 +7950,131 @@ North Carolina,Buncombe County,2018,259103,14938.0,53980,873
 North Carolina,Buncombe County,2019,261191,14358.0,54970,924
 North Carolina,Buncombe County,2021,271534,22763.0,64532,1041
 North Carolina,Buncombe County,2022,273589,25089.0,68019,1097
-North Carolina,Burke County,2005,85727,0.0,32963,403
-North Carolina,Burke County,2006,90054,0.0,37677,419
-North Carolina,Burke County,2007,88975,0.0,33641,423
-North Carolina,Burke County,2008,89361,0.0,35520,431
-North Carolina,Burke County,2009,89548,0.0,35004,425
-North Carolina,Burke County,2010,90771,0.0,38131,464
-North Carolina,Burke County,2011,90904,0.0,36706,434
-North Carolina,Burke County,2012,90505,0.0,37287,417
-North Carolina,Burke County,2013,89842,0.0,33379,451
-North Carolina,Burke County,2014,89486,0.0,37086,452
-North Carolina,Burke County,2015,88842,0.0,42970,469
-North Carolina,Burke County,2016,88851,0.0,40345,475
-North Carolina,Burke County,2017,89293,0.0,40274,499
-North Carolina,Burke County,2018,90382,0.0,43663,499
-North Carolina,Burke County,2019,90485,0.0,47361,510
-North Carolina,Burke County,2021,87611,0.0,55529,555
-North Carolina,Burke County,2022,87881,0.0,62267,545
-North Carolina,Cabarrus County,2005,147939,0.0,49997,529
-North Carolina,Cabarrus County,2006,156395,0.0,49562,535
-North Carolina,Cabarrus County,2007,163262,0.0,50779,582
-North Carolina,Cabarrus County,2008,168740,0.0,56782,562
-North Carolina,Cabarrus County,2009,172223,0.0,51846,603
-North Carolina,Cabarrus County,2010,178588,0.0,48666,586
-North Carolina,Cabarrus County,2011,181468,0.0,48668,617
-North Carolina,Cabarrus County,2012,184498,0.0,55824,626
+North Carolina,Burke County,2005,85727,,32963,403
+North Carolina,Burke County,2006,90054,,37677,419
+North Carolina,Burke County,2007,88975,,33641,423
+North Carolina,Burke County,2008,89361,,35520,431
+North Carolina,Burke County,2009,89548,,35004,425
+North Carolina,Burke County,2010,90771,,38131,464
+North Carolina,Burke County,2011,90904,,36706,434
+North Carolina,Burke County,2012,90505,,37287,417
+North Carolina,Burke County,2013,89842,,33379,451
+North Carolina,Burke County,2014,89486,,37086,452
+North Carolina,Burke County,2015,88842,,42970,469
+North Carolina,Burke County,2016,88851,,40345,475
+North Carolina,Burke County,2017,89293,,40274,499
+North Carolina,Burke County,2018,90382,,43663,499
+North Carolina,Burke County,2019,90485,,47361,510
+North Carolina,Burke County,2021,87611,,55529,555
+North Carolina,Burke County,2022,87881,,62267,545
+North Carolina,Cabarrus County,2005,147939,,49997,529
+North Carolina,Cabarrus County,2006,156395,,49562,535
+North Carolina,Cabarrus County,2007,163262,,50779,582
+North Carolina,Cabarrus County,2008,168740,,56782,562
+North Carolina,Cabarrus County,2009,172223,,51846,603
+North Carolina,Cabarrus County,2010,178588,,48666,586
+North Carolina,Cabarrus County,2011,181468,,48668,617
+North Carolina,Cabarrus County,2012,184498,,55824,626
 North Carolina,Cabarrus County,2013,187226,3007.0,54307,612
 North Carolina,Cabarrus County,2014,192103,5058.0,54347,629
-North Carolina,Cabarrus County,2015,196762,0.0,56853,675
-North Carolina,Cabarrus County,2016,201590,0.0,63386,688
-North Carolina,Cabarrus County,2017,206872,0.0,61490,704
-North Carolina,Cabarrus County,2018,211342,0.0,69679,720
+North Carolina,Cabarrus County,2015,196762,,56853,675
+North Carolina,Cabarrus County,2016,201590,,63386,688
+North Carolina,Cabarrus County,2017,206872,,61490,704
+North Carolina,Cabarrus County,2018,211342,,69679,720
 North Carolina,Cabarrus County,2019,216453,6856.0,72333,824
-North Carolina,Cabarrus County,2021,231278,0.0,79672,973
-North Carolina,Cabarrus County,2022,235797,0.0,78857,1074
-North Carolina,Caldwell County,2005,77918,0.0,37260,402
-North Carolina,Caldwell County,2006,79841,0.0,34052,405
-North Carolina,Caldwell County,2007,79454,0.0,37974,370
-North Carolina,Caldwell County,2008,80059,0.0,43421,434
-North Carolina,Caldwell County,2009,79914,0.0,32297,445
-North Carolina,Caldwell County,2010,82998,0.0,36050,459
-North Carolina,Caldwell County,2011,82395,0.0,33198,430
-North Carolina,Caldwell County,2012,81930,0.0,31391,447
-North Carolina,Caldwell County,2013,81990,0.0,32386,468
-North Carolina,Caldwell County,2014,81484,0.0,37876,477
-North Carolina,Caldwell County,2015,81287,0.0,38708,435
-North Carolina,Caldwell County,2016,81449,0.0,36301,451
-North Carolina,Caldwell County,2017,81981,0.0,45033,474
-North Carolina,Caldwell County,2018,82029,0.0,42257,488
-North Carolina,Caldwell County,2019,82178,0.0,48737,505
-North Carolina,Caldwell County,2021,80463,0.0,41210,465
-North Carolina,Caldwell County,2022,80492,0.0,51592,468
-North Carolina,Carteret County,2010,66685,0.0,40614,517
-North Carolina,Carteret County,2011,67373,0.0,44429,572
-North Carolina,Carteret County,2012,67632,0.0,49853,664
-North Carolina,Carteret County,2013,68434,0.0,45231,653
-North Carolina,Carteret County,2014,68811,0.0,48881,689
-North Carolina,Carteret County,2015,68879,0.0,51048,678
+North Carolina,Cabarrus County,2021,231278,,79672,973
+North Carolina,Cabarrus County,2022,235797,,78857,1074
+North Carolina,Caldwell County,2005,77918,,37260,402
+North Carolina,Caldwell County,2006,79841,,34052,405
+North Carolina,Caldwell County,2007,79454,,37974,370
+North Carolina,Caldwell County,2008,80059,,43421,434
+North Carolina,Caldwell County,2009,79914,,32297,445
+North Carolina,Caldwell County,2010,82998,,36050,459
+North Carolina,Caldwell County,2011,82395,,33198,430
+North Carolina,Caldwell County,2012,81930,,31391,447
+North Carolina,Caldwell County,2013,81990,,32386,468
+North Carolina,Caldwell County,2014,81484,,37876,477
+North Carolina,Caldwell County,2015,81287,,38708,435
+North Carolina,Caldwell County,2016,81449,,36301,451
+North Carolina,Caldwell County,2017,81981,,45033,474
+North Carolina,Caldwell County,2018,82029,,42257,488
+North Carolina,Caldwell County,2019,82178,,48737,505
+North Carolina,Caldwell County,2021,80463,,41210,465
+North Carolina,Caldwell County,2022,80492,,51592,468
+North Carolina,Carteret County,2010,66685,,40614,517
+North Carolina,Carteret County,2011,67373,,44429,572
+North Carolina,Carteret County,2012,67632,,49853,664
+North Carolina,Carteret County,2013,68434,,45231,653
+North Carolina,Carteret County,2014,68811,,48881,689
+North Carolina,Carteret County,2015,68879,,51048,678
 North Carolina,Carteret County,2016,68890,1450.0,51206,670
-North Carolina,Carteret County,2017,68881,0.0,52807,726
-North Carolina,Carteret County,2018,69524,0.0,54833,670
-North Carolina,Carteret County,2019,69473,0.0,60186,659
-North Carolina,Carteret County,2021,68541,0.0,62907,755
-North Carolina,Carteret County,2022,69380,0.0,66799,843
-North Carolina,Catawba County,2005,149294,0.0,39279,443
-North Carolina,Catawba County,2006,153784,0.0,42349,463
-North Carolina,Catawba County,2007,155646,0.0,42625,463
-North Carolina,Catawba County,2008,157079,0.0,43009,502
-North Carolina,Catawba County,2009,159125,0.0,41116,472
-North Carolina,Catawba County,2010,154389,0.0,41244,495
-North Carolina,Catawba County,2011,154181,0.0,44369,529
-North Carolina,Catawba County,2012,154339,0.0,41420,501
-North Carolina,Catawba County,2013,154810,0.0,42859,519
-North Carolina,Catawba County,2014,154534,0.0,44677,518
-North Carolina,Catawba County,2015,155056,0.0,40450,498
-North Carolina,Catawba County,2016,156459,0.0,48913,557
-North Carolina,Catawba County,2017,157974,0.0,53539,577
-North Carolina,Catawba County,2018,158652,0.0,53454,566
-North Carolina,Catawba County,2019,159551,0.0,52436,554
-North Carolina,Catawba County,2021,161723,0.0,59603,694
-North Carolina,Catawba County,2022,163462,0.0,62981,695
-North Carolina,Chatham County,2012,65976,0.0,54705,627
-North Carolina,Chatham County,2013,66817,0.0,56550,567
-North Carolina,Chatham County,2014,68698,0.0,54229,619
-North Carolina,Chatham County,2015,70928,0.0,55642,656
-North Carolina,Chatham County,2016,72243,0.0,62961,515
-North Carolina,Chatham County,2017,71472,0.0,57770,529
-North Carolina,Chatham County,2018,73139,0.0,74959,747
-North Carolina,Chatham County,2019,74470,0.0,66857,610
-North Carolina,Chatham County,2021,77889,0.0,84555,540
-North Carolina,Chatham County,2022,79864,0.0,77906,832
-North Carolina,Cleveland County,2005,95778,0.0,34628,406
-North Carolina,Cleveland County,2006,98373,0.0,36582,421
-North Carolina,Cleveland County,2007,98453,0.0,36045,414
-North Carolina,Cleveland County,2008,99015,0.0,36748,450
-North Carolina,Cleveland County,2009,99274,0.0,37902,450
-North Carolina,Cleveland County,2010,98050,0.0,38282,428
-North Carolina,Cleveland County,2011,97489,0.0,35753,482
-North Carolina,Cleveland County,2012,97474,0.0,35547,447
-North Carolina,Cleveland County,2013,97047,0.0,40581,445
-North Carolina,Cleveland County,2014,97076,0.0,37433,499
-North Carolina,Cleveland County,2015,96879,0.0,38885,462
-North Carolina,Cleveland County,2016,97144,0.0,36992,482
-North Carolina,Cleveland County,2017,97334,0.0,37205,510
-North Carolina,Cleveland County,2018,97645,0.0,40690,475
-North Carolina,Cleveland County,2019,97947,0.0,44987,501
-North Carolina,Cleveland County,2021,100359,0.0,47150,583
-North Carolina,Cleveland County,2022,100670,0.0,51470,650
-North Carolina,Craven County,2005,86369,0.0,41428,422
-North Carolina,Craven County,2006,94875,0.0,42320,497
+North Carolina,Carteret County,2017,68881,,52807,726
+North Carolina,Carteret County,2018,69524,,54833,670
+North Carolina,Carteret County,2019,69473,,60186,659
+North Carolina,Carteret County,2021,68541,,62907,755
+North Carolina,Carteret County,2022,69380,,66799,843
+North Carolina,Catawba County,2005,149294,,39279,443
+North Carolina,Catawba County,2006,153784,,42349,463
+North Carolina,Catawba County,2007,155646,,42625,463
+North Carolina,Catawba County,2008,157079,,43009,502
+North Carolina,Catawba County,2009,159125,,41116,472
+North Carolina,Catawba County,2010,154389,,41244,495
+North Carolina,Catawba County,2011,154181,,44369,529
+North Carolina,Catawba County,2012,154339,,41420,501
+North Carolina,Catawba County,2013,154810,,42859,519
+North Carolina,Catawba County,2014,154534,,44677,518
+North Carolina,Catawba County,2015,155056,,40450,498
+North Carolina,Catawba County,2016,156459,,48913,557
+North Carolina,Catawba County,2017,157974,,53539,577
+North Carolina,Catawba County,2018,158652,,53454,566
+North Carolina,Catawba County,2019,159551,,52436,554
+North Carolina,Catawba County,2021,161723,,59603,694
+North Carolina,Catawba County,2022,163462,,62981,695
+North Carolina,Chatham County,2012,65976,,54705,627
+North Carolina,Chatham County,2013,66817,,56550,567
+North Carolina,Chatham County,2014,68698,,54229,619
+North Carolina,Chatham County,2015,70928,,55642,656
+North Carolina,Chatham County,2016,72243,,62961,515
+North Carolina,Chatham County,2017,71472,,57770,529
+North Carolina,Chatham County,2018,73139,,74959,747
+North Carolina,Chatham County,2019,74470,,66857,610
+North Carolina,Chatham County,2021,77889,,84555,540
+North Carolina,Chatham County,2022,79864,,77906,832
+North Carolina,Cleveland County,2005,95778,,34628,406
+North Carolina,Cleveland County,2006,98373,,36582,421
+North Carolina,Cleveland County,2007,98453,,36045,414
+North Carolina,Cleveland County,2008,99015,,36748,450
+North Carolina,Cleveland County,2009,99274,,37902,450
+North Carolina,Cleveland County,2010,98050,,38282,428
+North Carolina,Cleveland County,2011,97489,,35753,482
+North Carolina,Cleveland County,2012,97474,,35547,447
+North Carolina,Cleveland County,2013,97047,,40581,445
+North Carolina,Cleveland County,2014,97076,,37433,499
+North Carolina,Cleveland County,2015,96879,,38885,462
+North Carolina,Cleveland County,2016,97144,,36992,482
+North Carolina,Cleveland County,2017,97334,,37205,510
+North Carolina,Cleveland County,2018,97645,,40690,475
+North Carolina,Cleveland County,2019,97947,,44987,501
+North Carolina,Cleveland County,2021,100359,,47150,583
+North Carolina,Cleveland County,2022,100670,,51470,650
+North Carolina,Craven County,2005,86369,,41428,422
+North Carolina,Craven County,2006,94875,,42320,497
 North Carolina,Craven County,2007,96746,1462.0,45522,475
-North Carolina,Craven County,2008,96892,0.0,46259,558
-North Carolina,Craven County,2009,98529,0.0,38606,543
+North Carolina,Craven County,2008,96892,,46259,558
+North Carolina,Craven County,2009,98529,,38606,543
 North Carolina,Craven County,2010,103908,1108.0,40218,574
-North Carolina,Craven County,2011,104786,0.0,51298,650
-North Carolina,Craven County,2012,104770,0.0,48402,691
-North Carolina,Craven County,2013,104489,0.0,44963,704
-North Carolina,Craven County,2014,104510,0.0,43380,637
-North Carolina,Craven County,2015,103451,0.0,48145,694
-North Carolina,Craven County,2016,103445,0.0,49938,606
-North Carolina,Craven County,2017,102578,0.0,51789,636
-North Carolina,Craven County,2018,102912,0.0,50509,733
-North Carolina,Craven County,2019,102139,0.0,52832,777
-North Carolina,Craven County,2021,100674,0.0,57359,792
-North Carolina,Craven County,2022,100874,0.0,63964,852
-North Carolina,Cumberland County,2005,284231,0.0,39126,568
+North Carolina,Craven County,2011,104786,,51298,650
+North Carolina,Craven County,2012,104770,,48402,691
+North Carolina,Craven County,2013,104489,,44963,704
+North Carolina,Craven County,2014,104510,,43380,637
+North Carolina,Craven County,2015,103451,,48145,694
+North Carolina,Craven County,2016,103445,,49938,606
+North Carolina,Craven County,2017,102578,,51789,636
+North Carolina,Craven County,2018,102912,,50509,733
+North Carolina,Craven County,2019,102139,,52832,777
+North Carolina,Craven County,2021,100674,,57359,792
+North Carolina,Craven County,2022,100874,,63964,852
+North Carolina,Cumberland County,2005,284231,,39126,568
 North Carolina,Cumberland County,2006,299060,9755.0,41162,560
 North Carolina,Cumberland County,2007,306518,5172.0,42427,583
 North Carolina,Cumberland County,2008,312696,14380.0,44786,566
@@ -8091,24 +8091,24 @@ North Carolina,Cumberland County,2018,332330,4397.0,46716,719
 North Carolina,Cumberland County,2019,335509,4891.0,46292,732
 North Carolina,Cumberland County,2021,335508,12637.0,52372,842
 North Carolina,Cumberland County,2022,336699,11704.0,58110,907
-North Carolina,Davidson County,2005,152670,0.0,39680,412
-North Carolina,Davidson County,2006,156236,0.0,43868,389
-North Carolina,Davidson County,2007,156530,0.0,43321,414
-North Carolina,Davidson County,2008,158166,0.0,43997,453
-North Carolina,Davidson County,2009,158582,0.0,43587,441
-North Carolina,Davidson County,2010,162930,0.0,39660,418
-North Carolina,Davidson County,2011,162697,0.0,40281,437
-North Carolina,Davidson County,2012,163260,0.0,43711,478
-North Carolina,Davidson County,2013,163420,0.0,38803,468
-North Carolina,Davidson County,2014,164072,0.0,42201,434
-North Carolina,Davidson County,2015,164622,0.0,46150,480
-North Carolina,Davidson County,2016,164926,0.0,45678,495
-North Carolina,Davidson County,2017,165466,0.0,46802,498
-North Carolina,Davidson County,2018,166614,0.0,45320,494
-North Carolina,Davidson County,2019,167609,0.0,53473,546
-North Carolina,Davidson County,2021,170637,0.0,52205,575
-North Carolina,Davidson County,2022,172586,0.0,63741,596
-North Carolina,Durham County,2005,232573,0.0,44941,633
+North Carolina,Davidson County,2005,152670,,39680,412
+North Carolina,Davidson County,2006,156236,,43868,389
+North Carolina,Davidson County,2007,156530,,43321,414
+North Carolina,Davidson County,2008,158166,,43997,453
+North Carolina,Davidson County,2009,158582,,43587,441
+North Carolina,Davidson County,2010,162930,,39660,418
+North Carolina,Davidson County,2011,162697,,40281,437
+North Carolina,Davidson County,2012,163260,,43711,478
+North Carolina,Davidson County,2013,163420,,38803,468
+North Carolina,Davidson County,2014,164072,,42201,434
+North Carolina,Davidson County,2015,164622,,46150,480
+North Carolina,Davidson County,2016,164926,,45678,495
+North Carolina,Davidson County,2017,165466,,46802,498
+North Carolina,Davidson County,2018,166614,,45320,494
+North Carolina,Davidson County,2019,167609,,53473,546
+North Carolina,Davidson County,2021,170637,,52205,575
+North Carolina,Davidson County,2022,172586,,63741,596
+North Carolina,Durham County,2005,232573,,44941,633
 North Carolina,Durham County,2006,246896,4240.0,46636,639
 North Carolina,Durham County,2007,256500,5156.0,47186,633
 North Carolina,Durham County,2008,262715,5226.0,51028,674
@@ -8125,7 +8125,7 @@ North Carolina,Durham County,2018,316739,9619.0,58073,902
 North Carolina,Durham County,2019,321488,11587.0,65317,976
 North Carolina,Durham County,2021,326126,49896.0,71403,1068
 North Carolina,Durham County,2022,332680,40882.0,80089,1247
-North Carolina,Forsyth County,2005,315856,0.0,45046,503
+North Carolina,Forsyth County,2005,315856,,45046,503
 North Carolina,Forsyth County,2006,332355,4198.0,45792,501
 North Carolina,Forsyth County,2007,338774,5491.0,45636,539
 North Carolina,Forsyth County,2008,343028,4357.0,46912,525
@@ -8142,27 +8142,27 @@ North Carolina,Forsyth County,2018,379099,8120.0,49166,652
 North Carolina,Forsyth County,2019,382295,9072.0,52017,677
 North Carolina,Forsyth County,2021,385523,27773.0,59879,746
 North Carolina,Forsyth County,2022,389157,27249.0,62319,864
-North Carolina,Franklin County,2017,66168,0.0,54825,542
-North Carolina,Franklin County,2018,67560,0.0,60598,685
-North Carolina,Franklin County,2019,69685,0.0,57099,633
-North Carolina,Franklin County,2021,71703,0.0,64064,748
-North Carolina,Franklin County,2022,74539,0.0,73182,681
-North Carolina,Gaston County,2005,193162,0.0,35247,467
-North Carolina,Gaston County,2006,199397,0.0,42410,492
-North Carolina,Gaston County,2007,202535,0.0,41259,503
+North Carolina,Franklin County,2017,66168,,54825,542
+North Carolina,Franklin County,2018,67560,,60598,685
+North Carolina,Franklin County,2019,69685,,57099,633
+North Carolina,Franklin County,2021,71703,,64064,748
+North Carolina,Franklin County,2022,74539,,73182,681
+North Carolina,Gaston County,2005,193162,,35247,467
+North Carolina,Gaston County,2006,199397,,42410,492
+North Carolina,Gaston County,2007,202535,,41259,503
 North Carolina,Gaston County,2008,206679,2690.0,46353,513
-North Carolina,Gaston County,2009,208958,0.0,40335,525
-North Carolina,Gaston County,2010,206213,0.0,39054,484
-North Carolina,Gaston County,2011,207031,0.0,40674,524
+North Carolina,Gaston County,2009,208958,,40335,525
+North Carolina,Gaston County,2010,206213,,39054,484
+North Carolina,Gaston County,2011,207031,,40674,524
 North Carolina,Gaston County,2012,208049,2672.0,41067,530
-North Carolina,Gaston County,2013,209420,0.0,41728,528
+North Carolina,Gaston County,2013,209420,,41728,528
 North Carolina,Gaston County,2014,211127,3429.0,41011,548
 North Carolina,Gaston County,2015,213442,2178.0,44293,569
-North Carolina,Gaston County,2016,216965,0.0,48711,605
-North Carolina,Gaston County,2017,220182,0.0,49670,599
+North Carolina,Gaston County,2016,216965,,48711,605
+North Carolina,Gaston County,2017,220182,,49670,599
 North Carolina,Gaston County,2018,222846,3297.0,52741,672
 North Carolina,Gaston County,2019,224529,3738.0,56595,632
-North Carolina,Gaston County,2021,230856,0.0,54734,787
+North Carolina,Gaston County,2021,230856,,54734,787
 North Carolina,Gaston County,2022,234215,14943.0,65615,898
 North Carolina,Guilford County,2005,429603,7802.0,42320,547
 North Carolina,Guilford County,2006,451905,5898.0,43892,571
@@ -8181,92 +8181,92 @@ North Carolina,Guilford County,2018,533670,12909.0,51803,715
 North Carolina,Guilford County,2019,537174,14229.0,55328,752
 North Carolina,Guilford County,2021,542410,43401.0,60734,820
 North Carolina,Guilford County,2022,546101,36726.0,63475,911
-North Carolina,Harnett County,2005,100634,0.0,38142,432
-North Carolina,Harnett County,2006,106283,0.0,40943,478
-North Carolina,Harnett County,2007,108721,0.0,38657,470
-North Carolina,Harnett County,2008,112030,0.0,43547,500
-North Carolina,Harnett County,2009,115761,0.0,43815,495
-North Carolina,Harnett County,2010,115733,0.0,39584,537
-North Carolina,Harnett County,2011,119256,0.0,39513,534
-North Carolina,Harnett County,2012,122135,0.0,45655,537
-North Carolina,Harnett County,2013,124987,0.0,45533,563
+North Carolina,Harnett County,2005,100634,,38142,432
+North Carolina,Harnett County,2006,106283,,40943,478
+North Carolina,Harnett County,2007,108721,,38657,470
+North Carolina,Harnett County,2008,112030,,43547,500
+North Carolina,Harnett County,2009,115761,,43815,495
+North Carolina,Harnett County,2010,115733,,39584,537
+North Carolina,Harnett County,2011,119256,,39513,534
+North Carolina,Harnett County,2012,122135,,45655,537
+North Carolina,Harnett County,2013,124987,,45533,563
 North Carolina,Harnett County,2014,126666,1014.0,44880,570
-North Carolina,Harnett County,2015,128140,0.0,48960,594
-North Carolina,Harnett County,2016,130881,0.0,51637,609
-North Carolina,Harnett County,2017,132754,0.0,51479,615
-North Carolina,Harnett County,2018,134214,0.0,51022,664
-North Carolina,Harnett County,2019,135976,0.0,55753,664
-North Carolina,Harnett County,2021,135966,0.0,62478,770
-North Carolina,Harnett County,2022,138832,0.0,65778,709
-North Carolina,Henderson County,2005,95381,0.0,37031,482
-North Carolina,Henderson County,2006,99033,0.0,41573,513
-North Carolina,Henderson County,2007,100810,0.0,47844,522
-North Carolina,Henderson County,2008,102367,0.0,45695,580
-North Carolina,Henderson County,2009,103669,0.0,42808,573
-North Carolina,Henderson County,2010,106978,0.0,43105,533
-North Carolina,Henderson County,2011,107927,0.0,46789,548
-North Carolina,Henderson County,2012,108266,0.0,45067,663
-North Carolina,Henderson County,2013,109540,0.0,44036,629
-North Carolina,Henderson County,2014,111149,0.0,47335,635
-North Carolina,Henderson County,2015,112655,0.0,47021,589
-North Carolina,Henderson County,2016,114209,0.0,54963,732
-North Carolina,Henderson County,2017,115708,0.0,51078,767
-North Carolina,Henderson County,2018,116748,0.0,53706,606
-North Carolina,Henderson County,2019,117417,0.0,62131,670
-North Carolina,Henderson County,2021,116829,0.0,59669,862
+North Carolina,Harnett County,2015,128140,,48960,594
+North Carolina,Harnett County,2016,130881,,51637,609
+North Carolina,Harnett County,2017,132754,,51479,615
+North Carolina,Harnett County,2018,134214,,51022,664
+North Carolina,Harnett County,2019,135976,,55753,664
+North Carolina,Harnett County,2021,135966,,62478,770
+North Carolina,Harnett County,2022,138832,,65778,709
+North Carolina,Henderson County,2005,95381,,37031,482
+North Carolina,Henderson County,2006,99033,,41573,513
+North Carolina,Henderson County,2007,100810,,47844,522
+North Carolina,Henderson County,2008,102367,,45695,580
+North Carolina,Henderson County,2009,103669,,42808,573
+North Carolina,Henderson County,2010,106978,,43105,533
+North Carolina,Henderson County,2011,107927,,46789,548
+North Carolina,Henderson County,2012,108266,,45067,663
+North Carolina,Henderson County,2013,109540,,44036,629
+North Carolina,Henderson County,2014,111149,,47335,635
+North Carolina,Henderson County,2015,112655,,47021,589
+North Carolina,Henderson County,2016,114209,,54963,732
+North Carolina,Henderson County,2017,115708,,51078,767
+North Carolina,Henderson County,2018,116748,,53706,606
+North Carolina,Henderson County,2019,117417,,62131,670
+North Carolina,Henderson County,2021,116829,,59669,862
 North Carolina,Henderson County,2022,118106,4930.0,63552,877
-North Carolina,Iredell County,2005,139249,0.0,44200,538
-North Carolina,Iredell County,2006,146206,0.0,43307,502
-North Carolina,Iredell County,2007,151445,0.0,50500,508
-North Carolina,Iredell County,2008,155359,0.0,50343,563
-North Carolina,Iredell County,2009,158153,0.0,47344,588
-North Carolina,Iredell County,2010,159771,0.0,45714,612
-North Carolina,Iredell County,2011,161202,0.0,50241,554
-North Carolina,Iredell County,2012,162708,0.0,49219,585
+North Carolina,Iredell County,2005,139249,,44200,538
+North Carolina,Iredell County,2006,146206,,43307,502
+North Carolina,Iredell County,2007,151445,,50500,508
+North Carolina,Iredell County,2008,155359,,50343,563
+North Carolina,Iredell County,2009,158153,,47344,588
+North Carolina,Iredell County,2010,159771,,45714,612
+North Carolina,Iredell County,2011,161202,,50241,554
+North Carolina,Iredell County,2012,162708,,49219,585
 North Carolina,Iredell County,2013,164517,2524.0,49488,627
 North Carolina,Iredell County,2014,166675,3096.0,54384,641
-North Carolina,Iredell County,2015,169866,0.0,55949,636
+North Carolina,Iredell County,2015,169866,,55949,636
 North Carolina,Iredell County,2016,172916,5526.0,55891,670
-North Carolina,Iredell County,2017,175711,0.0,55690,670
-North Carolina,Iredell County,2018,178435,0.0,59341,680
-North Carolina,Iredell County,2019,181806,0.0,68660,809
-North Carolina,Iredell County,2021,191968,0.0,69410,875
-North Carolina,Iredell County,2022,195897,0.0,71943,919
-North Carolina,Johnston County,2005,144621,0.0,45208,451
-North Carolina,Johnston County,2006,152143,0.0,46555,484
-North Carolina,Johnston County,2007,157437,0.0,45551,501
-North Carolina,Johnston County,2008,163428,0.0,52484,514
-North Carolina,Johnston County,2009,168525,0.0,49102,546
-North Carolina,Johnston County,2010,169735,0.0,45988,570
-North Carolina,Johnston County,2011,172595,0.0,46915,565
-North Carolina,Johnston County,2012,174938,0.0,47108,478
-North Carolina,Johnston County,2013,177967,0.0,50492,609
-North Carolina,Johnston County,2014,181423,0.0,48851,598
-North Carolina,Johnston County,2015,185660,0.0,52234,590
-North Carolina,Johnston County,2016,191450,0.0,54719,612
-North Carolina,Johnston County,2017,196708,0.0,58111,618
-North Carolina,Johnston County,2018,202675,0.0,60132,646
-North Carolina,Johnston County,2019,209339,0.0,60951,575
-North Carolina,Johnston County,2021,226504,0.0,69394,680
-North Carolina,Johnston County,2022,234778,0.0,81725,832
-North Carolina,Lee County,2022,65476,0.0,56540,745
-North Carolina,Lincoln County,2005,68947,0.0,45001,420
-North Carolina,Lincoln County,2006,71894,0.0,38433,471
-North Carolina,Lincoln County,2007,73106,0.0,49092,464
-North Carolina,Lincoln County,2008,74746,0.0,49279,450
-North Carolina,Lincoln County,2009,76043,0.0,47242,489
-North Carolina,Lincoln County,2010,78450,0.0,42456,467
-North Carolina,Lincoln County,2011,78932,0.0,52147,498
-North Carolina,Lincoln County,2012,79313,0.0,46098,496
-North Carolina,Lincoln County,2013,79740,0.0,49079,499
-North Carolina,Lincoln County,2014,79829,0.0,48131,525
-North Carolina,Lincoln County,2015,81035,0.0,46884,539
-North Carolina,Lincoln County,2016,81168,0.0,49453,528
-North Carolina,Lincoln County,2017,82403,0.0,54361,586
-North Carolina,Lincoln County,2018,83770,0.0,63782,540
-North Carolina,Lincoln County,2019,86111,0.0,71514,599
-North Carolina,Lincoln County,2021,89670,0.0,74201,666
-North Carolina,Lincoln County,2022,93095,0.0,79003,764
+North Carolina,Iredell County,2017,175711,,55690,670
+North Carolina,Iredell County,2018,178435,,59341,680
+North Carolina,Iredell County,2019,181806,,68660,809
+North Carolina,Iredell County,2021,191968,,69410,875
+North Carolina,Iredell County,2022,195897,,71943,919
+North Carolina,Johnston County,2005,144621,,45208,451
+North Carolina,Johnston County,2006,152143,,46555,484
+North Carolina,Johnston County,2007,157437,,45551,501
+North Carolina,Johnston County,2008,163428,,52484,514
+North Carolina,Johnston County,2009,168525,,49102,546
+North Carolina,Johnston County,2010,169735,,45988,570
+North Carolina,Johnston County,2011,172595,,46915,565
+North Carolina,Johnston County,2012,174938,,47108,478
+North Carolina,Johnston County,2013,177967,,50492,609
+North Carolina,Johnston County,2014,181423,,48851,598
+North Carolina,Johnston County,2015,185660,,52234,590
+North Carolina,Johnston County,2016,191450,,54719,612
+North Carolina,Johnston County,2017,196708,,58111,618
+North Carolina,Johnston County,2018,202675,,60132,646
+North Carolina,Johnston County,2019,209339,,60951,575
+North Carolina,Johnston County,2021,226504,,69394,680
+North Carolina,Johnston County,2022,234778,,81725,832
+North Carolina,Lee County,2022,65476,,56540,745
+North Carolina,Lincoln County,2005,68947,,45001,420
+North Carolina,Lincoln County,2006,71894,,38433,471
+North Carolina,Lincoln County,2007,73106,,49092,464
+North Carolina,Lincoln County,2008,74746,,49279,450
+North Carolina,Lincoln County,2009,76043,,47242,489
+North Carolina,Lincoln County,2010,78450,,42456,467
+North Carolina,Lincoln County,2011,78932,,52147,498
+North Carolina,Lincoln County,2012,79313,,46098,496
+North Carolina,Lincoln County,2013,79740,,49079,499
+North Carolina,Lincoln County,2014,79829,,48131,525
+North Carolina,Lincoln County,2015,81035,,46884,539
+North Carolina,Lincoln County,2016,81168,,49453,528
+North Carolina,Lincoln County,2017,82403,,54361,586
+North Carolina,Lincoln County,2018,83770,,63782,540
+North Carolina,Lincoln County,2019,86111,,71514,599
+North Carolina,Lincoln County,2021,89670,,74201,666
+North Carolina,Lincoln County,2022,93095,,79003,764
 North Carolina,Mecklenburg County,2005,780618,16246.0,50215,617
 North Carolina,Mecklenburg County,2006,827445,18327.0,51945,639
 North Carolina,Mecklenburg County,2007,867067,19222.0,55890,678
@@ -8284,41 +8284,41 @@ North Carolina,Mecklenburg County,2018,1093901,49299.0,63967,999
 North Carolina,Mecklenburg County,2019,1110356,62143.0,69072,1051
 North Carolina,Mecklenburg County,2021,1122276,204363.0,74890,1181
 North Carolina,Mecklenburg County,2022,1145392,189130.0,80365,1346
-North Carolina,Moore County,2005,79938,0.0,37440,450
-North Carolina,Moore County,2006,83162,0.0,43616,441
-North Carolina,Moore County,2007,84435,0.0,51332,523
-North Carolina,Moore County,2008,85608,0.0,46697,559
-North Carolina,Moore County,2009,87158,0.0,45193,503
-North Carolina,Moore County,2010,88569,0.0,47692,439
-North Carolina,Moore County,2011,89352,0.0,45158,539
-North Carolina,Moore County,2012,90302,0.0,49763,520
-North Carolina,Moore County,2013,91587,0.0,49959,656
-North Carolina,Moore County,2014,93077,0.0,51328,576
-North Carolina,Moore County,2015,94352,0.0,51547,702
-North Carolina,Moore County,2016,95776,0.0,52279,703
-North Carolina,Moore County,2017,97264,0.0,64184,695
-North Carolina,Moore County,2018,98682,0.0,58531,712
-North Carolina,Moore County,2019,100880,0.0,62469,821
-North Carolina,Moore County,2021,102763,0.0,67160,770
-North Carolina,Moore County,2022,105531,0.0,85382,1157
-North Carolina,Nash County,2005,89157,0.0,38957,387
-North Carolina,Nash County,2006,92312,0.0,41031,427
-North Carolina,Nash County,2007,92949,0.0,45826,442
-North Carolina,Nash County,2008,93674,0.0,45482,447
-North Carolina,Nash County,2009,94743,0.0,38936,470
-North Carolina,Nash County,2010,95938,0.0,42967,488
-North Carolina,Nash County,2011,96116,0.0,44261,506
-North Carolina,Nash County,2012,95708,0.0,39962,477
-North Carolina,Nash County,2013,95093,0.0,40057,464
-North Carolina,Nash County,2014,94357,0.0,43209,500
-North Carolina,Nash County,2015,93919,0.0,42718,511
-North Carolina,Nash County,2016,94005,0.0,47902,498
-North Carolina,Nash County,2017,93991,0.0,47289,601
-North Carolina,Nash County,2018,94016,0.0,51601,509
-North Carolina,Nash County,2019,94298,0.0,50656,555
-North Carolina,Nash County,2021,95176,0.0,56560,604
-North Carolina,Nash County,2022,95789,0.0,54175,660
-North Carolina,New Hanover County,2005,174861,0.0,44793,617
+North Carolina,Moore County,2005,79938,,37440,450
+North Carolina,Moore County,2006,83162,,43616,441
+North Carolina,Moore County,2007,84435,,51332,523
+North Carolina,Moore County,2008,85608,,46697,559
+North Carolina,Moore County,2009,87158,,45193,503
+North Carolina,Moore County,2010,88569,,47692,439
+North Carolina,Moore County,2011,89352,,45158,539
+North Carolina,Moore County,2012,90302,,49763,520
+North Carolina,Moore County,2013,91587,,49959,656
+North Carolina,Moore County,2014,93077,,51328,576
+North Carolina,Moore County,2015,94352,,51547,702
+North Carolina,Moore County,2016,95776,,52279,703
+North Carolina,Moore County,2017,97264,,64184,695
+North Carolina,Moore County,2018,98682,,58531,712
+North Carolina,Moore County,2019,100880,,62469,821
+North Carolina,Moore County,2021,102763,,67160,770
+North Carolina,Moore County,2022,105531,,85382,1157
+North Carolina,Nash County,2005,89157,,38957,387
+North Carolina,Nash County,2006,92312,,41031,427
+North Carolina,Nash County,2007,92949,,45826,442
+North Carolina,Nash County,2008,93674,,45482,447
+North Carolina,Nash County,2009,94743,,38936,470
+North Carolina,Nash County,2010,95938,,42967,488
+North Carolina,Nash County,2011,96116,,44261,506
+North Carolina,Nash County,2012,95708,,39962,477
+North Carolina,Nash County,2013,95093,,40057,464
+North Carolina,Nash County,2014,94357,,43209,500
+North Carolina,Nash County,2015,93919,,42718,511
+North Carolina,Nash County,2016,94005,,47902,498
+North Carolina,Nash County,2017,93991,,47289,601
+North Carolina,Nash County,2018,94016,,51601,509
+North Carolina,Nash County,2019,94298,,50656,555
+North Carolina,Nash County,2021,95176,,56560,604
+North Carolina,Nash County,2022,95789,,54175,660
+North Carolina,New Hanover County,2005,174861,,44793,617
 North Carolina,New Hanover County,2006,182591,3308.0,43031,650
 North Carolina,New Hanover County,2007,190432,3571.0,48206,685
 North Carolina,New Hanover County,2008,192538,4638.0,51223,716
@@ -8331,16 +8331,16 @@ North Carolina,New Hanover County,2014,216298,8380.0,49982,744
 North Carolina,New Hanover County,2015,220358,7733.0,52685,805
 North Carolina,New Hanover County,2016,223483,6730.0,50028,805
 North Carolina,New Hanover County,2017,227198,8807.0,52674,813
-North Carolina,New Hanover County,2018,232274,0.0,52239,904
+North Carolina,New Hanover County,2018,232274,,52239,904
 North Carolina,New Hanover County,2019,234473,12766.0,56382,966
 North Carolina,New Hanover County,2021,229018,20277.0,66097,1037
 North Carolina,New Hanover County,2022,234921,22640.0,70485,1178
-North Carolina,Onslow County,2005,125251,0.0,41242,530
+North Carolina,Onslow County,2005,125251,,41242,530
 North Carolina,Onslow County,2006,150673,3990.0,38991,488
 North Carolina,Onslow County,2007,162745,11641.0,42143,530
 North Carolina,Onslow County,2008,165938,8861.0,48017,609
-North Carolina,Onslow County,2009,173064,0.0,41231,689
-North Carolina,Onslow County,2010,179471,0.0,41787,772
+North Carolina,Onslow County,2009,173064,,41231,689
+North Carolina,Onslow County,2010,179471,,41787,772
 North Carolina,Onslow County,2011,179719,8197.0,45573,775
 North Carolina,Onslow County,2012,183263,6135.0,44250,758
 North Carolina,Onslow County,2013,185220,4947.0,44673,740
@@ -8348,11 +8348,11 @@ North Carolina,Onslow County,2014,187589,4355.0,47581,733
 North Carolina,Onslow County,2015,186311,4664.0,45832,801
 North Carolina,Onslow County,2016,187136,2315.0,47150,819
 North Carolina,Onslow County,2017,193893,4696.0,49883,902
-North Carolina,Onslow County,2018,197683,0.0,50639,839
-North Carolina,Onslow County,2019,197938,0.0,49544,765
-North Carolina,Onslow County,2021,206160,0.0,55534,872
-North Carolina,Onslow County,2022,207298,0.0,62460,933
-North Carolina,Orange County,2005,108104,0.0,43978,599
+North Carolina,Onslow County,2018,197683,,50639,839
+North Carolina,Onslow County,2019,197938,,49544,765
+North Carolina,Onslow County,2021,206160,,55534,872
+North Carolina,Onslow County,2022,207298,,62460,933
+North Carolina,Orange County,2005,108104,,43978,599
 North Carolina,Orange County,2006,120100,3939.0,46114,666
 North Carolina,Orange County,2007,124313,3170.0,54741,669
 North Carolina,Orange County,2008,126532,3117.0,54390,714
@@ -8367,127 +8367,127 @@ North Carolina,Orange County,2016,141796,7404.0,66423,923
 North Carolina,Orange County,2017,144946,6862.0,69940,953
 North Carolina,Orange County,2018,146027,6951.0,72563,940
 North Carolina,Orange County,2019,148476,8009.0,74299,913
-North Carolina,Orange County,2021,148884,0.0,80294,1103
+North Carolina,Orange County,2021,148884,,80294,1103
 North Carolina,Orange County,2022,150477,19798.0,89291,1277
-North Carolina,Pender County,2022,65737,0.0,76922,900
-North Carolina,Pitt County,2005,136271,0.0,31979,412
-North Carolina,Pitt County,2006,145619,0.0,36782,470
-North Carolina,Pitt County,2007,152068,0.0,37210,488
+North Carolina,Pender County,2022,65737,,76922,900
+North Carolina,Pitt County,2005,136271,,31979,412
+North Carolina,Pitt County,2006,145619,,36782,470
+North Carolina,Pitt County,2007,152068,,37210,488
 North Carolina,Pitt County,2008,156081,2242.0,40025,473
-North Carolina,Pitt County,2009,159057,0.0,35509,487
+North Carolina,Pitt County,2009,159057,,35509,487
 North Carolina,Pitt County,2010,168817,1661.0,39222,515
-North Carolina,Pitt County,2011,171134,0.0,39047,497
+North Carolina,Pitt County,2011,171134,,39047,497
 North Carolina,Pitt County,2012,172554,2955.0,38589,526
-North Carolina,Pitt County,2013,174263,0.0,40639,517
+North Carolina,Pitt County,2013,174263,,40639,517
 North Carolina,Pitt County,2014,175354,2437.0,41632,560
-North Carolina,Pitt County,2015,175842,0.0,41453,558
-North Carolina,Pitt County,2016,177220,0.0,46573,560
-North Carolina,Pitt County,2017,179042,0.0,45849,605
+North Carolina,Pitt County,2015,175842,,41453,558
+North Carolina,Pitt County,2016,177220,,46573,560
+North Carolina,Pitt County,2017,179042,,45849,605
 North Carolina,Pitt County,2018,179914,3218.0,42481,536
 North Carolina,Pitt County,2019,180742,5072.0,53401,618
-North Carolina,Pitt County,2021,172169,0.0,44450,670
-North Carolina,Pitt County,2022,173542,0.0,57049,741
-North Carolina,Randolph County,2005,136953,0.0,34502,417
-North Carolina,Randolph County,2006,140410,0.0,38563,429
-North Carolina,Randolph County,2007,140145,0.0,36563,409
-North Carolina,Randolph County,2008,141186,0.0,41989,430
-North Carolina,Randolph County,2009,142151,0.0,36712,452
-North Carolina,Randolph County,2010,141960,0.0,38267,467
-North Carolina,Randolph County,2011,142358,0.0,40301,476
-North Carolina,Randolph County,2012,142466,0.0,41550,466
-North Carolina,Randolph County,2013,142577,0.0,40109,471
-North Carolina,Randolph County,2014,142778,0.0,41107,483
-North Carolina,Randolph County,2015,142799,0.0,42347,474
-North Carolina,Randolph County,2016,143416,0.0,44836,512
-North Carolina,Randolph County,2017,143282,0.0,43154,519
-North Carolina,Randolph County,2018,143351,0.0,47653,524
-North Carolina,Randolph County,2019,143667,0.0,49742,545
-North Carolina,Randolph County,2021,145172,0.0,57367,623
-North Carolina,Randolph County,2022,146043,0.0,55671,620
-North Carolina,Robeson County,2005,123921,0.0,25107,315
-North Carolina,Robeson County,2006,129021,0.0,26646,327
-North Carolina,Robeson County,2007,128149,0.0,30882,326
-North Carolina,Robeson County,2008,129123,0.0,30932,358
-North Carolina,Robeson County,2009,129559,0.0,24788,352
-North Carolina,Robeson County,2010,134473,0.0,29453,364
-North Carolina,Robeson County,2011,135517,0.0,30806,391
+North Carolina,Pitt County,2021,172169,,44450,670
+North Carolina,Pitt County,2022,173542,,57049,741
+North Carolina,Randolph County,2005,136953,,34502,417
+North Carolina,Randolph County,2006,140410,,38563,429
+North Carolina,Randolph County,2007,140145,,36563,409
+North Carolina,Randolph County,2008,141186,,41989,430
+North Carolina,Randolph County,2009,142151,,36712,452
+North Carolina,Randolph County,2010,141960,,38267,467
+North Carolina,Randolph County,2011,142358,,40301,476
+North Carolina,Randolph County,2012,142466,,41550,466
+North Carolina,Randolph County,2013,142577,,40109,471
+North Carolina,Randolph County,2014,142778,,41107,483
+North Carolina,Randolph County,2015,142799,,42347,474
+North Carolina,Randolph County,2016,143416,,44836,512
+North Carolina,Randolph County,2017,143282,,43154,519
+North Carolina,Randolph County,2018,143351,,47653,524
+North Carolina,Randolph County,2019,143667,,49742,545
+North Carolina,Randolph County,2021,145172,,57367,623
+North Carolina,Randolph County,2022,146043,,55671,620
+North Carolina,Robeson County,2005,123921,,25107,315
+North Carolina,Robeson County,2006,129021,,26646,327
+North Carolina,Robeson County,2007,128149,,30882,326
+North Carolina,Robeson County,2008,129123,,30932,358
+North Carolina,Robeson County,2009,129559,,24788,352
+North Carolina,Robeson County,2010,134473,,29453,364
+North Carolina,Robeson County,2011,135517,,30806,391
 North Carolina,Robeson County,2012,135496,603.0,28293,393
-North Carolina,Robeson County,2013,134841,0.0,29542,397
-North Carolina,Robeson County,2014,134760,0.0,29889,404
-North Carolina,Robeson County,2015,134197,0.0,31558,400
-North Carolina,Robeson County,2016,133235,0.0,34254,403
-North Carolina,Robeson County,2017,132606,0.0,32729,440
-North Carolina,Robeson County,2018,131831,0.0,35037,439
-North Carolina,Robeson County,2019,130625,0.0,35035,449
-North Carolina,Robeson County,2021,116328,0.0,37008,499
-North Carolina,Robeson County,2022,116663,0.0,38610,527
-North Carolina,Rockingham County,2005,91419,0.0,34860,406
-North Carolina,Rockingham County,2006,93063,0.0,36840,364
-North Carolina,Rockingham County,2007,92421,0.0,39315,383
-North Carolina,Rockingham County,2008,92282,0.0,37678,423
-North Carolina,Rockingham County,2009,92252,0.0,35066,418
-North Carolina,Rockingham County,2010,93641,0.0,37818,439
-North Carolina,Rockingham County,2011,93329,0.0,35816,446
-North Carolina,Rockingham County,2012,92720,0.0,35863,420
-North Carolina,Rockingham County,2013,91878,0.0,41335,416
-North Carolina,Rockingham County,2014,91696,0.0,38878,440
-North Carolina,Rockingham County,2015,91758,0.0,38241,454
-North Carolina,Rockingham County,2016,91393,0.0,40985,467
-North Carolina,Rockingham County,2017,90949,0.0,48196,464
-North Carolina,Rockingham County,2018,90690,0.0,40688,463
-North Carolina,Rockingham County,2019,91010,0.0,43230,502
-North Carolina,Rockingham County,2021,91266,0.0,42901,535
-North Carolina,Rockingham County,2022,91957,0.0,51310,546
-North Carolina,Rowan County,2005,130457,0.0,39676,473
-North Carolina,Rowan County,2006,136254,0.0,42863,437
-North Carolina,Rowan County,2007,137383,0.0,46675,471
-North Carolina,Rowan County,2008,139225,0.0,42540,525
-North Carolina,Rowan County,2009,140798,0.0,43578,524
-North Carolina,Rowan County,2010,138446,0.0,37360,515
-North Carolina,Rowan County,2011,138019,0.0,40008,518
-North Carolina,Rowan County,2012,138180,0.0,40089,537
-North Carolina,Rowan County,2013,138323,0.0,41154,500
-North Carolina,Rowan County,2014,138630,0.0,45978,552
-North Carolina,Rowan County,2015,139142,0.0,45320,571
-North Carolina,Rowan County,2016,139933,0.0,48379,569
-North Carolina,Rowan County,2017,140644,0.0,47396,549
-North Carolina,Rowan County,2018,141262,0.0,46035,613
-North Carolina,Rowan County,2019,142088,0.0,51927,656
-North Carolina,Rowan County,2021,148150,0.0,56408,696
-North Carolina,Rowan County,2022,149645,0.0,61311,780
-North Carolina,Surry County,2005,71330,0.0,33954,334
-North Carolina,Surry County,2006,72687,0.0,35215,341
-North Carolina,Surry County,2007,72380,0.0,35628,397
-North Carolina,Surry County,2008,72468,0.0,36679,312
-North Carolina,Surry County,2009,72496,0.0,33159,400
-North Carolina,Surry County,2010,73694,0.0,35928,414
-North Carolina,Surry County,2011,73714,0.0,32310,410
-North Carolina,Surry County,2012,73561,0.0,36131,426
-North Carolina,Surry County,2013,73050,0.0,35579,417
-North Carolina,Surry County,2014,72968,0.0,36511,416
-North Carolina,Surry County,2015,72743,0.0,37337,444
-North Carolina,Surry County,2016,72113,0.0,36802,442
-North Carolina,Surry County,2017,72224,0.0,42438,435
-North Carolina,Surry County,2018,71948,0.0,48398,457
-North Carolina,Surry County,2019,71783,0.0,49250,444
-North Carolina,Surry County,2021,71152,0.0,51950,548
-North Carolina,Surry County,2022,71403,0.0,44485,499
-North Carolina,Union County,2005,161127,0.0,50072,588
-North Carolina,Union County,2006,175272,0.0,59125,557
-North Carolina,Union County,2007,184675,0.0,60022,621
-North Carolina,Union County,2008,193255,0.0,62087,640
+North Carolina,Robeson County,2013,134841,,29542,397
+North Carolina,Robeson County,2014,134760,,29889,404
+North Carolina,Robeson County,2015,134197,,31558,400
+North Carolina,Robeson County,2016,133235,,34254,403
+North Carolina,Robeson County,2017,132606,,32729,440
+North Carolina,Robeson County,2018,131831,,35037,439
+North Carolina,Robeson County,2019,130625,,35035,449
+North Carolina,Robeson County,2021,116328,,37008,499
+North Carolina,Robeson County,2022,116663,,38610,527
+North Carolina,Rockingham County,2005,91419,,34860,406
+North Carolina,Rockingham County,2006,93063,,36840,364
+North Carolina,Rockingham County,2007,92421,,39315,383
+North Carolina,Rockingham County,2008,92282,,37678,423
+North Carolina,Rockingham County,2009,92252,,35066,418
+North Carolina,Rockingham County,2010,93641,,37818,439
+North Carolina,Rockingham County,2011,93329,,35816,446
+North Carolina,Rockingham County,2012,92720,,35863,420
+North Carolina,Rockingham County,2013,91878,,41335,416
+North Carolina,Rockingham County,2014,91696,,38878,440
+North Carolina,Rockingham County,2015,91758,,38241,454
+North Carolina,Rockingham County,2016,91393,,40985,467
+North Carolina,Rockingham County,2017,90949,,48196,464
+North Carolina,Rockingham County,2018,90690,,40688,463
+North Carolina,Rockingham County,2019,91010,,43230,502
+North Carolina,Rockingham County,2021,91266,,42901,535
+North Carolina,Rockingham County,2022,91957,,51310,546
+North Carolina,Rowan County,2005,130457,,39676,473
+North Carolina,Rowan County,2006,136254,,42863,437
+North Carolina,Rowan County,2007,137383,,46675,471
+North Carolina,Rowan County,2008,139225,,42540,525
+North Carolina,Rowan County,2009,140798,,43578,524
+North Carolina,Rowan County,2010,138446,,37360,515
+North Carolina,Rowan County,2011,138019,,40008,518
+North Carolina,Rowan County,2012,138180,,40089,537
+North Carolina,Rowan County,2013,138323,,41154,500
+North Carolina,Rowan County,2014,138630,,45978,552
+North Carolina,Rowan County,2015,139142,,45320,571
+North Carolina,Rowan County,2016,139933,,48379,569
+North Carolina,Rowan County,2017,140644,,47396,549
+North Carolina,Rowan County,2018,141262,,46035,613
+North Carolina,Rowan County,2019,142088,,51927,656
+North Carolina,Rowan County,2021,148150,,56408,696
+North Carolina,Rowan County,2022,149645,,61311,780
+North Carolina,Surry County,2005,71330,,33954,334
+North Carolina,Surry County,2006,72687,,35215,341
+North Carolina,Surry County,2007,72380,,35628,397
+North Carolina,Surry County,2008,72468,,36679,312
+North Carolina,Surry County,2009,72496,,33159,400
+North Carolina,Surry County,2010,73694,,35928,414
+North Carolina,Surry County,2011,73714,,32310,410
+North Carolina,Surry County,2012,73561,,36131,426
+North Carolina,Surry County,2013,73050,,35579,417
+North Carolina,Surry County,2014,72968,,36511,416
+North Carolina,Surry County,2015,72743,,37337,444
+North Carolina,Surry County,2016,72113,,36802,442
+North Carolina,Surry County,2017,72224,,42438,435
+North Carolina,Surry County,2018,71948,,48398,457
+North Carolina,Surry County,2019,71783,,49250,444
+North Carolina,Surry County,2021,71152,,51950,548
+North Carolina,Surry County,2022,71403,,44485,499
+North Carolina,Union County,2005,161127,,50072,588
+North Carolina,Union County,2006,175272,,59125,557
+North Carolina,Union County,2007,184675,,60022,621
+North Carolina,Union County,2008,193255,,62087,640
 North Carolina,Union County,2009,198645,5777.0,62387,620
-North Carolina,Union County,2010,202206,0.0,65576,636
-North Carolina,Union County,2011,205463,0.0,61048,584
+North Carolina,Union County,2010,202206,,65576,636
+North Carolina,Union County,2011,205463,,61048,584
 North Carolina,Union County,2012,208520,6333.0,59957,625
 North Carolina,Union County,2013,212756,6854.0,63355,711
 North Carolina,Union County,2014,218568,7864.0,62898,683
-North Carolina,Union County,2015,222742,0.0,71729,733
+North Carolina,Union County,2015,222742,,71729,733
 North Carolina,Union County,2016,226606,7982.0,71588,738
 North Carolina,Union County,2017,231366,8362.0,77691,722
 North Carolina,Union County,2018,235908,8909.0,80337,832
 North Carolina,Union County,2019,239859,10071.0,85985,836
-North Carolina,Union County,2021,243648,0.0,86606,921
+North Carolina,Union County,2021,243648,,86606,921
 North Carolina,Union County,2022,249070,24395.0,94168,1317
 North Carolina,Wake County,2005,730138,19259.0,57284,630
 North Carolina,Wake County,2006,786522,21606.0,60903,640
@@ -8506,76 +8506,76 @@ North Carolina,Wake County,2018,1092305,57777.0,79970,1010
 North Carolina,Wake County,2019,1111761,64182.0,84215,1062
 North Carolina,Wake County,2021,1150204,207878.0,91299,1172
 North Carolina,Wake County,2022,1175021,180063.0,96806,1328
-North Carolina,Wayne County,2005,109615,0.0,35928,378
+North Carolina,Wayne County,2005,109615,,35928,378
 North Carolina,Wayne County,2006,113847,802.0,38158,406
-North Carolina,Wayne County,2007,113590,0.0,40110,396
-North Carolina,Wayne County,2008,113671,0.0,39388,434
-North Carolina,Wayne County,2009,113811,0.0,40944,445
-North Carolina,Wayne County,2010,122907,0.0,40787,438
-North Carolina,Wayne County,2011,123697,0.0,39085,463
+North Carolina,Wayne County,2007,113590,,40110,396
+North Carolina,Wayne County,2008,113671,,39388,434
+North Carolina,Wayne County,2009,113811,,40944,445
+North Carolina,Wayne County,2010,122907,,40787,438
+North Carolina,Wayne County,2011,123697,,39085,463
 North Carolina,Wayne County,2012,124246,1717.0,37905,442
-North Carolina,Wayne County,2013,124583,0.0,42193,545
-North Carolina,Wayne County,2014,124456,0.0,35966,503
-North Carolina,Wayne County,2015,124132,0.0,40361,521
-North Carolina,Wayne County,2016,124150,0.0,41711,563
-North Carolina,Wayne County,2017,124172,0.0,44347,535
-North Carolina,Wayne County,2018,123248,0.0,40791,561
-North Carolina,Wayne County,2019,123131,0.0,44596,631
-North Carolina,Wayne County,2021,116835,0.0,47595,612
-North Carolina,Wayne County,2022,117286,0.0,55588,720
-North Carolina,Wilkes County,2005,66492,0.0,33257,385
-North Carolina,Wilkes County,2006,67310,0.0,32453,369
-North Carolina,Wilkes County,2007,66844,0.0,35705,382
-North Carolina,Wilkes County,2008,66655,0.0,29705,381
-North Carolina,Wilkes County,2009,66555,0.0,33883,367
-North Carolina,Wilkes County,2010,69287,0.0,31869,402
-North Carolina,Wilkes County,2011,68984,0.0,30181,429
-North Carolina,Wilkes County,2012,69306,0.0,33022,416
-North Carolina,Wilkes County,2013,69023,0.0,31135,413
-North Carolina,Wilkes County,2014,68838,0.0,30743,439
-North Carolina,Wilkes County,2015,68502,0.0,40919,404
-North Carolina,Wilkes County,2016,68740,0.0,41332,473
-North Carolina,Wilkes County,2017,68576,0.0,40995,495
-North Carolina,Wilkes County,2018,68557,0.0,43466,440
-North Carolina,Wilkes County,2019,68412,0.0,43290,522
-North Carolina,Wilkes County,2021,65806,0.0,43933,515
-North Carolina,Wilkes County,2022,65784,0.0,45508,501
-North Carolina,Wilson County,2005,74480,0.0,35033,368
-North Carolina,Wilson County,2006,76624,0.0,37023,403
-North Carolina,Wilson County,2007,76754,0.0,36908,390
-North Carolina,Wilson County,2008,77527,0.0,38004,447
-North Carolina,Wilson County,2009,78353,0.0,40053,461
-North Carolina,Wilson County,2010,81359,0.0,34883,404
-North Carolina,Wilson County,2011,81452,0.0,36508,476
-North Carolina,Wilson County,2012,81867,0.0,37020,431
-North Carolina,Wilson County,2013,81667,0.0,41095,480
-North Carolina,Wilson County,2014,81401,0.0,38774,464
-North Carolina,Wilson County,2015,81714,0.0,41204,486
-North Carolina,Wilson County,2016,81661,0.0,39036,471
-North Carolina,Wilson County,2017,81671,0.0,45960,539
-North Carolina,Wilson County,2018,81455,0.0,42769,506
-North Carolina,Wilson County,2019,81801,0.0,38830,435
-North Carolina,Wilson County,2021,78369,0.0,47201,617
-North Carolina,Wilson County,2022,78449,0.0,50267,641
-North Dakota,Burleigh County,2005,71020,0.0,44830,450
-North Dakota,Burleigh County,2006,75384,0.0,48941,477
+North Carolina,Wayne County,2013,124583,,42193,545
+North Carolina,Wayne County,2014,124456,,35966,503
+North Carolina,Wayne County,2015,124132,,40361,521
+North Carolina,Wayne County,2016,124150,,41711,563
+North Carolina,Wayne County,2017,124172,,44347,535
+North Carolina,Wayne County,2018,123248,,40791,561
+North Carolina,Wayne County,2019,123131,,44596,631
+North Carolina,Wayne County,2021,116835,,47595,612
+North Carolina,Wayne County,2022,117286,,55588,720
+North Carolina,Wilkes County,2005,66492,,33257,385
+North Carolina,Wilkes County,2006,67310,,32453,369
+North Carolina,Wilkes County,2007,66844,,35705,382
+North Carolina,Wilkes County,2008,66655,,29705,381
+North Carolina,Wilkes County,2009,66555,,33883,367
+North Carolina,Wilkes County,2010,69287,,31869,402
+North Carolina,Wilkes County,2011,68984,,30181,429
+North Carolina,Wilkes County,2012,69306,,33022,416
+North Carolina,Wilkes County,2013,69023,,31135,413
+North Carolina,Wilkes County,2014,68838,,30743,439
+North Carolina,Wilkes County,2015,68502,,40919,404
+North Carolina,Wilkes County,2016,68740,,41332,473
+North Carolina,Wilkes County,2017,68576,,40995,495
+North Carolina,Wilkes County,2018,68557,,43466,440
+North Carolina,Wilkes County,2019,68412,,43290,522
+North Carolina,Wilkes County,2021,65806,,43933,515
+North Carolina,Wilkes County,2022,65784,,45508,501
+North Carolina,Wilson County,2005,74480,,35033,368
+North Carolina,Wilson County,2006,76624,,37023,403
+North Carolina,Wilson County,2007,76754,,36908,390
+North Carolina,Wilson County,2008,77527,,38004,447
+North Carolina,Wilson County,2009,78353,,40053,461
+North Carolina,Wilson County,2010,81359,,34883,404
+North Carolina,Wilson County,2011,81452,,36508,476
+North Carolina,Wilson County,2012,81867,,37020,431
+North Carolina,Wilson County,2013,81667,,41095,480
+North Carolina,Wilson County,2014,81401,,38774,464
+North Carolina,Wilson County,2015,81714,,41204,486
+North Carolina,Wilson County,2016,81661,,39036,471
+North Carolina,Wilson County,2017,81671,,45960,539
+North Carolina,Wilson County,2018,81455,,42769,506
+North Carolina,Wilson County,2019,81801,,38830,435
+North Carolina,Wilson County,2021,78369,,47201,617
+North Carolina,Wilson County,2022,78449,,50267,641
+North Dakota,Burleigh County,2005,71020,,44830,450
+North Dakota,Burleigh County,2006,75384,,48941,477
 North Dakota,Burleigh County,2007,77316,1933.0,51935,475
-North Dakota,Burleigh County,2008,78689,0.0,53575,523
-North Dakota,Burleigh County,2009,79822,0.0,54379,542
-North Dakota,Burleigh County,2010,81666,0.0,55489,534
-North Dakota,Burleigh County,2011,83145,0.0,57460,596
-North Dakota,Burleigh County,2012,85774,0.0,63258,664
-North Dakota,Burleigh County,2013,88457,0.0,64388,687
-North Dakota,Burleigh County,2014,90503,0.0,68339,714
+North Dakota,Burleigh County,2008,78689,,53575,523
+North Dakota,Burleigh County,2009,79822,,54379,542
+North Dakota,Burleigh County,2010,81666,,55489,534
+North Dakota,Burleigh County,2011,83145,,57460,596
+North Dakota,Burleigh County,2012,85774,,63258,664
+North Dakota,Burleigh County,2013,88457,,64388,687
+North Dakota,Burleigh County,2014,90503,,68339,714
 North Dakota,Burleigh County,2015,92991,1423.0,65079,768
 North Dakota,Burleigh County,2016,94487,1905.0,64558,769
-North Dakota,Burleigh County,2017,95030,0.0,69193,770
-North Dakota,Burleigh County,2018,95273,0.0,71172,760
-North Dakota,Burleigh County,2019,95626,0.0,72494,805
-North Dakota,Burleigh County,2021,98933,0.0,68424,783
-North Dakota,Burleigh County,2022,99280,0.0,81893,818
-North Dakota,Cass County,2005,126098,0.0,43810,495
-North Dakota,Cass County,2006,132525,0.0,46522,507
+North Dakota,Burleigh County,2017,95030,,69193,770
+North Dakota,Burleigh County,2018,95273,,71172,760
+North Dakota,Burleigh County,2019,95626,,72494,805
+North Dakota,Burleigh County,2021,98933,,68424,783
+North Dakota,Burleigh County,2022,99280,,81893,818
+North Dakota,Cass County,2005,126098,,43810,495
+North Dakota,Cass County,2006,132525,,46522,507
 North Dakota,Cass County,2007,137582,2809.0,42596,523
 North Dakota,Cass County,2008,139918,2348.0,45715,522
 North Dakota,Cass County,2009,143339,3538.0,45473,558
@@ -8591,84 +8591,84 @@ North Dakota,Cass County,2018,181516,2768.0,62418,763
 North Dakota,Cass County,2019,181923,3005.0,62218,757
 North Dakota,Cass County,2021,186562,14750.0,66009,736
 North Dakota,Cass County,2022,192734,11458.0,66747,824
-North Dakota,Grand Forks County,2005,59320,0.0,42099,486
-North Dakota,Grand Forks County,2006,65435,0.0,39715,503
-North Dakota,Grand Forks County,2007,66983,0.0,42475,548
-North Dakota,Grand Forks County,2008,66585,0.0,48145,558
-North Dakota,Grand Forks County,2009,66414,0.0,41880,573
-North Dakota,Grand Forks County,2010,66991,0.0,42923,577
-North Dakota,Grand Forks County,2011,66598,0.0,43917,591
+North Dakota,Grand Forks County,2005,59320,,42099,486
+North Dakota,Grand Forks County,2006,65435,,39715,503
+North Dakota,Grand Forks County,2007,66983,,42475,548
+North Dakota,Grand Forks County,2008,66585,,48145,558
+North Dakota,Grand Forks County,2009,66414,,41880,573
+North Dakota,Grand Forks County,2010,66991,,42923,577
+North Dakota,Grand Forks County,2011,66598,,43917,591
 North Dakota,Grand Forks County,2012,67472,2086.0,42176,621
-North Dakota,Grand Forks County,2013,69179,0.0,49248,666
-North Dakota,Grand Forks County,2014,70138,0.0,49532,674
-North Dakota,Grand Forks County,2015,70916,0.0,51264,755
-North Dakota,Grand Forks County,2016,71083,0.0,50008,680
+North Dakota,Grand Forks County,2013,69179,,49248,666
+North Dakota,Grand Forks County,2014,70138,,49532,674
+North Dakota,Grand Forks County,2015,70916,,51264,755
+North Dakota,Grand Forks County,2016,71083,,50008,680
 North Dakota,Grand Forks County,2017,70795,1856.0,47496,678
-North Dakota,Grand Forks County,2018,70770,0.0,52853,779
-North Dakota,Grand Forks County,2019,69451,0.0,56622,733
+North Dakota,Grand Forks County,2018,70770,,52853,779
+North Dakota,Grand Forks County,2019,69451,,56622,733
 North Dakota,Grand Forks County,2021,72705,3285.0,65184,888
-North Dakota,Grand Forks County,2022,72413,0.0,61972,780
-North Dakota,Ward County,2013,67990,0.0,57679,848
-North Dakota,Ward County,2014,69384,0.0,66570,1003
-North Dakota,Ward County,2015,71275,0.0,62631,917
-North Dakota,Ward County,2016,70210,0.0,62573,865
-North Dakota,Ward County,2017,68946,0.0,64742,756
-North Dakota,Ward County,2018,67744,0.0,65719,861
-North Dakota,Ward County,2019,67641,0.0,71415,747
-North Dakota,Ward County,2021,69071,0.0,71061,887
-North Dakota,Ward County,2022,68870,0.0,73787,820
-Ohio,Allen County,2005,101619,0.0,41712,408
-Ohio,Allen County,2006,105788,0.0,44100,389
-Ohio,Allen County,2007,105233,0.0,44002,429
-Ohio,Allen County,2008,105168,0.0,44210,461
-Ohio,Allen County,2009,104357,0.0,37855,450
-Ohio,Allen County,2010,106205,0.0,41057,457
-Ohio,Allen County,2011,106094,0.0,41307,448
-Ohio,Allen County,2012,105141,0.0,41729,491
-Ohio,Allen County,2013,105298,0.0,43030,500
-Ohio,Allen County,2014,105040,0.0,42701,479
-Ohio,Allen County,2015,104425,0.0,50332,510
-Ohio,Allen County,2016,103742,0.0,47592,487
+North Dakota,Grand Forks County,2022,72413,,61972,780
+North Dakota,Ward County,2013,67990,,57679,848
+North Dakota,Ward County,2014,69384,,66570,1003
+North Dakota,Ward County,2015,71275,,62631,917
+North Dakota,Ward County,2016,70210,,62573,865
+North Dakota,Ward County,2017,68946,,64742,756
+North Dakota,Ward County,2018,67744,,65719,861
+North Dakota,Ward County,2019,67641,,71415,747
+North Dakota,Ward County,2021,69071,,71061,887
+North Dakota,Ward County,2022,68870,,73787,820
+Ohio,Allen County,2005,101619,,41712,408
+Ohio,Allen County,2006,105788,,44100,389
+Ohio,Allen County,2007,105233,,44002,429
+Ohio,Allen County,2008,105168,,44210,461
+Ohio,Allen County,2009,104357,,37855,450
+Ohio,Allen County,2010,106205,,41057,457
+Ohio,Allen County,2011,106094,,41307,448
+Ohio,Allen County,2012,105141,,41729,491
+Ohio,Allen County,2013,105298,,43030,500
+Ohio,Allen County,2014,105040,,42701,479
+Ohio,Allen County,2015,104425,,50332,510
+Ohio,Allen County,2016,103742,,47592,487
 Ohio,Allen County,2017,103198,1606.0,51542,508
-Ohio,Allen County,2018,102663,0.0,49063,538
-Ohio,Allen County,2019,102351,0.0,60429,513
-Ohio,Allen County,2021,101670,0.0,51497,600
+Ohio,Allen County,2018,102663,,49063,538
+Ohio,Allen County,2019,102351,,60429,513
+Ohio,Allen County,2021,101670,,51497,600
 Ohio,Allen County,2022,101115,2287.0,59880,683
-Ohio,Ashtabula County,2005,101082,0.0,36611,424
-Ohio,Ashtabula County,2006,102703,0.0,37628,464
-Ohio,Ashtabula County,2007,101141,0.0,39806,444
-Ohio,Ashtabula County,2008,100648,0.0,42417,470
-Ohio,Ashtabula County,2009,100767,0.0,39610,442
-Ohio,Ashtabula County,2010,101429,0.0,38751,475
-Ohio,Ashtabula County,2011,101345,0.0,38204,464
-Ohio,Ashtabula County,2012,100389,0.0,36015,485
-Ohio,Ashtabula County,2013,99811,0.0,40839,474
-Ohio,Ashtabula County,2014,99175,0.0,39079,494
-Ohio,Ashtabula County,2015,98632,0.0,44511,531
-Ohio,Ashtabula County,2016,98231,0.0,42965,546
-Ohio,Ashtabula County,2017,97807,0.0,44173,530
-Ohio,Ashtabula County,2018,97493,0.0,46349,534
-Ohio,Ashtabula County,2019,97241,0.0,44580,533
-Ohio,Ashtabula County,2021,97337,0.0,46771,605
+Ohio,Ashtabula County,2005,101082,,36611,424
+Ohio,Ashtabula County,2006,102703,,37628,464
+Ohio,Ashtabula County,2007,101141,,39806,444
+Ohio,Ashtabula County,2008,100648,,42417,470
+Ohio,Ashtabula County,2009,100767,,39610,442
+Ohio,Ashtabula County,2010,101429,,38751,475
+Ohio,Ashtabula County,2011,101345,,38204,464
+Ohio,Ashtabula County,2012,100389,,36015,485
+Ohio,Ashtabula County,2013,99811,,40839,474
+Ohio,Ashtabula County,2014,99175,,39079,494
+Ohio,Ashtabula County,2015,98632,,44511,531
+Ohio,Ashtabula County,2016,98231,,42965,546
+Ohio,Ashtabula County,2017,97807,,44173,530
+Ohio,Ashtabula County,2018,97493,,46349,534
+Ohio,Ashtabula County,2019,97241,,44580,533
+Ohio,Ashtabula County,2021,97337,,46771,605
 Ohio,Ashtabula County,2022,97014,1820.0,51737,630
-Ohio,Belmont County,2005,65833,0.0,34628,342
-Ohio,Belmont County,2006,68771,0.0,37760,320
-Ohio,Belmont County,2007,67908,0.0,35732,350
-Ohio,Belmont County,2008,67975,0.0,39549,331
-Ohio,Belmont County,2009,68066,0.0,38256,367
-Ohio,Belmont County,2010,70319,0.0,38548,368
-Ohio,Belmont County,2011,70151,0.0,40981,385
-Ohio,Belmont County,2012,69671,0.0,44245,405
-Ohio,Belmont County,2013,69571,0.0,38224,400
-Ohio,Belmont County,2014,69461,0.0,42079,439
-Ohio,Belmont County,2015,69154,0.0,46113,419
-Ohio,Belmont County,2016,68673,0.0,48220,435
-Ohio,Belmont County,2017,68029,0.0,54253,466
-Ohio,Belmont County,2018,67505,0.0,50250,477
-Ohio,Belmont County,2019,67006,0.0,49780,494
-Ohio,Belmont County,2021,65849,0.0,50993,461
-Ohio,Belmont County,2022,65509,0.0,56422,566
-Ohio,Butler County,2005,339309,0.0,50140,537
+Ohio,Belmont County,2005,65833,,34628,342
+Ohio,Belmont County,2006,68771,,37760,320
+Ohio,Belmont County,2007,67908,,35732,350
+Ohio,Belmont County,2008,67975,,39549,331
+Ohio,Belmont County,2009,68066,,38256,367
+Ohio,Belmont County,2010,70319,,38548,368
+Ohio,Belmont County,2011,70151,,40981,385
+Ohio,Belmont County,2012,69671,,44245,405
+Ohio,Belmont County,2013,69571,,38224,400
+Ohio,Belmont County,2014,69461,,42079,439
+Ohio,Belmont County,2015,69154,,46113,419
+Ohio,Belmont County,2016,68673,,48220,435
+Ohio,Belmont County,2017,68029,,54253,466
+Ohio,Belmont County,2018,67505,,50250,477
+Ohio,Belmont County,2019,67006,,49780,494
+Ohio,Belmont County,2021,65849,,50993,461
+Ohio,Belmont County,2022,65509,,56422,566
+Ohio,Butler County,2005,339309,,50140,537
 Ohio,Butler County,2006,354992,5263.0,53278,540
 Ohio,Butler County,2007,357888,6328.0,52955,562
 Ohio,Butler County,2008,360765,5326.0,52297,610
@@ -8685,57 +8685,57 @@ Ohio,Butler County,2018,382378,9118.0,60589,715
 Ohio,Butler County,2019,383134,10580.0,68584,723
 Ohio,Butler County,2021,390234,28068.0,72820,799
 Ohio,Butler County,2022,388420,26286.0,74581,785
-Ohio,Clark County,2005,139053,0.0,39319,429
+Ohio,Clark County,2005,139053,,39319,429
 Ohio,Clark County,2006,141872,1800.0,42546,449
-Ohio,Clark County,2007,140477,0.0,42687,441
-Ohio,Clark County,2008,139859,0.0,45467,459
+Ohio,Clark County,2007,140477,,42687,441
+Ohio,Clark County,2008,139859,,45467,459
 Ohio,Clark County,2009,139671,1211.0,42367,471
-Ohio,Clark County,2010,138193,0.0,39580,490
-Ohio,Clark County,2011,137691,0.0,41292,495
-Ohio,Clark County,2012,137206,0.0,39178,502
+Ohio,Clark County,2010,138193,,39580,490
+Ohio,Clark County,2011,137691,,41292,495
+Ohio,Clark County,2012,137206,,39178,502
 Ohio,Clark County,2013,136167,1211.0,43742,491
 Ohio,Clark County,2014,136554,2225.0,41729,520
-Ohio,Clark County,2015,135959,0.0,47963,537
+Ohio,Clark County,2015,135959,,47963,537
 Ohio,Clark County,2016,134786,1761.0,46811,566
-Ohio,Clark County,2017,134557,0.0,46665,524
+Ohio,Clark County,2017,134557,,46665,524
 Ohio,Clark County,2018,134585,2202.0,49875,562
-Ohio,Clark County,2019,134083,0.0,50128,562
-Ohio,Clark County,2021,135633,0.0,59431,570
+Ohio,Clark County,2019,134083,,50128,562
+Ohio,Clark County,2021,135633,,59431,570
 Ohio,Clark County,2022,134831,4596.0,56132,629
-Ohio,Clermont County,2005,189124,0.0,50845,567
+Ohio,Clermont County,2005,189124,,50845,567
 Ohio,Clermont County,2006,192706,3219.0,52279,564
-Ohio,Clermont County,2007,193490,0.0,53029,558
+Ohio,Clermont County,2007,193490,,53029,558
 Ohio,Clermont County,2008,195385,4608.0,61288,568
-Ohio,Clermont County,2009,196364,0.0,58348,570
-Ohio,Clermont County,2010,197604,0.0,56952,605
-Ohio,Clermont County,2011,199139,0.0,55934,633
-Ohio,Clermont County,2012,199085,0.0,53087,610
-Ohio,Clermont County,2013,200218,0.0,61702,603
+Ohio,Clermont County,2009,196364,,58348,570
+Ohio,Clermont County,2010,197604,,56952,605
+Ohio,Clermont County,2011,199139,,55934,633
+Ohio,Clermont County,2012,199085,,53087,610
+Ohio,Clermont County,2013,200218,,61702,603
 Ohio,Clermont County,2014,201560,4805.0,62554,591
 Ohio,Clermont County,2015,201973,5241.0,62054,669
-Ohio,Clermont County,2016,203022,0.0,60661,662
-Ohio,Clermont County,2017,204214,0.0,65632,695
+Ohio,Clermont County,2016,203022,,60661,662
+Ohio,Clermont County,2017,204214,,65632,695
 Ohio,Clermont County,2018,205466,4626.0,64526,709
-Ohio,Clermont County,2019,206428,0.0,67744,700
-Ohio,Clermont County,2021,209642,0.0,69489,766
-Ohio,Clermont County,2022,210805,0.0,78010,895
-Ohio,Columbiana County,2005,107164,0.0,36969,395
-Ohio,Columbiana County,2006,110542,0.0,37791,395
-Ohio,Columbiana County,2007,108698,0.0,39605,407
-Ohio,Columbiana County,2008,107873,0.0,40941,414
-Ohio,Columbiana County,2009,107722,0.0,37595,416
-Ohio,Columbiana County,2010,107800,0.0,35909,424
-Ohio,Columbiana County,2011,107570,0.0,43975,434
-Ohio,Columbiana County,2012,106507,0.0,44210,443
-Ohio,Columbiana County,2013,105893,0.0,42100,450
-Ohio,Columbiana County,2014,105686,0.0,42640,459
-Ohio,Columbiana County,2015,104806,0.0,41887,470
-Ohio,Columbiana County,2016,103685,0.0,47864,482
-Ohio,Columbiana County,2017,103077,0.0,41818,522
-Ohio,Columbiana County,2018,102665,0.0,43745,480
-Ohio,Columbiana County,2019,101883,0.0,53542,485
-Ohio,Columbiana County,2021,101310,0.0,49265,504
-Ohio,Columbiana County,2022,100511,0.0,53095,529
+Ohio,Clermont County,2019,206428,,67744,700
+Ohio,Clermont County,2021,209642,,69489,766
+Ohio,Clermont County,2022,210805,,78010,895
+Ohio,Columbiana County,2005,107164,,36969,395
+Ohio,Columbiana County,2006,110542,,37791,395
+Ohio,Columbiana County,2007,108698,,39605,407
+Ohio,Columbiana County,2008,107873,,40941,414
+Ohio,Columbiana County,2009,107722,,37595,416
+Ohio,Columbiana County,2010,107800,,35909,424
+Ohio,Columbiana County,2011,107570,,43975,434
+Ohio,Columbiana County,2012,106507,,44210,443
+Ohio,Columbiana County,2013,105893,,42100,450
+Ohio,Columbiana County,2014,105686,,42640,459
+Ohio,Columbiana County,2015,104806,,41887,470
+Ohio,Columbiana County,2016,103685,,47864,482
+Ohio,Columbiana County,2017,103077,,41818,522
+Ohio,Columbiana County,2018,102665,,43745,480
+Ohio,Columbiana County,2019,101883,,53542,485
+Ohio,Columbiana County,2021,101310,,49265,504
+Ohio,Columbiana County,2022,100511,,53095,529
 Ohio,Cuyahoga County,2005,1305166,14840.0,39752,533
 Ohio,Cuyahoga County,2006,1314241,15629.0,41522,544
 Ohio,Cuyahoga County,2007,1295958,18239.0,44358,560
@@ -8753,57 +8753,57 @@ Ohio,Cuyahoga County,2018,1243857,26602.0,49910,678
 Ohio,Cuyahoga County,2019,1235072,27913.0,52423,697
 Ohio,Cuyahoga County,2021,1249387,100283.0,55132,757
 Ohio,Cuyahoga County,2022,1236041,95798.0,60736,818
-Ohio,Delaware County,2005,147601,0.0,75767,573
-Ohio,Delaware County,2006,156697,0.0,79173,564
-Ohio,Delaware County,2007,160865,0.0,80448,585
-Ohio,Delaware County,2008,165026,0.0,88899,664
-Ohio,Delaware County,2009,168708,0.0,83106,644
-Ohio,Delaware County,2010,175250,0.0,85146,659
-Ohio,Delaware County,2011,178341,0.0,85365,696
+Ohio,Delaware County,2005,147601,,75767,573
+Ohio,Delaware County,2006,156697,,79173,564
+Ohio,Delaware County,2007,160865,,80448,585
+Ohio,Delaware County,2008,165026,,88899,664
+Ohio,Delaware County,2009,168708,,83106,644
+Ohio,Delaware County,2010,175250,,85146,659
+Ohio,Delaware County,2011,178341,,85365,696
 Ohio,Delaware County,2012,181061,5439.0,85470,706
-Ohio,Delaware County,2013,184979,0.0,84159,742
+Ohio,Delaware County,2013,184979,,84159,742
 Ohio,Delaware County,2014,189113,6739.0,96949,798
-Ohio,Delaware County,2015,193013,0.0,96410,806
+Ohio,Delaware County,2015,193013,,96410,806
 Ohio,Delaware County,2016,196463,7700.0,101693,791
-Ohio,Delaware County,2017,200464,0.0,106933,878
+Ohio,Delaware County,2017,200464,,106933,878
 Ohio,Delaware County,2018,204826,9941.0,99881,917
 Ohio,Delaware County,2019,209177,9332.0,107854,916
-Ohio,Delaware County,2021,220740,0.0,117224,1096
-Ohio,Delaware County,2022,226296,0.0,119030,1181
-Ohio,Erie County,2005,76797,0.0,40627,488
-Ohio,Erie County,2006,78116,0.0,45549,481
-Ohio,Erie County,2007,77323,0.0,48654,507
-Ohio,Erie County,2008,77062,0.0,46385,492
-Ohio,Erie County,2009,76963,0.0,43099,552
-Ohio,Erie County,2010,77070,0.0,42246,513
-Ohio,Erie County,2011,76751,0.0,46949,541
-Ohio,Erie County,2012,76398,0.0,44694,539
-Ohio,Erie County,2013,76048,0.0,46073,535
-Ohio,Erie County,2014,75828,0.0,48734,573
-Ohio,Erie County,2015,75550,0.0,47544,593
-Ohio,Erie County,2016,75107,0.0,48949,553
-Ohio,Erie County,2017,74817,0.0,54958,585
-Ohio,Erie County,2018,74615,0.0,49751,600
-Ohio,Erie County,2019,74266,0.0,60653,609
-Ohio,Erie County,2021,74852,0.0,58403,670
-Ohio,Erie County,2022,74501,0.0,69296,675
-Ohio,Fairfield County,2005,135828,0.0,51044,516
-Ohio,Fairfield County,2006,140591,0.0,55113,527
-Ohio,Fairfield County,2007,141318,0.0,59033,561
-Ohio,Fairfield County,2008,142223,0.0,58104,551
-Ohio,Fairfield County,2009,143712,0.0,51427,571
-Ohio,Fairfield County,2010,146351,0.0,55981,584
-Ohio,Fairfield County,2011,147066,0.0,59607,582
-Ohio,Fairfield County,2012,147474,0.0,60615,613
-Ohio,Fairfield County,2013,148867,0.0,56286,600
-Ohio,Fairfield County,2014,150381,0.0,59933,655
-Ohio,Fairfield County,2015,151408,0.0,61291,638
-Ohio,Fairfield County,2016,152597,0.0,65316,656
-Ohio,Fairfield County,2017,154733,0.0,67310,692
-Ohio,Fairfield County,2018,155782,0.0,67144,718
-Ohio,Fairfield County,2019,157574,0.0,71469,671
-Ohio,Fairfield County,2021,161064,0.0,81226,796
-Ohio,Fairfield County,2022,162898,0.0,82486,806
+Ohio,Delaware County,2021,220740,,117224,1096
+Ohio,Delaware County,2022,226296,,119030,1181
+Ohio,Erie County,2005,76797,,40627,488
+Ohio,Erie County,2006,78116,,45549,481
+Ohio,Erie County,2007,77323,,48654,507
+Ohio,Erie County,2008,77062,,46385,492
+Ohio,Erie County,2009,76963,,43099,552
+Ohio,Erie County,2010,77070,,42246,513
+Ohio,Erie County,2011,76751,,46949,541
+Ohio,Erie County,2012,76398,,44694,539
+Ohio,Erie County,2013,76048,,46073,535
+Ohio,Erie County,2014,75828,,48734,573
+Ohio,Erie County,2015,75550,,47544,593
+Ohio,Erie County,2016,75107,,48949,553
+Ohio,Erie County,2017,74817,,54958,585
+Ohio,Erie County,2018,74615,,49751,600
+Ohio,Erie County,2019,74266,,60653,609
+Ohio,Erie County,2021,74852,,58403,670
+Ohio,Erie County,2022,74501,,69296,675
+Ohio,Fairfield County,2005,135828,,51044,516
+Ohio,Fairfield County,2006,140591,,55113,527
+Ohio,Fairfield County,2007,141318,,59033,561
+Ohio,Fairfield County,2008,142223,,58104,551
+Ohio,Fairfield County,2009,143712,,51427,571
+Ohio,Fairfield County,2010,146351,,55981,584
+Ohio,Fairfield County,2011,147066,,59607,582
+Ohio,Fairfield County,2012,147474,,60615,613
+Ohio,Fairfield County,2013,148867,,56286,600
+Ohio,Fairfield County,2014,150381,,59933,655
+Ohio,Fairfield County,2015,151408,,61291,638
+Ohio,Fairfield County,2016,152597,,65316,656
+Ohio,Fairfield County,2017,154733,,67310,692
+Ohio,Fairfield County,2018,155782,,67144,718
+Ohio,Fairfield County,2019,157574,,71469,671
+Ohio,Fairfield County,2021,161064,,81226,796
+Ohio,Fairfield County,2022,162898,,82486,806
 Ohio,Franklin County,2005,1068080,16830.0,45410,568
 Ohio,Franklin County,2006,1095662,19674.0,45803,571
 Ohio,Franklin County,2007,1118107,21874.0,47900,581
@@ -8821,40 +8821,40 @@ Ohio,Franklin County,2018,1310300,32501.0,60373,802
 Ohio,Franklin County,2019,1316756,35772.0,64713,837
 Ohio,Franklin County,2021,1321414,162342.0,65988,926
 Ohio,Franklin County,2022,1321820,134022.0,69681,1012
-Ohio,Geauga County,2005,94171,0.0,69890,592
-Ohio,Geauga County,2006,95676,0.0,61120,569
-Ohio,Geauga County,2007,95029,0.0,67276,668
-Ohio,Geauga County,2008,94753,0.0,60969,599
-Ohio,Geauga County,2009,99060,0.0,60957,670
-Ohio,Geauga County,2010,93408,0.0,61236,566
-Ohio,Geauga County,2011,93228,0.0,63855,607
-Ohio,Geauga County,2012,93680,0.0,67264,682
+Ohio,Geauga County,2005,94171,,69890,592
+Ohio,Geauga County,2006,95676,,61120,569
+Ohio,Geauga County,2007,95029,,67276,668
+Ohio,Geauga County,2008,94753,,60969,599
+Ohio,Geauga County,2009,99060,,60957,670
+Ohio,Geauga County,2010,93408,,61236,566
+Ohio,Geauga County,2011,93228,,63855,607
+Ohio,Geauga County,2012,93680,,67264,682
 Ohio,Geauga County,2013,93972,3719.0,66428,679
 Ohio,Geauga County,2014,94295,3422.0,72001,695
-Ohio,Geauga County,2015,94102,0.0,75895,620
+Ohio,Geauga County,2015,94102,,75895,620
 Ohio,Geauga County,2016,94060,4474.0,76384,648
 Ohio,Geauga County,2017,93918,5225.0,82741,641
-Ohio,Geauga County,2018,94031,0.0,82784,740
+Ohio,Geauga County,2018,94031,,82784,740
 Ohio,Geauga County,2019,93649,3432.0,77391,695
 Ohio,Geauga County,2021,95565,8456.0,91305,867
-Ohio,Geauga County,2022,95469,0.0,102350,834
-Ohio,Greene County,2005,143218,0.0,56659,613
-Ohio,Greene County,2006,152298,0.0,55895,569
-Ohio,Greene County,2007,154656,0.0,54560,592
+Ohio,Geauga County,2022,95469,,102350,834
+Ohio,Greene County,2005,143218,,56659,613
+Ohio,Greene County,2006,152298,,55895,569
+Ohio,Greene County,2007,154656,,54560,592
 Ohio,Greene County,2008,159190,2654.0,57849,651
-Ohio,Greene County,2009,159823,0.0,55310,590
-Ohio,Greene County,2010,161605,0.0,51048,626
-Ohio,Greene County,2011,162846,0.0,56194,632
-Ohio,Greene County,2012,163587,0.0,52544,656
-Ohio,Greene County,2013,163204,0.0,59872,677
-Ohio,Greene County,2014,163820,0.0,58396,642
-Ohio,Greene County,2015,164427,0.0,59803,688
-Ohio,Greene County,2016,164765,0.0,62018,696
-Ohio,Greene County,2017,166752,0.0,67923,699
-Ohio,Greene County,2018,167995,0.0,67680,698
+Ohio,Greene County,2009,159823,,55310,590
+Ohio,Greene County,2010,161605,,51048,626
+Ohio,Greene County,2011,162846,,56194,632
+Ohio,Greene County,2012,163587,,52544,656
+Ohio,Greene County,2013,163204,,59872,677
+Ohio,Greene County,2014,163820,,58396,642
+Ohio,Greene County,2015,164427,,59803,688
+Ohio,Greene County,2016,164765,,62018,696
+Ohio,Greene County,2017,166752,,67923,699
+Ohio,Greene County,2018,167995,,67680,698
 Ohio,Greene County,2019,168937,3820.0,67394,723
-Ohio,Greene County,2021,168412,0.0,79271,793
-Ohio,Greene County,2022,168456,0.0,82602,866
+Ohio,Greene County,2021,168412,,79271,793
+Ohio,Greene County,2022,168456,,82602,866
 Ohio,Hamilton County,2005,786982,14596.0,43933,503
 Ohio,Hamilton County,2006,822596,11341.0,44652,497
 Ohio,Hamilton County,2007,842369,13818.0,48416,515
@@ -8872,24 +8872,24 @@ Ohio,Hamilton County,2018,816684,19712.0,57189,675
 Ohio,Hamilton County,2019,817473,22769.0,60198,704
 Ohio,Hamilton County,2021,826139,77455.0,64065,766
 Ohio,Hamilton County,2022,825037,64384.0,66878,823
-Ohio,Hancock County,2005,71503,0.0,45117,476
-Ohio,Hancock County,2006,73824,0.0,44433,442
-Ohio,Hancock County,2007,74204,0.0,48567,526
-Ohio,Hancock County,2008,74273,0.0,51386,493
-Ohio,Hancock County,2009,74538,0.0,47556,520
-Ohio,Hancock County,2010,74727,0.0,50150,546
-Ohio,Hancock County,2011,75056,0.0,46742,476
-Ohio,Hancock County,2012,75671,0.0,47947,531
-Ohio,Hancock County,2013,75773,0.0,46382,532
-Ohio,Hancock County,2014,75337,0.0,50898,541
-Ohio,Hancock County,2015,75573,0.0,54709,621
-Ohio,Hancock County,2016,75872,0.0,52810,572
-Ohio,Hancock County,2017,75754,0.0,51360,597
-Ohio,Hancock County,2018,75930,0.0,60788,577
-Ohio,Hancock County,2019,75783,0.0,60944,601
-Ohio,Hancock County,2021,74656,0.0,64024,642
-Ohio,Hancock County,2022,74861,0.0,71377,739
-Ohio,Lake County,2005,229566,0.0,48885,631
+Ohio,Hancock County,2005,71503,,45117,476
+Ohio,Hancock County,2006,73824,,44433,442
+Ohio,Hancock County,2007,74204,,48567,526
+Ohio,Hancock County,2008,74273,,51386,493
+Ohio,Hancock County,2009,74538,,47556,520
+Ohio,Hancock County,2010,74727,,50150,546
+Ohio,Hancock County,2011,75056,,46742,476
+Ohio,Hancock County,2012,75671,,47947,531
+Ohio,Hancock County,2013,75773,,46382,532
+Ohio,Hancock County,2014,75337,,50898,541
+Ohio,Hancock County,2015,75573,,54709,621
+Ohio,Hancock County,2016,75872,,52810,572
+Ohio,Hancock County,2017,75754,,51360,597
+Ohio,Hancock County,2018,75930,,60788,577
+Ohio,Hancock County,2019,75783,,60944,601
+Ohio,Hancock County,2021,74656,,64024,642
+Ohio,Hancock County,2022,74861,,71377,739
+Ohio,Lake County,2005,229566,,48885,631
 Ohio,Lake County,2006,232892,2732.0,51322,613
 Ohio,Lake County,2007,233392,4599.0,55607,646
 Ohio,Lake County,2008,234030,4156.0,58536,643
@@ -8904,26 +8904,26 @@ Ohio,Lake County,2016,228614,3721.0,61870,768
 Ohio,Lake County,2017,230117,3992.0,59618,749
 Ohio,Lake County,2018,230514,5918.0,65835,773
 Ohio,Lake County,2019,230149,5998.0,64076,763
-Ohio,Lake County,2021,232023,0.0,74273,829
+Ohio,Lake County,2021,232023,,74273,829
 Ohio,Lake County,2022,231842,18669.0,75615,902
-Ohio,Licking County,2005,151499,0.0,49980,450
-Ohio,Licking County,2006,156287,0.0,50386,517
-Ohio,Licking County,2007,156985,0.0,53551,524
+Ohio,Licking County,2005,151499,,49980,450
+Ohio,Licking County,2006,156287,,50386,517
+Ohio,Licking County,2007,156985,,53551,524
 Ohio,Licking County,2008,157721,3287.0,51392,520
-Ohio,Licking County,2009,158488,0.0,50922,522
-Ohio,Licking County,2010,166701,0.0,51132,581
+Ohio,Licking County,2009,158488,,50922,522
+Ohio,Licking County,2010,166701,,51132,581
 Ohio,Licking County,2011,167248,3819.0,54887,539
 Ohio,Licking County,2012,167537,5322.0,52331,580
-Ohio,Licking County,2013,168375,0.0,54875,565
-Ohio,Licking County,2014,169390,0.0,57654,563
-Ohio,Licking County,2015,170570,0.0,59883,624
-Ohio,Licking County,2016,172198,0.0,58685,629
+Ohio,Licking County,2013,168375,,54875,565
+Ohio,Licking County,2014,169390,,57654,563
+Ohio,Licking County,2015,170570,,59883,624
+Ohio,Licking County,2016,172198,,58685,629
 Ohio,Licking County,2017,173448,3912.0,62883,637
-Ohio,Licking County,2018,175769,0.0,67784,639
-Ohio,Licking County,2019,176862,0.0,66013,704
-Ohio,Licking County,2021,180401,0.0,73325,742
+Ohio,Licking County,2018,175769,,67784,639
+Ohio,Licking County,2019,176862,,66013,704
+Ohio,Licking County,2021,180401,,73325,742
 Ohio,Licking County,2022,181359,14509.0,76654,745
-Ohio,Lorain County,2005,287985,0.0,47913,493
+Ohio,Lorain County,2005,287985,,47913,493
 Ohio,Lorain County,2006,301993,2871.0,48838,508
 Ohio,Lorain County,2007,302260,2959.0,50718,525
 Ohio,Lorain County,2008,304373,3866.0,52834,515
@@ -8957,12 +8957,12 @@ Ohio,Lucas County,2018,429899,4194.0,47360,588
 Ohio,Lucas County,2019,428348,5440.0,49448,606
 Ohio,Lucas County,2021,429191,20179.0,52687,638
 Ohio,Lucas County,2022,426643,16253.0,57736,698
-Ohio,Mahoning County,2005,240774,0.0,36294,413
+Ohio,Mahoning County,2005,240774,,36294,413
 Ohio,Mahoning County,2006,251026,1648.0,38393,417
 Ohio,Mahoning County,2007,240420,3216.0,38763,456
 Ohio,Mahoning County,2008,237978,2467.0,40125,441
-Ohio,Mahoning County,2009,236735,0.0,39111,459
-Ohio,Mahoning County,2010,238310,0.0,37847,479
+Ohio,Mahoning County,2009,236735,,39111,459
+Ohio,Mahoning County,2010,238310,,37847,479
 Ohio,Mahoning County,2011,237270,2143.0,39356,478
 Ohio,Mahoning County,2012,235145,2664.0,39642,496
 Ohio,Mahoning County,2013,233869,3079.0,40843,498
@@ -8972,59 +8972,59 @@ Ohio,Mahoning County,2016,230008,3942.0,42295,518
 Ohio,Mahoning County,2017,229796,2733.0,43389,537
 Ohio,Mahoning County,2018,229642,4480.0,47962,529
 Ohio,Mahoning County,2019,228683,3543.0,47170,555
-Ohio,Mahoning County,2021,226762,0.0,49520,545
+Ohio,Mahoning County,2021,226762,,49520,545
 Ohio,Mahoning County,2022,225636,9045.0,54473,622
-Ohio,Marion County,2005,61031,0.0,38129,416
-Ohio,Marion County,2006,65583,0.0,39585,467
-Ohio,Marion County,2007,65248,0.0,40841,449
-Ohio,Marion County,2008,65768,0.0,34449,456
-Ohio,Marion County,2009,65655,0.0,39621,481
-Ohio,Marion County,2010,66482,0.0,38824,506
-Ohio,Marion County,2011,66212,0.0,41133,490
-Ohio,Marion County,2012,66238,0.0,43004,516
-Ohio,Marion County,2013,65905,0.0,41849,522
-Ohio,Marion County,2014,65720,0.0,39233,505
-Ohio,Marion County,2015,65355,0.0,40607,510
-Ohio,Marion County,2016,65096,0.0,42826,520
-Ohio,Marion County,2017,64967,0.0,44766,530
-Ohio,Marion County,2018,65256,0.0,43008,540
-Ohio,Marion County,2019,65093,0.0,50608,575
-Ohio,Marion County,2021,65291,0.0,48919,600
-Ohio,Marion County,2022,64642,0.0,56707,621
-Ohio,Medina County,2005,165491,0.0,62022,621
+Ohio,Marion County,2005,61031,,38129,416
+Ohio,Marion County,2006,65583,,39585,467
+Ohio,Marion County,2007,65248,,40841,449
+Ohio,Marion County,2008,65768,,34449,456
+Ohio,Marion County,2009,65655,,39621,481
+Ohio,Marion County,2010,66482,,38824,506
+Ohio,Marion County,2011,66212,,41133,490
+Ohio,Marion County,2012,66238,,43004,516
+Ohio,Marion County,2013,65905,,41849,522
+Ohio,Marion County,2014,65720,,39233,505
+Ohio,Marion County,2015,65355,,40607,510
+Ohio,Marion County,2016,65096,,42826,520
+Ohio,Marion County,2017,64967,,44766,530
+Ohio,Marion County,2018,65256,,43008,540
+Ohio,Marion County,2019,65093,,50608,575
+Ohio,Marion County,2021,65291,,48919,600
+Ohio,Marion County,2022,64642,,56707,621
+Ohio,Medina County,2005,165491,,62022,621
 Ohio,Medina County,2006,169353,4678.0,64579,602
-Ohio,Medina County,2007,169832,0.0,61411,609
-Ohio,Medina County,2008,171210,0.0,65381,640
-Ohio,Medina County,2009,174035,0.0,66297,623
-Ohio,Medina County,2010,172592,0.0,63543,640
-Ohio,Medina County,2011,173262,0.0,59572,648
-Ohio,Medina County,2012,173684,0.0,65078,639
-Ohio,Medina County,2013,174915,0.0,66477,705
-Ohio,Medina County,2014,176029,0.0,67969,685
-Ohio,Medina County,2015,176395,0.0,69989,677
-Ohio,Medina County,2016,177221,0.0,72618,695
-Ohio,Medina County,2017,178371,0.0,71360,695
-Ohio,Medina County,2018,179146,0.0,75786,734
-Ohio,Medina County,2019,179746,0.0,76468,749
+Ohio,Medina County,2007,169832,,61411,609
+Ohio,Medina County,2008,171210,,65381,640
+Ohio,Medina County,2009,174035,,66297,623
+Ohio,Medina County,2010,172592,,63543,640
+Ohio,Medina County,2011,173262,,59572,648
+Ohio,Medina County,2012,173684,,65078,639
+Ohio,Medina County,2013,174915,,66477,705
+Ohio,Medina County,2014,176029,,67969,685
+Ohio,Medina County,2015,176395,,69989,677
+Ohio,Medina County,2016,177221,,72618,695
+Ohio,Medina County,2017,178371,,71360,695
+Ohio,Medina County,2018,179146,,75786,734
+Ohio,Medina County,2019,179746,,76468,749
 Ohio,Medina County,2021,183092,16000.0,86646,890
-Ohio,Medina County,2022,183512,0.0,87796,847
-Ohio,Miami County,2005,100220,0.0,46136,473
-Ohio,Miami County,2006,101914,0.0,49086,461
-Ohio,Miami County,2007,101038,0.0,50173,487
-Ohio,Miami County,2008,101085,0.0,53091,467
-Ohio,Miami County,2009,101256,0.0,49455,481
-Ohio,Miami County,2010,102461,0.0,49222,555
-Ohio,Miami County,2011,102857,0.0,46759,539
-Ohio,Miami County,2012,103060,0.0,53101,488
-Ohio,Miami County,2013,103439,0.0,51581,565
-Ohio,Miami County,2014,103900,0.0,51087,593
-Ohio,Miami County,2015,104224,0.0,49156,553
-Ohio,Miami County,2016,104679,0.0,60170,574
-Ohio,Miami County,2017,105122,0.0,60910,577
-Ohio,Miami County,2018,106222,0.0,58486,548
-Ohio,Miami County,2019,106987,0.0,62451,620
-Ohio,Miami County,2021,109264,0.0,64345,621
-Ohio,Miami County,2022,110247,0.0,71457,735
+Ohio,Medina County,2022,183512,,87796,847
+Ohio,Miami County,2005,100220,,46136,473
+Ohio,Miami County,2006,101914,,49086,461
+Ohio,Miami County,2007,101038,,50173,487
+Ohio,Miami County,2008,101085,,53091,467
+Ohio,Miami County,2009,101256,,49455,481
+Ohio,Miami County,2010,102461,,49222,555
+Ohio,Miami County,2011,102857,,46759,539
+Ohio,Miami County,2012,103060,,53101,488
+Ohio,Miami County,2013,103439,,51581,565
+Ohio,Miami County,2014,103900,,51087,593
+Ohio,Miami County,2015,104224,,49156,553
+Ohio,Miami County,2016,104679,,60170,574
+Ohio,Miami County,2017,105122,,60910,577
+Ohio,Miami County,2018,106222,,58486,548
+Ohio,Miami County,2019,106987,,62451,620
+Ohio,Miami County,2021,109264,,64345,621
+Ohio,Miami County,2022,110247,,71457,735
 Ohio,Montgomery County,2005,531864,3891.0,41004,496
 Ohio,Montgomery County,2006,542237,6358.0,41161,513
 Ohio,Montgomery County,2007,538104,6487.0,43939,499
@@ -9042,92 +9042,92 @@ Ohio,Montgomery County,2018,532331,9828.0,50838,622
 Ohio,Montgomery County,2019,531687,10905.0,54537,639
 Ohio,Montgomery County,2021,535840,32898.0,56471,725
 Ohio,Montgomery County,2022,533892,32838.0,62728,760
-Ohio,Muskingum County,2005,83110,0.0,36870,368
-Ohio,Muskingum County,2006,86125,0.0,36047,381
-Ohio,Muskingum County,2007,85333,0.0,40702,389
-Ohio,Muskingum County,2008,85087,0.0,41569,434
-Ohio,Muskingum County,2009,84884,0.0,36989,428
-Ohio,Muskingum County,2010,86142,0.0,40894,473
-Ohio,Muskingum County,2011,86237,0.0,38259,462
-Ohio,Muskingum County,2012,85950,0.0,39266,458
-Ohio,Muskingum County,2013,85231,0.0,39212,471
-Ohio,Muskingum County,2014,85818,0.0,41230,485
-Ohio,Muskingum County,2015,86290,0.0,42815,491
-Ohio,Muskingum County,2016,86068,0.0,43422,502
-Ohio,Muskingum County,2017,86149,0.0,43113,493
-Ohio,Muskingum County,2018,86183,0.0,49602,537
-Ohio,Muskingum County,2019,86215,0.0,51844,531
-Ohio,Muskingum County,2021,86408,0.0,51173,535
-Ohio,Muskingum County,2022,86113,0.0,58326,624
-Ohio,Portage County,2005,147502,0.0,46842,563
+Ohio,Muskingum County,2005,83110,,36870,368
+Ohio,Muskingum County,2006,86125,,36047,381
+Ohio,Muskingum County,2007,85333,,40702,389
+Ohio,Muskingum County,2008,85087,,41569,434
+Ohio,Muskingum County,2009,84884,,36989,428
+Ohio,Muskingum County,2010,86142,,40894,473
+Ohio,Muskingum County,2011,86237,,38259,462
+Ohio,Muskingum County,2012,85950,,39266,458
+Ohio,Muskingum County,2013,85231,,39212,471
+Ohio,Muskingum County,2014,85818,,41230,485
+Ohio,Muskingum County,2015,86290,,42815,491
+Ohio,Muskingum County,2016,86068,,43422,502
+Ohio,Muskingum County,2017,86149,,43113,493
+Ohio,Muskingum County,2018,86183,,49602,537
+Ohio,Muskingum County,2019,86215,,51844,531
+Ohio,Muskingum County,2021,86408,,51173,535
+Ohio,Muskingum County,2022,86113,,58326,624
+Ohio,Portage County,2005,147502,,46842,563
 Ohio,Portage County,2006,155012,2227.0,43840,583
-Ohio,Portage County,2007,155869,0.0,49983,621
-Ohio,Portage County,2008,155991,0.0,52364,616
-Ohio,Portage County,2009,157530,0.0,48897,629
-Ohio,Portage County,2010,161386,0.0,49244,612
-Ohio,Portage County,2011,161624,0.0,49554,599
-Ohio,Portage County,2012,161451,0.0,52364,661
-Ohio,Portage County,2013,163862,0.0,52337,703
+Ohio,Portage County,2007,155869,,49983,621
+Ohio,Portage County,2008,155991,,52364,616
+Ohio,Portage County,2009,157530,,48897,629
+Ohio,Portage County,2010,161386,,49244,612
+Ohio,Portage County,2011,161624,,49554,599
+Ohio,Portage County,2012,161451,,52364,661
+Ohio,Portage County,2013,163862,,52337,703
 Ohio,Portage County,2014,161882,3972.0,51275,666
 Ohio,Portage County,2015,162275,3288.0,52835,657
-Ohio,Portage County,2016,161921,0.0,49695,653
-Ohio,Portage County,2017,162277,0.0,59402,736
+Ohio,Portage County,2016,161921,,49695,653
+Ohio,Portage County,2017,162277,,59402,736
 Ohio,Portage County,2018,162927,5650.0,64550,738
-Ohio,Portage County,2019,162466,0.0,56679,744
-Ohio,Portage County,2021,162382,0.0,64471,747
-Ohio,Portage County,2022,161745,0.0,72964,825
-Ohio,Richland County,2005,121365,0.0,39220,387
-Ohio,Richland County,2006,127010,0.0,38393,396
-Ohio,Richland County,2007,125679,0.0,43445,422
-Ohio,Richland County,2008,124999,0.0,42578,430
-Ohio,Richland County,2009,124490,0.0,39350,443
-Ohio,Richland County,2010,124177,0.0,41572,444
-Ohio,Richland County,2011,123510,0.0,40117,462
-Ohio,Richland County,2012,122673,0.0,41680,480
-Ohio,Richland County,2013,121773,0.0,39455,441
-Ohio,Richland County,2014,121942,0.0,41548,465
-Ohio,Richland County,2015,121707,0.0,45155,492
-Ohio,Richland County,2016,121107,0.0,44073,510
-Ohio,Richland County,2017,120589,0.0,46032,468
-Ohio,Richland County,2018,121099,0.0,49564,485
+Ohio,Portage County,2019,162466,,56679,744
+Ohio,Portage County,2021,162382,,64471,747
+Ohio,Portage County,2022,161745,,72964,825
+Ohio,Richland County,2005,121365,,39220,387
+Ohio,Richland County,2006,127010,,38393,396
+Ohio,Richland County,2007,125679,,43445,422
+Ohio,Richland County,2008,124999,,42578,430
+Ohio,Richland County,2009,124490,,39350,443
+Ohio,Richland County,2010,124177,,41572,444
+Ohio,Richland County,2011,123510,,40117,462
+Ohio,Richland County,2012,122673,,41680,480
+Ohio,Richland County,2013,121773,,39455,441
+Ohio,Richland County,2014,121942,,41548,465
+Ohio,Richland County,2015,121707,,45155,492
+Ohio,Richland County,2016,121107,,44073,510
+Ohio,Richland County,2017,120589,,46032,468
+Ohio,Richland County,2018,121099,,49564,485
 Ohio,Richland County,2019,121154,1940.0,51783,525
 Ohio,Richland County,2021,125195,3884.0,51158,570
-Ohio,Richland County,2022,125319,0.0,53047,642
-Ohio,Ross County,2005,69435,0.0,36638,412
-Ohio,Ross County,2006,75556,0.0,37054,417
-Ohio,Ross County,2007,75398,0.0,42466,411
-Ohio,Ross County,2008,76073,0.0,43966,456
-Ohio,Ross County,2009,75972,0.0,41187,455
-Ohio,Ross County,2010,78090,0.0,40811,460
-Ohio,Ross County,2011,78249,0.0,43464,448
-Ohio,Ross County,2012,77429,0.0,42951,465
-Ohio,Ross County,2013,77910,0.0,40493,498
-Ohio,Ross County,2014,77159,0.0,40764,489
-Ohio,Ross County,2015,77170,0.0,44907,525
-Ohio,Ross County,2016,77000,0.0,46422,543
-Ohio,Ross County,2017,77313,0.0,50713,581
-Ohio,Ross County,2018,76931,0.0,46769,497
-Ohio,Ross County,2019,76666,0.0,55717,544
-Ohio,Ross County,2021,76891,0.0,50395,659
-Ohio,Ross County,2022,76606,0.0,60157,603
-Ohio,Scioto County,2005,73403,0.0,28348,382
-Ohio,Scioto County,2006,76441,0.0,29821,360
-Ohio,Scioto County,2007,75958,0.0,31446,367
-Ohio,Scioto County,2008,76587,0.0,38097,353
-Ohio,Scioto County,2009,76334,0.0,29665,384
-Ohio,Scioto County,2010,79506,0.0,36859,402
-Ohio,Scioto County,2011,79277,0.0,29657,351
-Ohio,Scioto County,2012,78477,0.0,36874,403
-Ohio,Scioto County,2013,78153,0.0,37351,389
-Ohio,Scioto County,2014,77258,0.0,38233,402
-Ohio,Scioto County,2015,76825,0.0,35833,444
-Ohio,Scioto County,2016,76088,0.0,39210,454
-Ohio,Scioto County,2017,75929,0.0,43367,474
-Ohio,Scioto County,2018,75502,0.0,37257,432
-Ohio,Scioto County,2019,75314,0.0,45571,515
-Ohio,Scioto County,2021,73346,0.0,40522,509
-Ohio,Scioto County,2022,72194,0.0,46606,523
-Ohio,Stark County,2005,371677,0.0,42303,453
+Ohio,Richland County,2022,125319,,53047,642
+Ohio,Ross County,2005,69435,,36638,412
+Ohio,Ross County,2006,75556,,37054,417
+Ohio,Ross County,2007,75398,,42466,411
+Ohio,Ross County,2008,76073,,43966,456
+Ohio,Ross County,2009,75972,,41187,455
+Ohio,Ross County,2010,78090,,40811,460
+Ohio,Ross County,2011,78249,,43464,448
+Ohio,Ross County,2012,77429,,42951,465
+Ohio,Ross County,2013,77910,,40493,498
+Ohio,Ross County,2014,77159,,40764,489
+Ohio,Ross County,2015,77170,,44907,525
+Ohio,Ross County,2016,77000,,46422,543
+Ohio,Ross County,2017,77313,,50713,581
+Ohio,Ross County,2018,76931,,46769,497
+Ohio,Ross County,2019,76666,,55717,544
+Ohio,Ross County,2021,76891,,50395,659
+Ohio,Ross County,2022,76606,,60157,603
+Ohio,Scioto County,2005,73403,,28348,382
+Ohio,Scioto County,2006,76441,,29821,360
+Ohio,Scioto County,2007,75958,,31446,367
+Ohio,Scioto County,2008,76587,,38097,353
+Ohio,Scioto County,2009,76334,,29665,384
+Ohio,Scioto County,2010,79506,,36859,402
+Ohio,Scioto County,2011,79277,,29657,351
+Ohio,Scioto County,2012,78477,,36874,403
+Ohio,Scioto County,2013,78153,,37351,389
+Ohio,Scioto County,2014,77258,,38233,402
+Ohio,Scioto County,2015,76825,,35833,444
+Ohio,Scioto County,2016,76088,,39210,454
+Ohio,Scioto County,2017,75929,,43367,474
+Ohio,Scioto County,2018,75502,,37257,432
+Ohio,Scioto County,2019,75314,,45571,515
+Ohio,Scioto County,2021,73346,,40522,509
+Ohio,Scioto County,2022,72194,,46606,523
+Ohio,Stark County,2005,371677,,42303,453
 Ohio,Stark County,2006,380575,4711.0,42332,463
 Ohio,Stark County,2007,378664,4200.0,44891,471
 Ohio,Stark County,2008,379214,5195.0,44447,480
@@ -9144,7 +9144,7 @@ Ohio,Stark County,2018,371574,7372.0,52068,575
 Ohio,Stark County,2019,370606,8548.0,55499,574
 Ohio,Stark County,2021,373834,22728.0,59127,629
 Ohio,Stark County,2022,372657,19573.0,64582,665
-Ohio,Summit County,2005,536957,0.0,43941,545
+Ohio,Summit County,2005,536957,,43941,545
 Ohio,Summit County,2006,545931,6125.0,44747,555
 Ohio,Summit County,2007,543487,7235.0,47333,568
 Ohio,Summit County,2008,542562,8100.0,49411,557
@@ -9161,12 +9161,12 @@ Ohio,Summit County,2018,541918,13131.0,58876,666
 Ohio,Summit County,2019,541013,12720.0,57364,699
 Ohio,Summit County,2021,537633,39353.0,63117,713
 Ohio,Summit County,2022,535882,40454.0,65763,766
-Ohio,Trumbull County,2005,215254,0.0,40922,428
-Ohio,Trumbull County,2006,217362,0.0,42344,429
+Ohio,Trumbull County,2005,215254,,40922,428
+Ohio,Trumbull County,2006,217362,,42344,429
 Ohio,Trumbull County,2007,213475,2625.0,41566,434
 Ohio,Trumbull County,2008,211317,2217.0,41037,465
 Ohio,Trumbull County,2009,210157,2534.0,40880,432
-Ohio,Trumbull County,2010,209936,0.0,40153,452
+Ohio,Trumbull County,2010,209936,,40153,452
 Ohio,Trumbull County,2011,209264,1748.0,40867,452
 Ohio,Trumbull County,2012,207406,2195.0,41049,478
 Ohio,Trumbull County,2013,206442,1835.0,41798,488
@@ -9178,50 +9178,50 @@ Ohio,Trumbull County,2018,198627,3588.0,46196,558
 Ohio,Trumbull County,2019,197974,3252.0,47087,545
 Ohio,Trumbull County,2021,201335,4573.0,51057,565
 Ohio,Trumbull County,2022,200643,4880.0,53220,579
-Ohio,Tuscarawas County,2005,90781,0.0,39411,397
-Ohio,Tuscarawas County,2006,91766,0.0,37560,423
-Ohio,Tuscarawas County,2007,91398,0.0,40699,410
-Ohio,Tuscarawas County,2008,91348,0.0,42992,433
-Ohio,Tuscarawas County,2009,91137,0.0,40801,406
-Ohio,Tuscarawas County,2010,92542,0.0,38882,462
-Ohio,Tuscarawas County,2011,92508,0.0,42082,455
+Ohio,Tuscarawas County,2005,90781,,39411,397
+Ohio,Tuscarawas County,2006,91766,,37560,423
+Ohio,Tuscarawas County,2007,91398,,40699,410
+Ohio,Tuscarawas County,2008,91348,,42992,433
+Ohio,Tuscarawas County,2009,91137,,40801,406
+Ohio,Tuscarawas County,2010,92542,,38882,462
+Ohio,Tuscarawas County,2011,92508,,42082,455
 Ohio,Tuscarawas County,2012,92392,1016.0,43702,458
-Ohio,Tuscarawas County,2013,92672,0.0,44130,458
-Ohio,Tuscarawas County,2014,92788,0.0,46253,509
-Ohio,Tuscarawas County,2015,92916,0.0,47331,519
-Ohio,Tuscarawas County,2016,92420,0.0,50440,546
-Ohio,Tuscarawas County,2017,92297,0.0,51386,547
-Ohio,Tuscarawas County,2018,92176,0.0,49658,554
-Ohio,Tuscarawas County,2019,91987,0.0,53616,567
-Ohio,Tuscarawas County,2021,92500,0.0,58060,599
-Ohio,Tuscarawas County,2022,91937,0.0,58588,611
-Ohio,Union County,2022,66898,0.0,104195,875
-Ohio,Warren County,2005,190403,0.0,63580,616
-Ohio,Warren County,2006,201871,0.0,66834,637
+Ohio,Tuscarawas County,2013,92672,,44130,458
+Ohio,Tuscarawas County,2014,92788,,46253,509
+Ohio,Tuscarawas County,2015,92916,,47331,519
+Ohio,Tuscarawas County,2016,92420,,50440,546
+Ohio,Tuscarawas County,2017,92297,,51386,547
+Ohio,Tuscarawas County,2018,92176,,49658,554
+Ohio,Tuscarawas County,2019,91987,,53616,567
+Ohio,Tuscarawas County,2021,92500,,58060,599
+Ohio,Tuscarawas County,2022,91937,,58588,611
+Ohio,Union County,2022,66898,,104195,875
+Ohio,Warren County,2005,190403,,63580,616
+Ohio,Warren County,2006,201871,,66834,637
 Ohio,Warren County,2007,204390,3214.0,71088,647
-Ohio,Warren County,2008,207353,0.0,70504,680
+Ohio,Warren County,2008,207353,,70504,680
 Ohio,Warren County,2009,210712,3867.0,68114,649
-Ohio,Warren County,2010,213192,0.0,66499,715
-Ohio,Warren County,2011,214910,0.0,69201,707
-Ohio,Warren County,2012,217241,0.0,72898,718
-Ohio,Warren County,2013,219169,0.0,73432,771
-Ohio,Warren County,2014,221659,0.0,71731,756
-Ohio,Warren County,2015,224469,0.0,81017,815
-Ohio,Warren County,2016,227063,0.0,80207,766
-Ohio,Warren County,2017,228882,0.0,84130,855
-Ohio,Warren County,2018,232173,0.0,86473,977
-Ohio,Warren County,2019,234602,0.0,90837,890
-Ohio,Warren County,2021,246553,0.0,95817,1016
-Ohio,Warren County,2022,249778,0.0,104066,1063
-Ohio,Wayne County,2005,110327,0.0,44118,442
+Ohio,Warren County,2010,213192,,66499,715
+Ohio,Warren County,2011,214910,,69201,707
+Ohio,Warren County,2012,217241,,72898,718
+Ohio,Warren County,2013,219169,,73432,771
+Ohio,Warren County,2014,221659,,71731,756
+Ohio,Warren County,2015,224469,,81017,815
+Ohio,Warren County,2016,227063,,80207,766
+Ohio,Warren County,2017,228882,,84130,855
+Ohio,Warren County,2018,232173,,86473,977
+Ohio,Warren County,2019,234602,,90837,890
+Ohio,Warren County,2021,246553,,95817,1016
+Ohio,Warren County,2022,249778,,104066,1063
+Ohio,Wayne County,2005,110327,,44118,442
 Ohio,Wayne County,2006,113950,2276.0,45271,458
-Ohio,Wayne County,2007,113554,0.0,46678,476
+Ohio,Wayne County,2007,113554,,46678,476
 Ohio,Wayne County,2008,113812,3405.0,48360,445
-Ohio,Wayne County,2009,114222,0.0,47562,486
-Ohio,Wayne County,2010,114505,0.0,46288,505
+Ohio,Wayne County,2009,114222,,47562,486
+Ohio,Wayne County,2010,114505,,46288,505
 Ohio,Wayne County,2011,114611,2344.0,46827,498
-Ohio,Wayne County,2012,114848,0.0,47946,553
-Ohio,Wayne County,2013,115071,0.0,49849,530
+Ohio,Wayne County,2012,114848,,47946,553
+Ohio,Wayne County,2013,115071,,49849,530
 Ohio,Wayne County,2014,115537,2491.0,49988,528
 Ohio,Wayne County,2015,116063,4722.0,52760,536
 Ohio,Wayne County,2016,116470,1946.0,53434,588
@@ -9230,41 +9230,41 @@ Ohio,Wayne County,2018,115967,2554.0,59111,575
 Ohio,Wayne County,2019,115710,1988.0,57458,569
 Ohio,Wayne County,2021,116710,6178.0,59666,617
 Ohio,Wayne County,2022,116559,3691.0,69876,627
-Ohio,Wood County,2005,115904,0.0,46893,491
-Ohio,Wood County,2006,124183,0.0,51442,496
-Ohio,Wood County,2007,125399,0.0,50276,513
-Ohio,Wood County,2008,125340,0.0,54681,558
-Ohio,Wood County,2009,125380,0.0,49959,564
-Ohio,Wood County,2010,125502,0.0,47485,563
-Ohio,Wood County,2011,126355,0.0,49792,573
-Ohio,Wood County,2012,128200,0.0,49575,587
+Ohio,Wood County,2005,115904,,46893,491
+Ohio,Wood County,2006,124183,,51442,496
+Ohio,Wood County,2007,125399,,50276,513
+Ohio,Wood County,2008,125340,,54681,558
+Ohio,Wood County,2009,125380,,49959,564
+Ohio,Wood County,2010,125502,,47485,563
+Ohio,Wood County,2011,126355,,49792,573
+Ohio,Wood County,2012,128200,,49575,587
 Ohio,Wood County,2013,129264,1559.0,51680,588
 Ohio,Wood County,2014,129590,1862.0,54402,569
-Ohio,Wood County,2015,129730,0.0,57027,614
-Ohio,Wood County,2016,130219,0.0,60166,660
+Ohio,Wood County,2015,129730,,57027,614
+Ohio,Wood County,2016,130219,,60166,660
 Ohio,Wood County,2017,130492,2911.0,60382,635
-Ohio,Wood County,2018,130696,0.0,63695,628
-Ohio,Wood County,2019,130817,0.0,63791,650
-Ohio,Wood County,2021,132472,0.0,63620,733
-Ohio,Wood County,2022,131592,0.0,65458,766
-Oklahoma,Canadian County,2005,96528,0.0,50527,487
-Oklahoma,Canadian County,2006,101335,0.0,51293,476
-Oklahoma,Canadian County,2007,103559,0.0,58137,544
-Oklahoma,Canadian County,2008,106079,0.0,61326,583
+Ohio,Wood County,2018,130696,,63695,628
+Ohio,Wood County,2019,130817,,63791,650
+Ohio,Wood County,2021,132472,,63620,733
+Ohio,Wood County,2022,131592,,65458,766
+Oklahoma,Canadian County,2005,96528,,50527,487
+Oklahoma,Canadian County,2006,101335,,51293,476
+Oklahoma,Canadian County,2007,103559,,58137,544
+Oklahoma,Canadian County,2008,106079,,61326,583
 Oklahoma,Canadian County,2009,109668,1928.0,65430,599
-Oklahoma,Canadian County,2010,116237,0.0,56072,612
-Oklahoma,Canadian County,2011,119492,0.0,59329,613
-Oklahoma,Canadian County,2012,122560,0.0,62357,719
-Oklahoma,Canadian County,2013,126123,0.0,63549,685
-Oklahoma,Canadian County,2014,129582,0.0,68552,692
-Oklahoma,Canadian County,2015,133378,0.0,62045,658
-Oklahoma,Canadian County,2016,136532,0.0,67177,762
-Oklahoma,Canadian County,2017,139926,0.0,74720,804
-Oklahoma,Canadian County,2018,144447,0.0,70204,789
-Oklahoma,Canadian County,2019,148306,0.0,73635,736
-Oklahoma,Canadian County,2021,161737,0.0,74768,911
-Oklahoma,Canadian County,2022,169149,0.0,80904,965
-Oklahoma,Cleveland County,2005,215597,0.0,44955,519
+Oklahoma,Canadian County,2010,116237,,56072,612
+Oklahoma,Canadian County,2011,119492,,59329,613
+Oklahoma,Canadian County,2012,122560,,62357,719
+Oklahoma,Canadian County,2013,126123,,63549,685
+Oklahoma,Canadian County,2014,129582,,68552,692
+Oklahoma,Canadian County,2015,133378,,62045,658
+Oklahoma,Canadian County,2016,136532,,67177,762
+Oklahoma,Canadian County,2017,139926,,74720,804
+Oklahoma,Canadian County,2018,144447,,70204,789
+Oklahoma,Canadian County,2019,148306,,73635,736
+Oklahoma,Canadian County,2021,161737,,74768,911
+Oklahoma,Canadian County,2022,169149,,80904,965
+Oklahoma,Cleveland County,2005,215597,,44955,519
 Oklahoma,Cleveland County,2006,228594,3108.0,47580,519
 Oklahoma,Cleveland County,2007,236452,3873.0,50888,547
 Oklahoma,Cleveland County,2008,239760,3538.0,53748,559
@@ -9281,57 +9281,57 @@ Oklahoma,Cleveland County,2018,281669,5881.0,62096,742
 Oklahoma,Cleveland County,2019,284014,6012.0,64290,788
 Oklahoma,Cleveland County,2021,297597,18959.0,67172,808
 Oklahoma,Cleveland County,2022,299587,17188.0,70422,884
-Oklahoma,Comanche County,2005,102887,0.0,39883,426
-Oklahoma,Comanche County,2006,109181,0.0,39591,428
+Oklahoma,Comanche County,2005,102887,,39883,426
+Oklahoma,Comanche County,2006,109181,,39591,428
 Oklahoma,Comanche County,2007,113811,4008.0,43693,449
-Oklahoma,Comanche County,2008,111772,0.0,39142,461
-Oklahoma,Comanche County,2009,113228,0.0,47867,530
-Oklahoma,Comanche County,2010,125368,0.0,43817,529
+Oklahoma,Comanche County,2008,111772,,39142,461
+Oklahoma,Comanche County,2009,113228,,47867,530
+Oklahoma,Comanche County,2010,125368,,43817,529
 Oklahoma,Comanche County,2011,125815,3389.0,44585,612
-Oklahoma,Comanche County,2012,126390,0.0,44874,598
-Oklahoma,Comanche County,2013,124937,0.0,41488,603
-Oklahoma,Comanche County,2014,125033,0.0,47235,608
-Oklahoma,Comanche County,2015,124648,0.0,47587,606
+Oklahoma,Comanche County,2012,126390,,44874,598
+Oklahoma,Comanche County,2013,124937,,41488,603
+Oklahoma,Comanche County,2014,125033,,47235,608
+Oklahoma,Comanche County,2015,124648,,47587,606
 Oklahoma,Comanche County,2016,122136,7583.0,51164,597
-Oklahoma,Comanche County,2017,121526,0.0,51059,659
-Oklahoma,Comanche County,2018,120422,0.0,52089,633
-Oklahoma,Comanche County,2019,120749,0.0,51300,639
-Oklahoma,Comanche County,2021,122063,0.0,49325,633
-Oklahoma,Comanche County,2022,123046,0.0,55285,714
-Oklahoma,Creek County,2005,68033,0.0,36454,431
-Oklahoma,Creek County,2006,69146,0.0,37473,371
-Oklahoma,Creek County,2007,69073,0.0,42100,444
-Oklahoma,Creek County,2008,69822,0.0,44065,466
-Oklahoma,Creek County,2009,70244,0.0,40554,478
-Oklahoma,Creek County,2010,70133,0.0,40640,425
-Oklahoma,Creek County,2011,70467,0.0,39030,433
-Oklahoma,Creek County,2012,70651,0.0,44444,489
-Oklahoma,Creek County,2013,70470,0.0,44469,509
-Oklahoma,Creek County,2014,70632,0.0,47286,508
-Oklahoma,Creek County,2015,70892,0.0,46665,548
-Oklahoma,Creek County,2016,71312,0.0,43609,574
-Oklahoma,Creek County,2017,71704,0.0,46877,585
-Oklahoma,Creek County,2018,71604,0.0,55264,570
-Oklahoma,Creek County,2019,71522,0.0,54969,548
-Oklahoma,Creek County,2021,72029,0.0,52818,646
-Oklahoma,Creek County,2022,72699,0.0,56756,682
-Oklahoma,Muskogee County,2005,67312,0.0,31188,349
-Oklahoma,Muskogee County,2006,71018,0.0,32975,367
-Oklahoma,Muskogee County,2007,71116,0.0,38089,383
-Oklahoma,Muskogee County,2008,71278,0.0,32658,405
-Oklahoma,Muskogee County,2009,71412,0.0,31855,401
-Oklahoma,Muskogee County,2010,71110,0.0,39910,410
-Oklahoma,Muskogee County,2011,71003,0.0,34440,424
-Oklahoma,Muskogee County,2012,70596,0.0,37233,470
-Oklahoma,Muskogee County,2013,70303,0.0,39130,464
-Oklahoma,Muskogee County,2014,69966,0.0,42756,469
-Oklahoma,Muskogee County,2015,69699,0.0,41016,484
-Oklahoma,Muskogee County,2016,69477,0.0,40860,476
-Oklahoma,Muskogee County,2017,69086,0.0,36342,482
-Oklahoma,Muskogee County,2018,68362,0.0,45290,530
-Oklahoma,Muskogee County,2019,67997,0.0,42450,539
-Oklahoma,Muskogee County,2021,66146,0.0,43437,531
-Oklahoma,Muskogee County,2022,66354,0.0,54070,622
+Oklahoma,Comanche County,2017,121526,,51059,659
+Oklahoma,Comanche County,2018,120422,,52089,633
+Oklahoma,Comanche County,2019,120749,,51300,639
+Oklahoma,Comanche County,2021,122063,,49325,633
+Oklahoma,Comanche County,2022,123046,,55285,714
+Oklahoma,Creek County,2005,68033,,36454,431
+Oklahoma,Creek County,2006,69146,,37473,371
+Oklahoma,Creek County,2007,69073,,42100,444
+Oklahoma,Creek County,2008,69822,,44065,466
+Oklahoma,Creek County,2009,70244,,40554,478
+Oklahoma,Creek County,2010,70133,,40640,425
+Oklahoma,Creek County,2011,70467,,39030,433
+Oklahoma,Creek County,2012,70651,,44444,489
+Oklahoma,Creek County,2013,70470,,44469,509
+Oklahoma,Creek County,2014,70632,,47286,508
+Oklahoma,Creek County,2015,70892,,46665,548
+Oklahoma,Creek County,2016,71312,,43609,574
+Oklahoma,Creek County,2017,71704,,46877,585
+Oklahoma,Creek County,2018,71604,,55264,570
+Oklahoma,Creek County,2019,71522,,54969,548
+Oklahoma,Creek County,2021,72029,,52818,646
+Oklahoma,Creek County,2022,72699,,56756,682
+Oklahoma,Muskogee County,2005,67312,,31188,349
+Oklahoma,Muskogee County,2006,71018,,32975,367
+Oklahoma,Muskogee County,2007,71116,,38089,383
+Oklahoma,Muskogee County,2008,71278,,32658,405
+Oklahoma,Muskogee County,2009,71412,,31855,401
+Oklahoma,Muskogee County,2010,71110,,39910,410
+Oklahoma,Muskogee County,2011,71003,,34440,424
+Oklahoma,Muskogee County,2012,70596,,37233,470
+Oklahoma,Muskogee County,2013,70303,,39130,464
+Oklahoma,Muskogee County,2014,69966,,42756,469
+Oklahoma,Muskogee County,2015,69699,,41016,484
+Oklahoma,Muskogee County,2016,69477,,40860,476
+Oklahoma,Muskogee County,2017,69086,,36342,482
+Oklahoma,Muskogee County,2018,68362,,45290,530
+Oklahoma,Muskogee County,2019,67997,,42450,539
+Oklahoma,Muskogee County,2021,66146,,43437,531
+Oklahoma,Muskogee County,2022,66354,,54070,622
 Oklahoma,Oklahoma County,2005,666904,9064.0,37270,457
 Oklahoma,Oklahoma County,2006,691266,11901.0,38977,475
 Oklahoma,Oklahoma County,2007,701807,12354.0,41444,490
@@ -9349,57 +9349,57 @@ Oklahoma,Oklahoma County,2018,792582,14640.0,52214,695
 Oklahoma,Oklahoma County,2019,797434,17131.0,56235,709
 Oklahoma,Oklahoma County,2021,798575,47346.0,57764,761
 Oklahoma,Oklahoma County,2022,802559,43399.0,61446,817
-Oklahoma,Payne County,2005,60771,0.0,28952,415
-Oklahoma,Payne County,2006,73818,0.0,37432,428
-Oklahoma,Payne County,2007,79931,0.0,32051,462
+Oklahoma,Payne County,2005,60771,,28952,415
+Oklahoma,Payne County,2006,73818,,37432,428
+Oklahoma,Payne County,2007,79931,,32051,462
 Oklahoma,Payne County,2008,78280,1388.0,38508,466
-Oklahoma,Payne County,2009,79727,0.0,33662,493
-Oklahoma,Payne County,2010,77448,0.0,35488,520
-Oklahoma,Payne County,2011,77988,0.0,35181,546
+Oklahoma,Payne County,2009,79727,,33662,493
+Oklahoma,Payne County,2010,77448,,35488,520
+Oklahoma,Payne County,2011,77988,,35181,546
 Oklahoma,Payne County,2012,78399,842.0,35831,548
 Oklahoma,Payne County,2013,79066,830.0,36087,536
 Oklahoma,Payne County,2014,80264,587.0,38642,607
 Oklahoma,Payne County,2015,80850,1830.0,39840,616
-Oklahoma,Payne County,2016,81131,0.0,35927,585
-Oklahoma,Payne County,2017,81575,0.0,36914,641
-Oklahoma,Payne County,2018,82040,0.0,48031,638
-Oklahoma,Payne County,2019,81784,0.0,41272,658
-Oklahoma,Payne County,2021,81989,0.0,49348,681
-Oklahoma,Payne County,2022,82794,0.0,45684,736
-Oklahoma,Pottawatomie County,2005,65077,0.0,33974,345
-Oklahoma,Pottawatomie County,2006,68638,0.0,36411,421
-Oklahoma,Pottawatomie County,2007,69038,0.0,38310,379
-Oklahoma,Pottawatomie County,2008,69616,0.0,42652,397
-Oklahoma,Pottawatomie County,2009,70274,0.0,38486,434
-Oklahoma,Pottawatomie County,2010,69608,0.0,36795,471
-Oklahoma,Pottawatomie County,2011,70280,0.0,42272,464
-Oklahoma,Pottawatomie County,2012,70760,0.0,42440,458
-Oklahoma,Pottawatomie County,2013,71158,0.0,45012,483
-Oklahoma,Pottawatomie County,2014,71811,0.0,46839,486
-Oklahoma,Pottawatomie County,2015,71875,0.0,43317,513
-Oklahoma,Pottawatomie County,2016,72290,0.0,41716,522
-Oklahoma,Pottawatomie County,2017,72226,0.0,48744,513
-Oklahoma,Pottawatomie County,2018,72679,0.0,48776,554
-Oklahoma,Pottawatomie County,2019,72592,0.0,53511,582
-Oklahoma,Pottawatomie County,2021,73019,0.0,51451,627
-Oklahoma,Pottawatomie County,2022,73533,0.0,50583,638
-Oklahoma,Rogers County,2005,79904,0.0,49960,460
-Oklahoma,Rogers County,2006,82435,0.0,52769,485
-Oklahoma,Rogers County,2007,83105,0.0,52176,472
-Oklahoma,Rogers County,2008,84300,0.0,55453,518
-Oklahoma,Rogers County,2009,85654,0.0,57154,553
-Oklahoma,Rogers County,2010,86988,0.0,56176,588
-Oklahoma,Rogers County,2011,87706,0.0,54591,537
+Oklahoma,Payne County,2016,81131,,35927,585
+Oklahoma,Payne County,2017,81575,,36914,641
+Oklahoma,Payne County,2018,82040,,48031,638
+Oklahoma,Payne County,2019,81784,,41272,658
+Oklahoma,Payne County,2021,81989,,49348,681
+Oklahoma,Payne County,2022,82794,,45684,736
+Oklahoma,Pottawatomie County,2005,65077,,33974,345
+Oklahoma,Pottawatomie County,2006,68638,,36411,421
+Oklahoma,Pottawatomie County,2007,69038,,38310,379
+Oklahoma,Pottawatomie County,2008,69616,,42652,397
+Oklahoma,Pottawatomie County,2009,70274,,38486,434
+Oklahoma,Pottawatomie County,2010,69608,,36795,471
+Oklahoma,Pottawatomie County,2011,70280,,42272,464
+Oklahoma,Pottawatomie County,2012,70760,,42440,458
+Oklahoma,Pottawatomie County,2013,71158,,45012,483
+Oklahoma,Pottawatomie County,2014,71811,,46839,486
+Oklahoma,Pottawatomie County,2015,71875,,43317,513
+Oklahoma,Pottawatomie County,2016,72290,,41716,522
+Oklahoma,Pottawatomie County,2017,72226,,48744,513
+Oklahoma,Pottawatomie County,2018,72679,,48776,554
+Oklahoma,Pottawatomie County,2019,72592,,53511,582
+Oklahoma,Pottawatomie County,2021,73019,,51451,627
+Oklahoma,Pottawatomie County,2022,73533,,50583,638
+Oklahoma,Rogers County,2005,79904,,49960,460
+Oklahoma,Rogers County,2006,82435,,52769,485
+Oklahoma,Rogers County,2007,83105,,52176,472
+Oklahoma,Rogers County,2008,84300,,55453,518
+Oklahoma,Rogers County,2009,85654,,57154,553
+Oklahoma,Rogers County,2010,86988,,56176,588
+Oklahoma,Rogers County,2011,87706,,54591,537
 Oklahoma,Rogers County,2012,88367,1372.0,56041,578
-Oklahoma,Rogers County,2013,89044,0.0,54425,562
-Oklahoma,Rogers County,2014,89815,0.0,55626,600
-Oklahoma,Rogers County,2015,90802,0.0,63041,608
-Oklahoma,Rogers County,2016,91766,0.0,62434,659
-Oklahoma,Rogers County,2017,91444,0.0,60735,616
-Oklahoma,Rogers County,2018,91984,0.0,60148,661
-Oklahoma,Rogers County,2019,92459,0.0,66132,702
+Oklahoma,Rogers County,2013,89044,,54425,562
+Oklahoma,Rogers County,2014,89815,,55626,600
+Oklahoma,Rogers County,2015,90802,,63041,608
+Oklahoma,Rogers County,2016,91766,,62434,659
+Oklahoma,Rogers County,2017,91444,,60735,616
+Oklahoma,Rogers County,2018,91984,,60148,661
+Oklahoma,Rogers County,2019,92459,,66132,702
 Oklahoma,Rogers County,2021,96695,4381.0,68777,692
-Oklahoma,Rogers County,2022,98836,0.0,71817,741
+Oklahoma,Rogers County,2022,98836,,71817,741
 Oklahoma,Tulsa County,2005,560431,7972.0,40863,505
 Oklahoma,Tulsa County,2006,577795,11270.0,41548,500
 Oklahoma,Tulsa County,2007,585068,9978.0,45003,510
@@ -9417,30 +9417,30 @@ Oklahoma,Tulsa County,2018,648360,11965.0,55638,698
 Oklahoma,Tulsa County,2019,651552,13801.0,57483,713
 Oklahoma,Tulsa County,2021,672858,43437.0,58954,769
 Oklahoma,Tulsa County,2022,677358,35981.0,63332,833
-Oklahoma,Wagoner County,2006,66313,0.0,47672,381
-Oklahoma,Wagoner County,2007,67239,0.0,54584,479
-Oklahoma,Wagoner County,2008,68960,0.0,55742,467
-Oklahoma,Wagoner County,2009,70394,0.0,57479,560
-Oklahoma,Wagoner County,2010,73349,0.0,57884,457
-Oklahoma,Wagoner County,2011,74098,0.0,49605,523
-Oklahoma,Wagoner County,2012,75030,0.0,54507,592
-Oklahoma,Wagoner County,2013,75700,0.0,52108,574
-Oklahoma,Wagoner County,2014,75702,0.0,59170,625
-Oklahoma,Wagoner County,2015,76559,0.0,57319,668
-Oklahoma,Wagoner County,2016,77679,0.0,62041,643
-Oklahoma,Wagoner County,2017,78657,0.0,57823,677
-Oklahoma,Wagoner County,2018,80110,0.0,62421,602
-Oklahoma,Wagoner County,2019,81289,0.0,64319,728
-Oklahoma,Wagoner County,2021,84050,0.0,70313,713
-Oklahoma,Wagoner County,2022,86644,0.0,73199,828
-Oregon,Benton County,2005,74075,0.0,44231,585
+Oklahoma,Wagoner County,2006,66313,,47672,381
+Oklahoma,Wagoner County,2007,67239,,54584,479
+Oklahoma,Wagoner County,2008,68960,,55742,467
+Oklahoma,Wagoner County,2009,70394,,57479,560
+Oklahoma,Wagoner County,2010,73349,,57884,457
+Oklahoma,Wagoner County,2011,74098,,49605,523
+Oklahoma,Wagoner County,2012,75030,,54507,592
+Oklahoma,Wagoner County,2013,75700,,52108,574
+Oklahoma,Wagoner County,2014,75702,,59170,625
+Oklahoma,Wagoner County,2015,76559,,57319,668
+Oklahoma,Wagoner County,2016,77679,,62041,643
+Oklahoma,Wagoner County,2017,78657,,57823,677
+Oklahoma,Wagoner County,2018,80110,,62421,602
+Oklahoma,Wagoner County,2019,81289,,64319,728
+Oklahoma,Wagoner County,2021,84050,,70313,713
+Oklahoma,Wagoner County,2022,86644,,73199,828
+Oregon,Benton County,2005,74075,,44231,585
 Oregon,Benton County,2006,79061,2248.0,47707,643
 Oregon,Benton County,2007,81428,1692.0,45574,622
 Oregon,Benton County,2008,81859,2403.0,53505,619
 Oregon,Benton County,2009,82605,3966.0,44616,676
 Oregon,Benton County,2010,85575,2620.0,45913,642
 Oregon,Benton County,2011,85928,2662.0,42513,685
-Oregon,Benton County,2012,86430,0.0,51133,735
+Oregon,Benton County,2012,86430,,51133,735
 Oregon,Benton County,2013,86591,2961.0,47808,763
 Oregon,Benton County,2014,86316,2807.0,52486,808
 Oregon,Benton County,2015,87572,3548.0,52852,794
@@ -9450,7 +9450,7 @@ Oregon,Benton County,2018,92101,2309.0,63773,968
 Oregon,Benton County,2019,93053,2187.0,70835,1015
 Oregon,Benton County,2021,96017,12304.0,64163,1112
 Oregon,Benton County,2022,97630,7043.0,68524,1185
-Oregon,Clackamas County,2005,365723,0.0,54480,673
+Oregon,Clackamas County,2005,365723,,54480,673
 Oregon,Clackamas County,2006,374230,12279.0,56000,700
 Oregon,Clackamas County,2007,376251,10336.0,61220,719
 Oregon,Clackamas County,2008,380576,13878.0,66122,760
@@ -9467,41 +9467,41 @@ Oregon,Clackamas County,2018,416075,17854.0,81278,1214
 Oregon,Clackamas County,2019,418187,18205.0,80294,1233
 Oregon,Clackamas County,2021,422537,51268.0,91329,1368
 Oregon,Clackamas County,2022,423177,46470.0,97419,1433
-Oregon,Deschutes County,2005,140161,0.0,49163,687
-Oregon,Deschutes County,2006,149140,0.0,50637,687
+Oregon,Deschutes County,2005,140161,,49163,687
+Oregon,Deschutes County,2006,149140,,50637,687
 Oregon,Deschutes County,2007,154028,5317.0,55957,742
 Oregon,Deschutes County,2008,158456,5976.0,51487,738
 Oregon,Deschutes County,2009,158629,4806.0,52233,761
-Oregon,Deschutes County,2010,157894,0.0,44680,733
-Oregon,Deschutes County,2011,160338,0.0,46984,768
+Oregon,Deschutes County,2010,157894,,44680,733
+Oregon,Deschutes County,2011,160338,,46984,768
 Oregon,Deschutes County,2012,162277,5070.0,47576,738
-Oregon,Deschutes County,2013,165954,0.0,46791,759
+Oregon,Deschutes County,2013,165954,,46791,759
 Oregon,Deschutes County,2014,170388,6911.0,52006,794
-Oregon,Deschutes County,2015,175268,0.0,57373,865
-Oregon,Deschutes County,2016,181307,0.0,61870,1029
-Oregon,Deschutes County,2017,186875,0.0,66273,999
+Oregon,Deschutes County,2015,175268,,57373,865
+Oregon,Deschutes County,2016,181307,,61870,1029
+Oregon,Deschutes County,2017,186875,,66273,999
 Oregon,Deschutes County,2018,191996,10523.0,67577,1001
 Oregon,Deschutes County,2019,197692,11354.0,71643,1239
-Oregon,Deschutes County,2021,204801,0.0,79796,1353
+Oregon,Deschutes County,2021,204801,,79796,1353
 Oregon,Deschutes County,2022,206549,24928.0,82052,1412
-Oregon,Douglas County,2005,102678,0.0,36576,488
-Oregon,Douglas County,2006,105117,0.0,38222,491
-Oregon,Douglas County,2007,104119,0.0,38841,545
-Oregon,Douglas County,2008,104059,0.0,39285,519
-Oregon,Douglas County,2009,103205,0.0,39076,583
-Oregon,Douglas County,2010,107638,0.0,36510,624
-Oregon,Douglas County,2011,107490,0.0,38502,575
-Oregon,Douglas County,2012,107164,0.0,39757,595
-Oregon,Douglas County,2013,106940,0.0,40605,590
-Oregon,Douglas County,2014,106972,0.0,42000,612
-Oregon,Douglas County,2015,107685,0.0,41428,615
-Oregon,Douglas County,2016,108457,0.0,42889,606
-Oregon,Douglas County,2017,109405,0.0,47746,661
-Oregon,Douglas County,2018,110283,0.0,47004,690
-Oregon,Douglas County,2019,110980,0.0,48585,710
-Oregon,Douglas County,2021,111978,0.0,51166,740
-Oregon,Douglas County,2022,112297,0.0,54387,757
-Oregon,Jackson County,2005,191465,0.0,41194,621
+Oregon,Douglas County,2005,102678,,36576,488
+Oregon,Douglas County,2006,105117,,38222,491
+Oregon,Douglas County,2007,104119,,38841,545
+Oregon,Douglas County,2008,104059,,39285,519
+Oregon,Douglas County,2009,103205,,39076,583
+Oregon,Douglas County,2010,107638,,36510,624
+Oregon,Douglas County,2011,107490,,38502,575
+Oregon,Douglas County,2012,107164,,39757,595
+Oregon,Douglas County,2013,106940,,40605,590
+Oregon,Douglas County,2014,106972,,42000,612
+Oregon,Douglas County,2015,107685,,41428,615
+Oregon,Douglas County,2016,108457,,42889,606
+Oregon,Douglas County,2017,109405,,47746,661
+Oregon,Douglas County,2018,110283,,47004,690
+Oregon,Douglas County,2019,110980,,48585,710
+Oregon,Douglas County,2021,111978,,51166,740
+Oregon,Douglas County,2022,112297,,54387,757
+Oregon,Jackson County,2005,191465,,41194,621
 Oregon,Jackson County,2006,197071,6143.0,40606,629
 Oregon,Jackson County,2007,199295,4711.0,44524,684
 Oregon,Jackson County,2008,201138,5808.0,40603,690
@@ -9518,40 +9518,40 @@ Oregon,Jackson County,2018,219564,6544.0,56546,861
 Oregon,Jackson County,2019,220944,5538.0,56450,914
 Oregon,Jackson County,2021,223734,15742.0,64249,1047
 Oregon,Jackson County,2022,221644,12026.0,69152,1134
-Oregon,Josephine County,2005,79751,0.0,34595,557
-Oregon,Josephine County,2006,81688,0.0,39993,515
-Oregon,Josephine County,2007,81056,0.0,37312,602
-Oregon,Josephine County,2008,81618,0.0,33564,557
-Oregon,Josephine County,2009,81026,0.0,34754,654
-Oregon,Josephine County,2010,82807,0.0,36626,586
-Oregon,Josephine County,2011,82987,0.0,37048,666
-Oregon,Josephine County,2012,82930,0.0,34430,683
-Oregon,Josephine County,2013,83306,0.0,38298,686
-Oregon,Josephine County,2014,83599,0.0,36870,645
-Oregon,Josephine County,2015,84745,0.0,41493,718
-Oregon,Josephine County,2016,85904,0.0,36472,643
-Oregon,Josephine County,2017,86352,0.0,44426,733
-Oregon,Josephine County,2018,87393,0.0,48315,728
-Oregon,Josephine County,2019,87487,0.0,47573,903
-Oregon,Josephine County,2021,88346,0.0,48785,800
-Oregon,Josephine County,2022,87730,0.0,53838,955
-Oregon,Klamath County,2005,65178,0.0,35901,470
-Oregon,Klamath County,2006,67673,0.0,37420,511
-Oregon,Klamath County,2007,66031,0.0,44482,485
-Oregon,Klamath County,2008,64854,0.0,42389,546
-Oregon,Klamath County,2009,66890,0.0,41298,556
-Oregon,Klamath County,2010,64723,0.0,37660,547
-Oregon,Klamath County,2011,65552,0.0,36464,530
-Oregon,Klamath County,2012,65912,0.0,38987,575
-Oregon,Klamath County,2013,65910,0.0,36885,591
-Oregon,Klamath County,2014,65455,0.0,39148,578
-Oregon,Klamath County,2015,66016,0.0,43952,583
-Oregon,Klamath County,2016,66443,0.0,45604,580
-Oregon,Klamath County,2017,66935,0.0,38916,563
-Oregon,Klamath County,2018,67653,0.0,45354,628
-Oregon,Klamath County,2019,68238,0.0,56348,693
-Oregon,Klamath County,2021,70164,0.0,46721,768
-Oregon,Klamath County,2022,70212,0.0,53923,718
+Oregon,Josephine County,2005,79751,,34595,557
+Oregon,Josephine County,2006,81688,,39993,515
+Oregon,Josephine County,2007,81056,,37312,602
+Oregon,Josephine County,2008,81618,,33564,557
+Oregon,Josephine County,2009,81026,,34754,654
+Oregon,Josephine County,2010,82807,,36626,586
+Oregon,Josephine County,2011,82987,,37048,666
+Oregon,Josephine County,2012,82930,,34430,683
+Oregon,Josephine County,2013,83306,,38298,686
+Oregon,Josephine County,2014,83599,,36870,645
+Oregon,Josephine County,2015,84745,,41493,718
+Oregon,Josephine County,2016,85904,,36472,643
+Oregon,Josephine County,2017,86352,,44426,733
+Oregon,Josephine County,2018,87393,,48315,728
+Oregon,Josephine County,2019,87487,,47573,903
+Oregon,Josephine County,2021,88346,,48785,800
+Oregon,Josephine County,2022,87730,,53838,955
+Oregon,Klamath County,2005,65178,,35901,470
+Oregon,Klamath County,2006,67673,,37420,511
+Oregon,Klamath County,2007,66031,,44482,485
+Oregon,Klamath County,2008,64854,,42389,546
+Oregon,Klamath County,2009,66890,,41298,556
+Oregon,Klamath County,2010,64723,,37660,547
+Oregon,Klamath County,2011,65552,,36464,530
+Oregon,Klamath County,2012,65912,,38987,575
+Oregon,Klamath County,2013,65910,,36885,591
+Oregon,Klamath County,2014,65455,,39148,578
+Oregon,Klamath County,2015,66016,,43952,583
+Oregon,Klamath County,2016,66443,,45604,580
+Oregon,Klamath County,2017,66935,,38916,563
+Oregon,Klamath County,2018,67653,,45354,628
+Oregon,Klamath County,2019,68238,,56348,693
+Oregon,Klamath County,2021,70164,,46721,768
+Oregon,Klamath County,2022,70212,,53923,718
 Oregon,Lane County,2005,327762,7056.0,37290,595
 Oregon,Lane County,2006,337870,7015.0,42127,614
 Oregon,Lane County,2007,343591,9235.0,43111,613
@@ -9569,22 +9569,22 @@ Oregon,Lane County,2018,379611,12207.0,53172,864
 Oregon,Lane County,2019,382067,11844.0,57325,909
 Oregon,Lane County,2021,383189,30670.0,61712,987
 Oregon,Lane County,2022,382353,27544.0,64069,1091
-Oregon,Linn County,2005,107920,0.0,39305,550
+Oregon,Linn County,2005,107920,,39305,550
 Oregon,Linn County,2006,111489,3696.0,40782,543
-Oregon,Linn County,2007,113264,0.0,44397,566
-Oregon,Linn County,2008,115348,0.0,45571,635
-Oregon,Linn County,2009,116584,0.0,47669,637
-Oregon,Linn County,2010,116910,0.0,42900,627
-Oregon,Linn County,2011,118122,0.0,42565,610
-Oregon,Linn County,2012,118360,0.0,43489,642
-Oregon,Linn County,2013,118765,0.0,45130,704
+Oregon,Linn County,2007,113264,,44397,566
+Oregon,Linn County,2008,115348,,45571,635
+Oregon,Linn County,2009,116584,,47669,637
+Oregon,Linn County,2010,116910,,42900,627
+Oregon,Linn County,2011,118122,,42565,610
+Oregon,Linn County,2012,118360,,43489,642
+Oregon,Linn County,2013,118765,,45130,704
 Oregon,Linn County,2014,119356,2650.0,43428,718
-Oregon,Linn County,2015,120547,0.0,47527,678
+Oregon,Linn County,2015,120547,,47527,678
 Oregon,Linn County,2016,122849,2423.0,51310,782
-Oregon,Linn County,2017,125047,0.0,51541,769
-Oregon,Linn County,2018,127335,0.0,54113,848
-Oregon,Linn County,2019,129749,0.0,61488,886
-Oregon,Linn County,2021,129839,0.0,65196,969
+Oregon,Linn County,2017,125047,,51541,769
+Oregon,Linn County,2018,127335,,54113,848
+Oregon,Linn County,2019,129749,,61488,886
+Oregon,Linn County,2021,129839,,65196,969
 Oregon,Linn County,2022,130467,6876.0,67009,1003
 Oregon,Marion County,2005,292984,5275.0,43137,545
 Oregon,Marion County,2006,311304,6752.0,45270,564
@@ -9620,40 +9620,40 @@ Oregon,Multnomah County,2018,811880,39577.0,71186,1154
 Oregon,Multnomah County,2019,812855,38073.0,72900,1203
 Oregon,Multnomah County,2021,803377,136802.0,78319,1273
 Oregon,Multnomah County,2022,795083,113101.0,79909,1354
-Oregon,Polk County,2005,67873,0.0,43963,561
-Oregon,Polk County,2006,73296,0.0,45371,583
-Oregon,Polk County,2007,75265,0.0,45939,579
-Oregon,Polk County,2008,77074,0.0,53452,645
-Oregon,Polk County,2009,78122,0.0,55588,668
-Oregon,Polk County,2010,75625,0.0,48809,656
-Oregon,Polk County,2011,75993,0.0,53252,653
-Oregon,Polk County,2012,76353,0.0,46827,671
-Oregon,Polk County,2013,76794,0.0,49781,599
-Oregon,Polk County,2014,77916,0.0,51893,684
-Oregon,Polk County,2015,79391,0.0,54970,711
-Oregon,Polk County,2016,81823,0.0,52485,845
-Oregon,Polk County,2017,83696,0.0,55428,832
-Oregon,Polk County,2018,85234,0.0,61616,903
-Oregon,Polk County,2019,86085,0.0,72914,1013
-Oregon,Polk County,2021,89164,0.0,71532,1010
-Oregon,Polk County,2022,89614,0.0,77368,1151
-Oregon,Umatilla County,2005,69526,0.0,38459,447
-Oregon,Umatilla County,2006,72928,0.0,45362,476
-Oregon,Umatilla County,2007,73491,0.0,38631,465
-Oregon,Umatilla County,2008,73526,0.0,45115,471
-Oregon,Umatilla County,2009,73347,0.0,49839,494
-Oregon,Umatilla County,2010,76079,0.0,44107,521
-Oregon,Umatilla County,2011,76725,0.0,43502,531
-Oregon,Umatilla County,2012,76820,0.0,49148,535
-Oregon,Umatilla County,2013,76720,0.0,48514,530
-Oregon,Umatilla County,2014,76705,0.0,44402,541
-Oregon,Umatilla County,2015,76531,0.0,49472,541
-Oregon,Umatilla County,2016,76456,0.0,50171,569
-Oregon,Umatilla County,2017,76985,0.0,52288,647
-Oregon,Umatilla County,2018,77516,0.0,56842,623
-Oregon,Umatilla County,2019,77950,0.0,60425,720
-Oregon,Umatilla County,2021,79988,0.0,58329,699
-Oregon,Umatilla County,2022,80215,0.0,77006,791
+Oregon,Polk County,2005,67873,,43963,561
+Oregon,Polk County,2006,73296,,45371,583
+Oregon,Polk County,2007,75265,,45939,579
+Oregon,Polk County,2008,77074,,53452,645
+Oregon,Polk County,2009,78122,,55588,668
+Oregon,Polk County,2010,75625,,48809,656
+Oregon,Polk County,2011,75993,,53252,653
+Oregon,Polk County,2012,76353,,46827,671
+Oregon,Polk County,2013,76794,,49781,599
+Oregon,Polk County,2014,77916,,51893,684
+Oregon,Polk County,2015,79391,,54970,711
+Oregon,Polk County,2016,81823,,52485,845
+Oregon,Polk County,2017,83696,,55428,832
+Oregon,Polk County,2018,85234,,61616,903
+Oregon,Polk County,2019,86085,,72914,1013
+Oregon,Polk County,2021,89164,,71532,1010
+Oregon,Polk County,2022,89614,,77368,1151
+Oregon,Umatilla County,2005,69526,,38459,447
+Oregon,Umatilla County,2006,72928,,45362,476
+Oregon,Umatilla County,2007,73491,,38631,465
+Oregon,Umatilla County,2008,73526,,45115,471
+Oregon,Umatilla County,2009,73347,,49839,494
+Oregon,Umatilla County,2010,76079,,44107,521
+Oregon,Umatilla County,2011,76725,,43502,531
+Oregon,Umatilla County,2012,76820,,49148,535
+Oregon,Umatilla County,2013,76720,,48514,530
+Oregon,Umatilla County,2014,76705,,44402,541
+Oregon,Umatilla County,2015,76531,,49472,541
+Oregon,Umatilla County,2016,76456,,50171,569
+Oregon,Umatilla County,2017,76985,,52288,647
+Oregon,Umatilla County,2018,77516,,56842,623
+Oregon,Umatilla County,2019,77950,,60425,720
+Oregon,Umatilla County,2021,79988,,58329,699
+Oregon,Umatilla County,2022,80215,,77006,791
 Oregon,Washington County,2005,495597,12156.0,53431,671
 Oregon,Washington County,2006,514269,15999.0,59481,693
 Oregon,Washington County,2007,522514,12898.0,61628,734
@@ -9671,40 +9671,40 @@ Oregon,Washington County,2018,597695,22427.0,83068,1253
 Oregon,Washington County,2019,601592,20789.0,85734,1323
 Oregon,Washington County,2021,600811,91222.0,92147,1423
 Oregon,Washington County,2022,600176,82512.0,98906,1549
-Oregon,Yamhill County,2005,87211,0.0,46238,670
-Oregon,Yamhill County,2006,94678,0.0,47805,590
-Oregon,Yamhill County,2007,96573,0.0,51140,640
-Oregon,Yamhill County,2008,98168,0.0,54889,635
-Oregon,Yamhill County,2009,99037,0.0,51441,671
+Oregon,Yamhill County,2005,87211,,46238,670
+Oregon,Yamhill County,2006,94678,,47805,590
+Oregon,Yamhill County,2007,96573,,51140,640
+Oregon,Yamhill County,2008,98168,,54889,635
+Oregon,Yamhill County,2009,99037,,51441,671
 Oregon,Yamhill County,2010,99391,1815.0,50297,756
-Oregon,Yamhill County,2011,100000,0.0,53612,737
-Oregon,Yamhill County,2012,100255,0.0,47221,737
-Oregon,Yamhill County,2013,100725,0.0,58612,830
-Oregon,Yamhill County,2014,101758,0.0,52255,741
+Oregon,Yamhill County,2011,100000,,53612,737
+Oregon,Yamhill County,2012,100255,,47221,737
+Oregon,Yamhill County,2013,100725,,58612,830
+Oregon,Yamhill County,2014,101758,,52255,741
 Oregon,Yamhill County,2015,102659,2485.0,51084,733
-Oregon,Yamhill County,2016,105035,0.0,61596,755
-Oregon,Yamhill County,2017,105722,0.0,64104,849
+Oregon,Yamhill County,2016,105035,,61596,755
+Oregon,Yamhill County,2017,105722,,64104,849
 Oregon,Yamhill County,2018,107002,2241.0,60893,983
-Oregon,Yamhill County,2019,107100,0.0,72904,1048
-Oregon,Yamhill County,2021,108239,0.0,77256,1065
-Oregon,Yamhill County,2022,108226,0.0,77267,1183
-Pennsylvania,Adams County,2005,95850,0.0,46815,495
-Pennsylvania,Adams County,2006,101105,0.0,53932,492
-Pennsylvania,Adams County,2007,100779,0.0,53281,539
+Oregon,Yamhill County,2019,107100,,72904,1048
+Oregon,Yamhill County,2021,108239,,77256,1065
+Oregon,Yamhill County,2022,108226,,77267,1183
+Pennsylvania,Adams County,2005,95850,,46815,495
+Pennsylvania,Adams County,2006,101105,,53932,492
+Pennsylvania,Adams County,2007,100779,,53281,539
 Pennsylvania,Adams County,2008,101119,2056.0,55261,573
-Pennsylvania,Adams County,2009,102323,0.0,56628,594
-Pennsylvania,Adams County,2010,101485,0.0,55652,635
+Pennsylvania,Adams County,2009,102323,,56628,594
+Pennsylvania,Adams County,2010,101485,,55652,635
 Pennsylvania,Adams County,2011,101434,2097.0,54906,628
-Pennsylvania,Adams County,2012,101482,0.0,60136,616
-Pennsylvania,Adams County,2013,101546,0.0,59029,673
-Pennsylvania,Adams County,2014,101714,0.0,61543,671
-Pennsylvania,Adams County,2015,102295,0.0,61023,685
-Pennsylvania,Adams County,2016,102180,0.0,59300,697
-Pennsylvania,Adams County,2017,102336,0.0,63107,695
-Pennsylvania,Adams County,2018,102811,0.0,62284,795
+Pennsylvania,Adams County,2012,101482,,60136,616
+Pennsylvania,Adams County,2013,101546,,59029,673
+Pennsylvania,Adams County,2014,101714,,61543,671
+Pennsylvania,Adams County,2015,102295,,61023,685
+Pennsylvania,Adams County,2016,102180,,59300,697
+Pennsylvania,Adams County,2017,102336,,63107,695
+Pennsylvania,Adams County,2018,102811,,62284,795
 Pennsylvania,Adams County,2019,103009,2345.0,67715,741
-Pennsylvania,Adams County,2021,104127,0.0,72985,752
-Pennsylvania,Adams County,2022,106027,0.0,76727,824
+Pennsylvania,Adams County,2021,104127,,72985,752
+Pennsylvania,Adams County,2022,106027,,76727,824
 Pennsylvania,Allegheny County,2005,1195503,16041.0,41562,510
 Pennsylvania,Allegheny County,2006,1223411,16820.0,43691,513
 Pennsylvania,Allegheny County,2007,1219210,18236.0,46401,533
@@ -9722,24 +9722,24 @@ Pennsylvania,Allegheny County,2018,1218452,36045.0,59899,734
 Pennsylvania,Allegheny County,2019,1216045,39825.0,64871,767
 Pennsylvania,Allegheny County,2021,1238090,158528.0,69091,831
 Pennsylvania,Allegheny County,2022,1233253,131103.0,72031,878
-Pennsylvania,Armstrong County,2005,69501,0.0,35451,348
-Pennsylvania,Armstrong County,2006,70096,0.0,36701,374
-Pennsylvania,Armstrong County,2007,69059,0.0,40517,374
-Pennsylvania,Armstrong County,2008,68790,0.0,41385,380
-Pennsylvania,Armstrong County,2009,67851,0.0,43922,395
-Pennsylvania,Armstrong County,2010,68839,0.0,43695,419
-Pennsylvania,Armstrong County,2011,68568,0.0,42530,442
-Pennsylvania,Armstrong County,2012,68409,0.0,41841,449
+Pennsylvania,Armstrong County,2005,69501,,35451,348
+Pennsylvania,Armstrong County,2006,70096,,36701,374
+Pennsylvania,Armstrong County,2007,69059,,40517,374
+Pennsylvania,Armstrong County,2008,68790,,41385,380
+Pennsylvania,Armstrong County,2009,67851,,43922,395
+Pennsylvania,Armstrong County,2010,68839,,43695,419
+Pennsylvania,Armstrong County,2011,68568,,42530,442
+Pennsylvania,Armstrong County,2012,68409,,41841,449
 Pennsylvania,Armstrong County,2013,68107,1386.0,43191,454
-Pennsylvania,Armstrong County,2014,67785,0.0,44946,498
+Pennsylvania,Armstrong County,2014,67785,,44946,498
 Pennsylvania,Armstrong County,2015,67052,896.0,44477,483
-Pennsylvania,Armstrong County,2016,66486,0.0,47398,455
-Pennsylvania,Armstrong County,2017,65642,0.0,45949,522
-Pennsylvania,Armstrong County,2018,65263,0.0,49950,490
-Pennsylvania,Armstrong County,2019,64735,0.0,57636,537
-Pennsylvania,Armstrong County,2021,65093,0.0,54039,516
+Pennsylvania,Armstrong County,2016,66486,,47398,455
+Pennsylvania,Armstrong County,2017,65642,,45949,522
+Pennsylvania,Armstrong County,2018,65263,,49950,490
+Pennsylvania,Armstrong County,2019,64735,,57636,537
+Pennsylvania,Armstrong County,2021,65093,,54039,516
 Pennsylvania,Armstrong County,2022,64747,2539.0,57500,599
-Pennsylvania,Beaver County,2005,173086,0.0,41303,375
+Pennsylvania,Beaver County,2005,173086,,41303,375
 Pennsylvania,Beaver County,2006,175736,2009.0,42023,379
 Pennsylvania,Beaver County,2007,173074,1899.0,45017,430
 Pennsylvania,Beaver County,2008,172476,1553.0,45408,438
@@ -9773,23 +9773,23 @@ Pennsylvania,Berks County,2018,420152,8806.0,62564,736
 Pennsylvania,Berks County,2019,421164,9009.0,67708,781
 Pennsylvania,Berks County,2021,429342,26292.0,68658,848
 Pennsylvania,Berks County,2022,430449,25969.0,72070,917
-Pennsylvania,Blair County,2005,122717,0.0,33730,395
-Pennsylvania,Blair County,2006,126494,0.0,40730,388
-Pennsylvania,Blair County,2007,125527,0.0,42509,435
-Pennsylvania,Blair County,2008,125174,0.0,40333,420
-Pennsylvania,Blair County,2009,126122,0.0,38455,426
+Pennsylvania,Blair County,2005,122717,,33730,395
+Pennsylvania,Blair County,2006,126494,,40730,388
+Pennsylvania,Blair County,2007,125527,,42509,435
+Pennsylvania,Blair County,2008,125174,,40333,420
+Pennsylvania,Blair County,2009,126122,,38455,426
 Pennsylvania,Blair County,2010,127031,1894.0,42990,464
-Pennsylvania,Blair County,2011,127099,0.0,43136,485
+Pennsylvania,Blair County,2011,127099,,43136,485
 Pennsylvania,Blair County,2012,127121,1010.0,41258,494
-Pennsylvania,Blair County,2013,126314,0.0,42164,469
-Pennsylvania,Blair County,2014,125955,0.0,44019,511
+Pennsylvania,Blair County,2013,126314,,42164,469
+Pennsylvania,Blair County,2014,125955,,44019,511
 Pennsylvania,Blair County,2015,125593,930.0,45432,533
 Pennsylvania,Blair County,2016,124650,1482.0,43443,538
 Pennsylvania,Blair County,2017,123457,1929.0,45957,564
-Pennsylvania,Blair County,2018,122492,0.0,49942,582
-Pennsylvania,Blair County,2019,121829,0.0,51004,586
+Pennsylvania,Blair County,2018,122492,,49942,582
+Pennsylvania,Blair County,2019,121829,,51004,586
 Pennsylvania,Blair County,2021,121767,4145.0,57361,576
-Pennsylvania,Blair County,2022,121032,0.0,58022,651
+Pennsylvania,Blair County,2022,121032,,58022,651
 Pennsylvania,Bucks County,2005,612210,10395.0,64346,793
 Pennsylvania,Bucks County,2006,623205,10959.0,70406,841
 Pennsylvania,Bucks County,2007,621144,12318.0,70655,854
@@ -9807,9 +9807,9 @@ Pennsylvania,Bucks County,2018,628195,21363.0,88569,1134
 Pennsylvania,Bucks County,2019,628270,23976.0,93767,1132
 Pennsylvania,Bucks County,2021,646098,76061.0,100144,1192
 Pennsylvania,Bucks County,2022,645054,65563.0,105398,1376
-Pennsylvania,Butler County,2005,175561,0.0,48418,529
+Pennsylvania,Butler County,2005,175561,,48418,529
 Pennsylvania,Butler County,2006,182901,3320.0,52943,497
-Pennsylvania,Butler County,2007,181934,0.0,54390,513
+Pennsylvania,Butler County,2007,181934,,54390,513
 Pennsylvania,Butler County,2008,182902,3090.0,58110,565
 Pennsylvania,Butler County,2009,184694,2664.0,54879,512
 Pennsylvania,Butler County,2010,184059,3680.0,54256,579
@@ -9822,9 +9822,9 @@ Pennsylvania,Butler County,2016,186847,5834.0,66426,678
 Pennsylvania,Butler County,2017,187108,4472.0,68934,635
 Pennsylvania,Butler County,2018,187888,3799.0,66423,724
 Pennsylvania,Butler County,2019,187853,4653.0,72262,738
-Pennsylvania,Butler County,2021,194273,0.0,78146,816
-Pennsylvania,Butler County,2022,197300,0.0,81353,749
-Pennsylvania,Cambria County,2005,138963,0.0,34841,329
+Pennsylvania,Butler County,2021,194273,,78146,816
+Pennsylvania,Butler County,2022,197300,,81353,749
+Pennsylvania,Cambria County,2005,138963,,34841,329
 Pennsylvania,Cambria County,2006,146967,1629.0,34387,329
 Pennsylvania,Cambria County,2007,144995,1210.0,37495,332
 Pennsylvania,Cambria County,2008,144319,2126.0,38071,346
@@ -9841,19 +9841,19 @@ Pennsylvania,Cambria County,2018,131730,2593.0,45084,446
 Pennsylvania,Cambria County,2019,130192,1786.0,49076,443
 Pennsylvania,Cambria County,2021,132167,6160.0,52995,524
 Pennsylvania,Cambria County,2022,131441,6035.0,54905,526
-Pennsylvania,Carbon County,2010,65220,0.0,50332,534
-Pennsylvania,Carbon County,2011,65154,0.0,44139,513
-Pennsylvania,Carbon County,2012,65006,0.0,50742,580
-Pennsylvania,Carbon County,2013,64786,0.0,44017,600
-Pennsylvania,Carbon County,2014,64441,0.0,50023,593
-Pennsylvania,Carbon County,2015,63960,0.0,57387,564
-Pennsylvania,Carbon County,2016,63594,0.0,51676,696
-Pennsylvania,Carbon County,2017,63853,0.0,49647,586
-Pennsylvania,Carbon County,2018,64227,0.0,53227,630
-Pennsylvania,Carbon County,2019,64182,0.0,61111,694
-Pennsylvania,Carbon County,2021,65412,0.0,57262,648
-Pennsylvania,Carbon County,2022,65460,0.0,64456,741
-Pennsylvania,Centre County,2005,124263,0.0,38450,650
+Pennsylvania,Carbon County,2010,65220,,50332,534
+Pennsylvania,Carbon County,2011,65154,,44139,513
+Pennsylvania,Carbon County,2012,65006,,50742,580
+Pennsylvania,Carbon County,2013,64786,,44017,600
+Pennsylvania,Carbon County,2014,64441,,50023,593
+Pennsylvania,Carbon County,2015,63960,,57387,564
+Pennsylvania,Carbon County,2016,63594,,51676,696
+Pennsylvania,Carbon County,2017,63853,,49647,586
+Pennsylvania,Carbon County,2018,64227,,53227,630
+Pennsylvania,Carbon County,2019,64182,,61111,694
+Pennsylvania,Carbon County,2021,65412,,57262,648
+Pennsylvania,Carbon County,2022,65460,,64456,741
+Pennsylvania,Centre County,2005,124263,,38450,650
 Pennsylvania,Centre County,2006,140953,2525.0,40886,636
 Pennsylvania,Centre County,2007,144658,3959.0,44644,630
 Pennsylvania,Centre County,2008,144779,2796.0,47549,687
@@ -9887,24 +9887,24 @@ Pennsylvania,Chester County,2018,522046,23525.0,99119,1138
 Pennsylvania,Chester County,2019,524989,24079.0,102016,1217
 Pennsylvania,Chester County,2021,538649,81670.0,109601,1365
 Pennsylvania,Chester County,2022,545823,63780.0,117232,1445
-Pennsylvania,Clearfield County,2005,79001,0.0,31952,355
-Pennsylvania,Clearfield County,2006,82442,0.0,33590,378
-Pennsylvania,Clearfield County,2007,81452,0.0,36271,362
-Pennsylvania,Clearfield County,2008,82896,0.0,36930,360
-Pennsylvania,Clearfield County,2009,82324,0.0,37282,423
-Pennsylvania,Clearfield County,2010,81562,0.0,36331,394
-Pennsylvania,Clearfield County,2011,81445,0.0,42780,417
+Pennsylvania,Clearfield County,2005,79001,,31952,355
+Pennsylvania,Clearfield County,2006,82442,,33590,378
+Pennsylvania,Clearfield County,2007,81452,,36271,362
+Pennsylvania,Clearfield County,2008,82896,,36930,360
+Pennsylvania,Clearfield County,2009,82324,,37282,423
+Pennsylvania,Clearfield County,2010,81562,,36331,394
+Pennsylvania,Clearfield County,2011,81445,,42780,417
 Pennsylvania,Clearfield County,2012,81184,1002.0,41817,422
-Pennsylvania,Clearfield County,2013,81174,0.0,39236,420
-Pennsylvania,Clearfield County,2014,81191,0.0,39592,477
-Pennsylvania,Clearfield County,2015,80994,0.0,44666,459
-Pennsylvania,Clearfield County,2016,80596,0.0,47352,443
-Pennsylvania,Clearfield County,2017,79685,0.0,48581,494
-Pennsylvania,Clearfield County,2018,79388,0.0,46205,475
-Pennsylvania,Clearfield County,2019,79255,0.0,45643,574
-Pennsylvania,Clearfield County,2021,80082,0.0,55193,504
-Pennsylvania,Clearfield County,2022,77904,0.0,60228,524
-Pennsylvania,Crawford County,2005,85445,0.0,35842,380
+Pennsylvania,Clearfield County,2013,81174,,39236,420
+Pennsylvania,Clearfield County,2014,81191,,39592,477
+Pennsylvania,Clearfield County,2015,80994,,44666,459
+Pennsylvania,Clearfield County,2016,80596,,47352,443
+Pennsylvania,Clearfield County,2017,79685,,48581,494
+Pennsylvania,Clearfield County,2018,79388,,46205,475
+Pennsylvania,Clearfield County,2019,79255,,45643,574
+Pennsylvania,Clearfield County,2021,80082,,55193,504
+Pennsylvania,Clearfield County,2022,77904,,60228,524
+Pennsylvania,Crawford County,2005,85445,,35842,380
 Pennsylvania,Crawford County,2006,89389,1290.0,35659,377
 Pennsylvania,Crawford County,2007,88663,1915.0,36217,361
 Pennsylvania,Crawford County,2008,88411,1497.0,40393,384
@@ -9913,15 +9913,15 @@ Pennsylvania,Crawford County,2010,88657,1355.0,38321,421
 Pennsylvania,Crawford County,2011,88740,1884.0,41199,422
 Pennsylvania,Crawford County,2012,87598,1547.0,42287,435
 Pennsylvania,Crawford County,2013,87376,1703.0,44575,472
-Pennsylvania,Crawford County,2014,87175,0.0,44598,498
+Pennsylvania,Crawford County,2014,87175,,44598,498
 Pennsylvania,Crawford County,2015,86484,1608.0,46574,471
 Pennsylvania,Crawford County,2016,86257,1624.0,45410,521
 Pennsylvania,Crawford County,2017,86159,1387.0,50657,497
-Pennsylvania,Crawford County,2018,85063,0.0,51502,467
+Pennsylvania,Crawford County,2018,85063,,51502,467
 Pennsylvania,Crawford County,2019,84629,1732.0,49428,537
 Pennsylvania,Crawford County,2021,83351,2320.0,55593,556
-Pennsylvania,Crawford County,2022,82670,0.0,54497,584
-Pennsylvania,Cumberland County,2005,208751,0.0,55429,532
+Pennsylvania,Crawford County,2022,82670,,54497,584
+Pennsylvania,Cumberland County,2005,208751,,55429,532
 Pennsylvania,Cumberland County,2006,226117,4894.0,56426,588
 Pennsylvania,Cumberland County,2007,228019,3414.0,58605,624
 Pennsylvania,Cumberland County,2008,229361,4009.0,60704,599
@@ -9938,7 +9938,7 @@ Pennsylvania,Cumberland County,2018,251423,7316.0,71802,825
 Pennsylvania,Cumberland County,2019,253370,8607.0,75391,840
 Pennsylvania,Cumberland County,2021,262919,26615.0,82691,966
 Pennsylvania,Cumberland County,2022,268579,23637.0,80926,978
-Pennsylvania,Dauphin County,2005,247379,0.0,49190,549
+Pennsylvania,Dauphin County,2005,247379,,49190,549
 Pennsylvania,Dauphin County,2006,254176,3746.0,49093,558
 Pennsylvania,Dauphin County,2007,255710,4016.0,50059,576
 Pennsylvania,Dauphin County,2008,256562,2111.0,52480,634
@@ -9972,7 +9972,7 @@ Pennsylvania,Delaware County,2018,564751,14747.0,72045,896
 Pennsylvania,Delaware County,2019,566747,13106.0,77339,948
 Pennsylvania,Delaware County,2021,573849,58879.0,78220,1059
 Pennsylvania,Delaware County,2022,575182,47529.0,83960,1088
-Pennsylvania,Erie County,2005,266662,0.0,40312,427
+Pennsylvania,Erie County,2005,266662,,40312,427
 Pennsylvania,Erie County,2006,279811,2781.0,39649,424
 Pennsylvania,Erie County,2007,279092,3428.0,42394,434
 Pennsylvania,Erie County,2008,279175,2852.0,44247,477
@@ -9989,57 +9989,57 @@ Pennsylvania,Erie County,2018,272061,4946.0,48007,600
 Pennsylvania,Erie County,2019,269728,5614.0,51818,606
 Pennsylvania,Erie County,2021,269011,14202.0,56851,639
 Pennsylvania,Erie County,2022,267689,9780.0,56094,664
-Pennsylvania,Fayette County,2005,141661,0.0,31338,335
-Pennsylvania,Fayette County,2006,145760,0.0,31637,359
-Pennsylvania,Fayette County,2007,144556,0.0,31344,363
-Pennsylvania,Fayette County,2008,143925,0.0,34004,401
-Pennsylvania,Fayette County,2009,142605,0.0,35807,374
-Pennsylvania,Fayette County,2010,136446,0.0,35750,393
-Pennsylvania,Fayette County,2011,136097,0.0,37052,426
-Pennsylvania,Fayette County,2012,135660,0.0,40410,433
+Pennsylvania,Fayette County,2005,141661,,31338,335
+Pennsylvania,Fayette County,2006,145760,,31637,359
+Pennsylvania,Fayette County,2007,144556,,31344,363
+Pennsylvania,Fayette County,2008,143925,,34004,401
+Pennsylvania,Fayette County,2009,142605,,35807,374
+Pennsylvania,Fayette County,2010,136446,,35750,393
+Pennsylvania,Fayette County,2011,136097,,37052,426
+Pennsylvania,Fayette County,2012,135660,,40410,433
 Pennsylvania,Fayette County,2013,134999,1309.0,38903,457
 Pennsylvania,Fayette County,2014,134086,1666.0,36562,443
-Pennsylvania,Fayette County,2015,133628,0.0,40495,455
-Pennsylvania,Fayette County,2016,132733,0.0,43140,489
-Pennsylvania,Fayette County,2017,131504,0.0,44184,504
-Pennsylvania,Fayette County,2018,130441,0.0,52984,519
-Pennsylvania,Fayette County,2019,129274,0.0,48509,508
-Pennsylvania,Fayette County,2021,126931,0.0,47981,530
-Pennsylvania,Fayette County,2022,125755,0.0,51776,526
-Pennsylvania,Franklin County,2005,134409,0.0,45228,430
+Pennsylvania,Fayette County,2015,133628,,40495,455
+Pennsylvania,Fayette County,2016,132733,,43140,489
+Pennsylvania,Fayette County,2017,131504,,44184,504
+Pennsylvania,Fayette County,2018,130441,,52984,519
+Pennsylvania,Fayette County,2019,129274,,48509,508
+Pennsylvania,Fayette County,2021,126931,,47981,530
+Pennsylvania,Fayette County,2022,125755,,51776,526
+Pennsylvania,Franklin County,2005,134409,,45228,430
 Pennsylvania,Franklin County,2006,139991,2367.0,50254,474
 Pennsylvania,Franklin County,2007,141665,2584.0,46985,496
 Pennsylvania,Franklin County,2008,143495,1936.0,54145,547
-Pennsylvania,Franklin County,2009,144994,0.0,46929,558
-Pennsylvania,Franklin County,2010,149834,0.0,49514,587
+Pennsylvania,Franklin County,2009,144994,,46929,558
+Pennsylvania,Franklin County,2010,149834,,49514,587
 Pennsylvania,Franklin County,2011,150811,2076.0,49068,590
 Pennsylvania,Franklin County,2012,151275,2795.0,51938,633
-Pennsylvania,Franklin County,2013,152085,0.0,54303,640
-Pennsylvania,Franklin County,2014,152892,0.0,49487,650
+Pennsylvania,Franklin County,2013,152085,,54303,640
+Pennsylvania,Franklin County,2014,152892,,49487,650
 Pennsylvania,Franklin County,2015,153638,2227.0,57960,648
-Pennsylvania,Franklin County,2016,153851,0.0,60559,679
+Pennsylvania,Franklin County,2016,153851,,60559,679
 Pennsylvania,Franklin County,2017,154234,3167.0,60459,695
-Pennsylvania,Franklin County,2018,154835,0.0,61208,693
+Pennsylvania,Franklin County,2018,154835,,61208,693
 Pennsylvania,Franklin County,2019,155027,2970.0,62484,751
-Pennsylvania,Franklin County,2021,156289,0.0,66715,730
-Pennsylvania,Franklin County,2022,156902,0.0,74002,774
-Pennsylvania,Indiana County,2005,83256,0.0,32356,415
-Pennsylvania,Indiana County,2006,88234,0.0,38735,442
-Pennsylvania,Indiana County,2007,87690,0.0,33441,466
-Pennsylvania,Indiana County,2008,87479,0.0,41687,492
-Pennsylvania,Indiana County,2009,87450,0.0,39582,473
-Pennsylvania,Indiana County,2010,88847,0.0,41162,509
-Pennsylvania,Indiana County,2011,89298,0.0,42498,517
-Pennsylvania,Indiana County,2012,88218,0.0,44403,533
+Pennsylvania,Franklin County,2021,156289,,66715,730
+Pennsylvania,Franklin County,2022,156902,,74002,774
+Pennsylvania,Indiana County,2005,83256,,32356,415
+Pennsylvania,Indiana County,2006,88234,,38735,442
+Pennsylvania,Indiana County,2007,87690,,33441,466
+Pennsylvania,Indiana County,2008,87479,,41687,492
+Pennsylvania,Indiana County,2009,87450,,39582,473
+Pennsylvania,Indiana County,2010,88847,,41162,509
+Pennsylvania,Indiana County,2011,89298,,42498,517
+Pennsylvania,Indiana County,2012,88218,,44403,533
 Pennsylvania,Indiana County,2013,87745,1538.0,45266,509
-Pennsylvania,Indiana County,2014,87706,0.0,42431,540
+Pennsylvania,Indiana County,2014,87706,,42431,540
 Pennsylvania,Indiana County,2015,86966,830.0,46990,583
-Pennsylvania,Indiana County,2016,86364,0.0,42962,548
-Pennsylvania,Indiana County,2017,84953,0.0,46237,580
-Pennsylvania,Indiana County,2018,84501,0.0,49448,572
+Pennsylvania,Indiana County,2016,86364,,42962,548
+Pennsylvania,Indiana County,2017,84953,,46237,580
+Pennsylvania,Indiana County,2018,84501,,49448,572
 Pennsylvania,Indiana County,2019,84073,1172.0,51914,525
-Pennsylvania,Indiana County,2021,82886,0.0,52023,575
-Pennsylvania,Indiana County,2022,82957,0.0,52361,599
+Pennsylvania,Indiana County,2021,82886,,52023,575
+Pennsylvania,Indiana County,2022,82957,,52361,599
 Pennsylvania,Lackawanna County,2005,201201,2666.0,37153,446
 Pennsylvania,Lackawanna County,2006,209728,2419.0,38915,440
 Pennsylvania,Lackawanna County,2007,209330,2148.0,41598,475
@@ -10074,41 +10074,41 @@ Pennsylvania,Lancaster County,2018,543557,15557.0,66277,826
 Pennsylvania,Lancaster County,2019,545724,13806.0,67376,890
 Pennsylvania,Lancaster County,2021,553652,37453.0,75688,977
 Pennsylvania,Lancaster County,2022,556629,27257.0,82691,1053
-Pennsylvania,Lawrence County,2005,89742,0.0,39940,387
-Pennsylvania,Lawrence County,2006,91795,0.0,39412,423
+Pennsylvania,Lawrence County,2005,89742,,39940,387
+Pennsylvania,Lawrence County,2006,91795,,39412,423
 Pennsylvania,Lawrence County,2007,90991,1223.0,40749,425
 Pennsylvania,Lawrence County,2008,90272,989.0,42151,445
-Pennsylvania,Lawrence County,2009,90160,0.0,43232,425
-Pennsylvania,Lawrence County,2010,90968,0.0,38192,447
-Pennsylvania,Lawrence County,2011,90535,0.0,41606,423
-Pennsylvania,Lawrence County,2012,89871,0.0,43558,459
-Pennsylvania,Lawrence County,2013,89333,0.0,43425,483
-Pennsylvania,Lawrence County,2014,88771,0.0,45356,491
-Pennsylvania,Lawrence County,2015,88082,0.0,42921,480
-Pennsylvania,Lawrence County,2016,87294,0.0,46918,496
-Pennsylvania,Lawrence County,2017,87069,0.0,49967,481
+Pennsylvania,Lawrence County,2009,90160,,43232,425
+Pennsylvania,Lawrence County,2010,90968,,38192,447
+Pennsylvania,Lawrence County,2011,90535,,41606,423
+Pennsylvania,Lawrence County,2012,89871,,43558,459
+Pennsylvania,Lawrence County,2013,89333,,43425,483
+Pennsylvania,Lawrence County,2014,88771,,45356,491
+Pennsylvania,Lawrence County,2015,88082,,42921,480
+Pennsylvania,Lawrence County,2016,87294,,46918,496
+Pennsylvania,Lawrence County,2017,87069,,49967,481
 Pennsylvania,Lawrence County,2018,86184,1462.0,47853,537
-Pennsylvania,Lawrence County,2019,85512,0.0,50547,522
-Pennsylvania,Lawrence County,2021,85497,0.0,59536,539
-Pennsylvania,Lawrence County,2022,84849,0.0,58908,592
-Pennsylvania,Lebanon County,2005,121054,0.0,47768,478
-Pennsylvania,Lebanon County,2006,126883,0.0,49189,496
+Pennsylvania,Lawrence County,2019,85512,,50547,522
+Pennsylvania,Lawrence County,2021,85497,,59536,539
+Pennsylvania,Lawrence County,2022,84849,,58908,592
+Pennsylvania,Lebanon County,2005,121054,,47768,478
+Pennsylvania,Lebanon County,2006,126883,,49189,496
 Pennsylvania,Lebanon County,2007,127889,1628.0,46711,505
-Pennsylvania,Lebanon County,2008,128934,0.0,52650,523
-Pennsylvania,Lebanon County,2009,130506,0.0,50728,542
-Pennsylvania,Lebanon County,2010,133688,0.0,51436,559
-Pennsylvania,Lebanon County,2011,134311,0.0,55019,585
+Pennsylvania,Lebanon County,2008,128934,,52650,523
+Pennsylvania,Lebanon County,2009,130506,,50728,542
+Pennsylvania,Lebanon County,2010,133688,,51436,559
+Pennsylvania,Lebanon County,2011,134311,,55019,585
 Pennsylvania,Lebanon County,2012,135251,2595.0,51557,587
-Pennsylvania,Lebanon County,2013,135486,0.0,55973,620
+Pennsylvania,Lebanon County,2013,135486,,55973,620
 Pennsylvania,Lebanon County,2014,136359,2812.0,54068,632
-Pennsylvania,Lebanon County,2015,137067,0.0,52571,629
-Pennsylvania,Lebanon County,2016,138863,0.0,57248,644
+Pennsylvania,Lebanon County,2015,137067,,52571,629
+Pennsylvania,Lebanon County,2016,138863,,57248,644
 Pennsylvania,Lebanon County,2017,139754,3184.0,57372,673
-Pennsylvania,Lebanon County,2018,141314,0.0,61362,760
-Pennsylvania,Lebanon County,2019,141793,0.0,61204,746
+Pennsylvania,Lebanon County,2018,141314,,61362,760
+Pennsylvania,Lebanon County,2019,141793,,61204,746
 Pennsylvania,Lebanon County,2021,143493,7631.0,72732,757
-Pennsylvania,Lebanon County,2022,144011,0.0,68467,898
-Pennsylvania,Lehigh County,2005,319993,0.0,48957,628
+Pennsylvania,Lebanon County,2022,144011,,68467,898
+Pennsylvania,Lehigh County,2005,319993,,48957,628
 Pennsylvania,Lehigh County,2006,335544,4039.0,48469,661
 Pennsylvania,Lehigh County,2007,337343,5269.0,51817,657
 Pennsylvania,Lehigh County,2008,339989,5061.0,54115,685
@@ -10142,12 +10142,12 @@ Pennsylvania,Luzerne County,2018,317646,6583.0,54433,614
 Pennsylvania,Luzerne County,2019,317417,5200.0,53972,630
 Pennsylvania,Luzerne County,2021,326053,17906.0,60020,707
 Pennsylvania,Luzerne County,2022,326369,15040.0,59603,746
-Pennsylvania,Lycoming County,2005,112735,0.0,38562,438
+Pennsylvania,Lycoming County,2005,112735,,38562,438
 Pennsylvania,Lycoming County,2006,117668,1219.0,38907,445
 Pennsylvania,Lycoming County,2007,116811,1250.0,41714,450
 Pennsylvania,Lycoming County,2008,116670,1374.0,42084,470
 Pennsylvania,Lycoming County,2009,116840,1866.0,39968,481
-Pennsylvania,Lycoming County,2010,116143,0.0,41037,478
+Pennsylvania,Lycoming County,2010,116143,,41037,478
 Pennsylvania,Lycoming County,2011,116747,1366.0,42391,531
 Pennsylvania,Lycoming County,2012,117168,1280.0,45710,541
 Pennsylvania,Lycoming County,2013,116754,1477.0,47373,552
@@ -10155,44 +10155,44 @@ Pennsylvania,Lycoming County,2014,116508,1104.0,45161,591
 Pennsylvania,Lycoming County,2015,116048,1393.0,51455,598
 Pennsylvania,Lycoming County,2016,115248,2286.0,49052,636
 Pennsylvania,Lycoming County,2017,113841,2267.0,50909,622
-Pennsylvania,Lycoming County,2018,113664,0.0,55045,615
-Pennsylvania,Lycoming County,2019,113299,0.0,53881,616
+Pennsylvania,Lycoming County,2018,113664,,55045,615
+Pennsylvania,Lycoming County,2019,113299,,53881,616
 Pennsylvania,Lycoming County,2021,113605,4905.0,60494,673
 Pennsylvania,Lycoming County,2022,113104,4339.0,62516,656
-Pennsylvania,Mercer County,2005,112981,0.0,38963,421
-Pennsylvania,Mercer County,2006,118551,0.0,37922,420
-Pennsylvania,Mercer County,2007,116809,0.0,41106,419
-Pennsylvania,Mercer County,2008,116652,0.0,40294,412
+Pennsylvania,Mercer County,2005,112981,,38963,421
+Pennsylvania,Mercer County,2006,118551,,37922,420
+Pennsylvania,Mercer County,2007,116809,,41106,419
+Pennsylvania,Mercer County,2008,116652,,40294,412
 Pennsylvania,Mercer County,2009,116071,3098.0,43450,433
-Pennsylvania,Mercer County,2010,116558,0.0,40398,436
+Pennsylvania,Mercer County,2010,116558,,40398,436
 Pennsylvania,Mercer County,2011,116205,2278.0,41648,451
-Pennsylvania,Mercer County,2012,115655,0.0,42101,467
+Pennsylvania,Mercer County,2012,115655,,42101,467
 Pennsylvania,Mercer County,2013,115195,2395.0,44222,487
 Pennsylvania,Mercer County,2014,114884,2109.0,43574,487
 Pennsylvania,Mercer County,2015,114234,2589.0,47051,504
-Pennsylvania,Mercer County,2016,112913,0.0,49890,505
-Pennsylvania,Mercer County,2017,111750,0.0,46785,517
+Pennsylvania,Mercer County,2016,112913,,49890,505
+Pennsylvania,Mercer County,2017,111750,,46785,517
 Pennsylvania,Mercer County,2018,110683,2052.0,48847,527
-Pennsylvania,Mercer County,2019,109424,0.0,54543,537
-Pennsylvania,Mercer County,2021,109972,0.0,54067,586
-Pennsylvania,Mercer County,2022,109220,0.0,57618,586
-Pennsylvania,Monroe County,2005,159175,0.0,52119,683
+Pennsylvania,Mercer County,2019,109424,,54543,537
+Pennsylvania,Mercer County,2021,109972,,54067,586
+Pennsylvania,Mercer County,2022,109220,,57618,586
+Pennsylvania,Monroe County,2005,159175,,52119,683
 Pennsylvania,Monroe County,2006,165685,2665.0,50173,670
-Pennsylvania,Monroe County,2007,164722,0.0,56860,696
-Pennsylvania,Monroe County,2008,165058,0.0,56838,795
-Pennsylvania,Monroe County,2009,166355,0.0,54879,756
-Pennsylvania,Monroe County,2010,169896,0.0,54549,833
-Pennsylvania,Monroe County,2011,169882,0.0,51875,695
-Pennsylvania,Monroe County,2012,168798,0.0,56178,782
-Pennsylvania,Monroe County,2013,167148,0.0,55536,874
-Pennsylvania,Monroe County,2014,166314,0.0,63118,903
+Pennsylvania,Monroe County,2007,164722,,56860,696
+Pennsylvania,Monroe County,2008,165058,,56838,795
+Pennsylvania,Monroe County,2009,166355,,54879,756
+Pennsylvania,Monroe County,2010,169896,,54549,833
+Pennsylvania,Monroe County,2011,169882,,51875,695
+Pennsylvania,Monroe County,2012,168798,,56178,782
+Pennsylvania,Monroe County,2013,167148,,55536,874
+Pennsylvania,Monroe County,2014,166314,,63118,903
 Pennsylvania,Monroe County,2015,166397,4727.0,57318,779
-Pennsylvania,Monroe County,2016,166098,0.0,60095,794
+Pennsylvania,Monroe County,2016,166098,,60095,794
 Pennsylvania,Monroe County,2017,168046,2541.0,61612,874
 Pennsylvania,Monroe County,2018,169507,3286.0,64170,859
-Pennsylvania,Monroe County,2019,170271,0.0,62413,956
-Pennsylvania,Monroe County,2021,169273,0.0,78575,963
-Pennsylvania,Monroe County,2022,167198,0.0,81580,999
+Pennsylvania,Monroe County,2019,170271,,62413,956
+Pennsylvania,Monroe County,2021,169273,,78575,963
+Pennsylvania,Monroe County,2022,167198,,81580,999
 Pennsylvania,Montgomery County,2005,753046,13395.0,68210,796
 Pennsylvania,Montgomery County,2006,775688,14726.0,71180,843
 Pennsylvania,Montgomery County,2007,776172,15633.0,74000,837
@@ -10227,23 +10227,23 @@ Pennsylvania,Northampton County,2018,304807,8228.0,68591,891
 Pennsylvania,Northampton County,2019,305285,6257.0,74328,957
 Pennsylvania,Northampton County,2021,313628,25829.0,79578,1035
 Pennsylvania,Northampton County,2022,318526,20724.0,74696,1096
-Pennsylvania,Northumberland County,2005,88726,0.0,36073,347
+Pennsylvania,Northumberland County,2005,88726,,36073,347
 Pennsylvania,Northumberland County,2006,91654,1054.0,35985,375
-Pennsylvania,Northumberland County,2007,91003,0.0,36591,355
-Pennsylvania,Northumberland County,2008,91091,0.0,40506,364
-Pennsylvania,Northumberland County,2009,91311,0.0,37602,413
-Pennsylvania,Northumberland County,2010,94366,0.0,35394,403
-Pennsylvania,Northumberland County,2011,94558,0.0,39822,424
+Pennsylvania,Northumberland County,2007,91003,,36591,355
+Pennsylvania,Northumberland County,2008,91091,,40506,364
+Pennsylvania,Northumberland County,2009,91311,,37602,413
+Pennsylvania,Northumberland County,2010,94366,,35394,403
+Pennsylvania,Northumberland County,2011,94558,,39822,424
 Pennsylvania,Northumberland County,2012,94428,1295.0,40948,432
-Pennsylvania,Northumberland County,2013,94076,0.0,41011,458
-Pennsylvania,Northumberland County,2014,93944,0.0,39778,467
-Pennsylvania,Northumberland County,2015,93246,0.0,44989,466
-Pennsylvania,Northumberland County,2016,92541,0.0,47736,484
-Pennsylvania,Northumberland County,2017,92029,0.0,44895,475
-Pennsylvania,Northumberland County,2018,91083,0.0,47160,503
-Pennsylvania,Northumberland County,2019,90843,0.0,47349,531
-Pennsylvania,Northumberland County,2021,91266,0.0,50751,517
-Pennsylvania,Northumberland County,2022,90133,0.0,58987,573
+Pennsylvania,Northumberland County,2013,94076,,41011,458
+Pennsylvania,Northumberland County,2014,93944,,39778,467
+Pennsylvania,Northumberland County,2015,93246,,44989,466
+Pennsylvania,Northumberland County,2016,92541,,47736,484
+Pennsylvania,Northumberland County,2017,92029,,44895,475
+Pennsylvania,Northumberland County,2018,91083,,47160,503
+Pennsylvania,Northumberland County,2019,90843,,47349,531
+Pennsylvania,Northumberland County,2021,91266,,50751,517
+Pennsylvania,Northumberland County,2022,90133,,58987,573
 Pennsylvania,Philadelphia County,2005,1406415,14159.0,32573,580
 Pennsylvania,Philadelphia County,2006,1448394,12995.0,33229,608
 Pennsylvania,Philadelphia County,2007,1449634,16110.0,35365,621
@@ -10261,13 +10261,13 @@ Pennsylvania,Philadelphia County,2018,1584138,29728.0,46116,857
 Pennsylvania,Philadelphia County,2019,1584064,36369.0,47474,906
 Pennsylvania,Philadelphia County,2021,1576251,170574.0,52899,999
 Pennsylvania,Philadelphia County,2022,1567258,143519.0,56517,1073
-Pennsylvania,Schuylkill County,2005,139811,0.0,35610,375
+Pennsylvania,Schuylkill County,2005,139811,,35610,375
 Pennsylvania,Schuylkill County,2006,147405,1865.0,38496,414
 Pennsylvania,Schuylkill County,2007,147269,2216.0,40839,403
 Pennsylvania,Schuylkill County,2008,147254,1668.0,43387,416
 Pennsylvania,Schuylkill County,2009,146952,938.0,41503,414
 Pennsylvania,Schuylkill County,2010,148228,1822.0,40265,457
-Pennsylvania,Schuylkill County,2011,147513,0.0,47437,459
+Pennsylvania,Schuylkill County,2011,147513,,47437,459
 Pennsylvania,Schuylkill County,2012,147063,1527.0,45056,472
 Pennsylvania,Schuylkill County,2013,146920,1327.0,41114,495
 Pennsylvania,Schuylkill County,2014,145797,2139.0,43044,505
@@ -10275,27 +10275,27 @@ Pennsylvania,Schuylkill County,2015,144590,1569.0,45810,515
 Pennsylvania,Schuylkill County,2016,143573,1556.0,50684,516
 Pennsylvania,Schuylkill County,2017,142569,1537.0,49559,510
 Pennsylvania,Schuylkill County,2018,142067,2775.0,48458,535
-Pennsylvania,Schuylkill County,2019,141359,0.0,56295,552
-Pennsylvania,Schuylkill County,2021,143264,0.0,58614,568
-Pennsylvania,Schuylkill County,2022,143104,0.0,64160,607
-Pennsylvania,Somerset County,2005,74617,0.0,33083,329
-Pennsylvania,Somerset County,2006,78508,0.0,33837,355
-Pennsylvania,Somerset County,2007,77861,0.0,37554,348
-Pennsylvania,Somerset County,2008,77454,0.0,37639,372
-Pennsylvania,Somerset County,2009,76953,0.0,39362,371
-Pennsylvania,Somerset County,2010,77626,0.0,39978,395
-Pennsylvania,Somerset County,2011,77405,0.0,38658,341
-Pennsylvania,Somerset County,2012,76957,0.0,46263,369
-Pennsylvania,Somerset County,2013,76520,0.0,43429,442
-Pennsylvania,Somerset County,2014,76218,0.0,46217,426
-Pennsylvania,Somerset County,2015,75522,0.0,43660,436
-Pennsylvania,Somerset County,2016,75061,0.0,43871,423
+Pennsylvania,Schuylkill County,2019,141359,,56295,552
+Pennsylvania,Schuylkill County,2021,143264,,58614,568
+Pennsylvania,Schuylkill County,2022,143104,,64160,607
+Pennsylvania,Somerset County,2005,74617,,33083,329
+Pennsylvania,Somerset County,2006,78508,,33837,355
+Pennsylvania,Somerset County,2007,77861,,37554,348
+Pennsylvania,Somerset County,2008,77454,,37639,372
+Pennsylvania,Somerset County,2009,76953,,39362,371
+Pennsylvania,Somerset County,2010,77626,,39978,395
+Pennsylvania,Somerset County,2011,77405,,38658,341
+Pennsylvania,Somerset County,2012,76957,,46263,369
+Pennsylvania,Somerset County,2013,76520,,43429,442
+Pennsylvania,Somerset County,2014,76218,,46217,426
+Pennsylvania,Somerset County,2015,75522,,43660,436
+Pennsylvania,Somerset County,2016,75061,,43871,423
 Pennsylvania,Somerset County,2017,74501,1900.0,48846,440
-Pennsylvania,Somerset County,2018,73952,0.0,50988,430
-Pennsylvania,Somerset County,2019,73447,0.0,48895,443
-Pennsylvania,Somerset County,2021,73627,0.0,54352,468
-Pennsylvania,Somerset County,2022,72710,0.0,48438,491
-Pennsylvania,Washington County,2005,200938,0.0,44947,398
+Pennsylvania,Somerset County,2018,73952,,50988,430
+Pennsylvania,Somerset County,2019,73447,,48895,443
+Pennsylvania,Somerset County,2021,73627,,54352,468
+Pennsylvania,Somerset County,2022,72710,,48438,491
+Pennsylvania,Washington County,2005,200938,,44947,398
 Pennsylvania,Washington County,2006,206432,2307.0,45789,392
 Pennsylvania,Washington County,2007,205553,3091.0,47299,425
 Pennsylvania,Washington County,2008,206407,2574.0,51379,425
@@ -10310,9 +10310,9 @@ Pennsylvania,Washington County,2016,207981,4069.0,57998,558
 Pennsylvania,Washington County,2017,207298,4651.0,60551,575
 Pennsylvania,Washington County,2018,207346,4942.0,63251,631
 Pennsylvania,Washington County,2019,206865,6334.0,65431,641
-Pennsylvania,Washington County,2021,209470,0.0,68408,633
+Pennsylvania,Washington County,2021,209470,,68408,633
 Pennsylvania,Washington County,2022,210383,14542.0,70303,675
-Pennsylvania,Westmoreland County,2005,358687,0.0,43323,399
+Pennsylvania,Westmoreland County,2005,358687,,43323,399
 Pennsylvania,Westmoreland County,2006,366440,5939.0,43617,419
 Pennsylvania,Westmoreland County,2007,362326,4746.0,46057,432
 Pennsylvania,Westmoreland County,2008,361589,5561.0,46966,439
@@ -10346,40 +10346,40 @@ Pennsylvania,York County,2018,448273,10573.0,65239,739
 Pennsylvania,York County,2019,449058,8385.0,69172,762
 Pennsylvania,York County,2021,458696,29429.0,72949,853
 Pennsylvania,York County,2022,461058,29767.0,80130,917
-Rhode Island,Kent County,2005,169719,0.0,57189,744
-Rhode Island,Kent County,2006,170053,0.0,59190,811
-Rhode Island,Kent County,2007,168639,0.0,58190,768
+Rhode Island,Kent County,2005,169719,,57189,744
+Rhode Island,Kent County,2006,170053,,59190,811
+Rhode Island,Kent County,2007,168639,,58190,768
 Rhode Island,Kent County,2008,168058,2700.0,64419,780
-Rhode Island,Kent County,2009,168752,0.0,58908,824
-Rhode Island,Kent County,2010,166103,0.0,53954,810
+Rhode Island,Kent County,2009,168752,,58908,824
+Rhode Island,Kent County,2010,166103,,53954,810
 Rhode Island,Kent County,2011,165535,2842.0,60416,857
-Rhode Island,Kent County,2012,164843,0.0,60114,891
-Rhode Island,Kent County,2013,165035,0.0,65631,849
+Rhode Island,Kent County,2012,164843,,60114,891
+Rhode Island,Kent County,2013,165035,,65631,849
 Rhode Island,Kent County,2014,165128,2223.0,62261,878
-Rhode Island,Kent County,2015,164801,0.0,65931,892
-Rhode Island,Kent County,2016,164614,0.0,63101,935
-Rhode Island,Kent County,2017,163760,0.0,75143,893
-Rhode Island,Kent County,2018,163861,0.0,68994,970
-Rhode Island,Kent County,2019,164292,0.0,74474,967
-Rhode Island,Kent County,2021,170715,0.0,73159,975
-Rhode Island,Kent County,2022,171275,0.0,85395,1095
-Rhode Island,Newport County,2005,80965,0.0,58455,756
-Rhode Island,Newport County,2006,82144,0.0,59758,814
-Rhode Island,Newport County,2007,82777,0.0,62688,960
-Rhode Island,Newport County,2008,80478,0.0,68754,984
-Rhode Island,Newport County,2009,80300,0.0,64251,985
-Rhode Island,Newport County,2010,82852,0.0,75397,1016
-Rhode Island,Newport County,2011,82695,0.0,69119,952
-Rhode Island,Newport County,2012,82036,0.0,64813,962
+Rhode Island,Kent County,2015,164801,,65931,892
+Rhode Island,Kent County,2016,164614,,63101,935
+Rhode Island,Kent County,2017,163760,,75143,893
+Rhode Island,Kent County,2018,163861,,68994,970
+Rhode Island,Kent County,2019,164292,,74474,967
+Rhode Island,Kent County,2021,170715,,73159,975
+Rhode Island,Kent County,2022,171275,,85395,1095
+Rhode Island,Newport County,2005,80965,,58455,756
+Rhode Island,Newport County,2006,82144,,59758,814
+Rhode Island,Newport County,2007,82777,,62688,960
+Rhode Island,Newport County,2008,80478,,68754,984
+Rhode Island,Newport County,2009,80300,,64251,985
+Rhode Island,Newport County,2010,82852,,75397,1016
+Rhode Island,Newport County,2011,82695,,69119,952
+Rhode Island,Newport County,2012,82036,,64813,962
 Rhode Island,Newport County,2013,82397,2123.0,70299,1019
-Rhode Island,Newport County,2014,82358,0.0,71799,1010
+Rhode Island,Newport County,2014,82358,,71799,1010
 Rhode Island,Newport County,2015,82423,2730.0,66026,967
-Rhode Island,Newport County,2016,82784,0.0,73596,1112
-Rhode Island,Newport County,2017,83460,0.0,80222,1154
-Rhode Island,Newport County,2018,82542,0.0,83822,1091
-Rhode Island,Newport County,2019,82082,0.0,81652,1339
-Rhode Island,Newport County,2021,85264,0.0,88090,1330
-Rhode Island,Newport County,2022,84481,0.0,93334,1351
+Rhode Island,Newport County,2016,82784,,73596,1112
+Rhode Island,Newport County,2017,83460,,80222,1154
+Rhode Island,Newport County,2018,82542,,83822,1091
+Rhode Island,Newport County,2019,82082,,81652,1339
+Rhode Island,Newport County,2021,85264,,88090,1330
+Rhode Island,Newport County,2022,84481,,93334,1351
 Rhode Island,Providence County,2005,610539,7620.0,45006,653
 Rhode Island,Providence County,2006,635596,7187.0,46098,700
 Rhode Island,Providence County,2007,629435,7989.0,47700,689
@@ -10397,92 +10397,92 @@ Rhode Island,Providence County,2018,636084,9105.0,56461,817
 Rhode Island,Providence County,2019,638931,13079.0,62994,860
 Rhode Island,Providence County,2021,658221,50856.0,67368,949
 Rhode Island,Providence County,2022,657288,42115.0,75293,1065
-Rhode Island,Washington County,2005,123322,0.0,62536,733
-Rhode Island,Washington County,2006,127561,0.0,66250,795
+Rhode Island,Washington County,2005,123322,,62536,733
+Rhode Island,Washington County,2006,127561,,66250,795
 Rhode Island,Washington County,2007,126902,3790.0,67765,756
 Rhode Island,Washington County,2008,126264,2852.0,73640,784
 Rhode Island,Washington County,2009,126925,3436.0,69083,796
-Rhode Island,Washington County,2010,127008,0.0,70161,831
-Rhode Island,Washington County,2011,126563,0.0,69528,918
+Rhode Island,Washington County,2010,127008,,70161,831
+Rhode Island,Washington County,2011,126563,,69528,918
 Rhode Island,Washington County,2012,125946,3257.0,70649,873
 Rhode Island,Washington County,2013,126259,2422.0,70433,912
-Rhode Island,Washington County,2014,126653,0.0,71229,900
-Rhode Island,Washington County,2015,126517,0.0,72453,945
-Rhode Island,Washington County,2016,126288,0.0,77813,981
-Rhode Island,Washington County,2017,126150,0.0,79374,882
-Rhode Island,Washington County,2018,126179,0.0,89847,963
-Rhode Island,Washington County,2019,125577,0.0,90003,1074
-Rhode Island,Washington County,2021,130592,0.0,90427,1101
-Rhode Island,Washington County,2022,130330,0.0,100459,1153
-South Carolina,Aiken County,2005,148084,0.0,42090,437
-South Carolina,Aiken County,2006,151800,0.0,44128,425
-South Carolina,Aiken County,2007,152307,0.0,45522,411
-South Carolina,Aiken County,2008,154071,0.0,42445,465
-South Carolina,Aiken County,2009,156017,0.0,43831,470
-South Carolina,Aiken County,2010,160565,0.0,42377,514
-South Carolina,Aiken County,2011,160682,0.0,41522,468
-South Carolina,Aiken County,2012,162812,0.0,45658,529
-South Carolina,Aiken County,2013,164176,0.0,42259,528
-South Carolina,Aiken County,2014,164753,0.0,48882,518
-South Carolina,Aiken County,2015,165829,0.0,47219,566
-South Carolina,Aiken County,2016,167458,0.0,45945,595
-South Carolina,Aiken County,2017,168179,0.0,50749,578
-South Carolina,Aiken County,2018,169401,0.0,51932,595
-South Carolina,Aiken County,2019,170872,0.0,55634,680
-South Carolina,Aiken County,2021,170776,0.0,55138,716
-South Carolina,Aiken County,2022,174150,0.0,68473,777
-South Carolina,Anderson County,2005,172748,0.0,37955,429
-South Carolina,Anderson County,2006,177963,0.0,41015,434
-South Carolina,Anderson County,2007,179981,0.0,40778,455
-South Carolina,Anderson County,2008,182825,0.0,45178,463
-South Carolina,Anderson County,2009,184901,0.0,41246,451
-South Carolina,Anderson County,2010,187269,0.0,36770,475
-South Carolina,Anderson County,2011,188488,0.0,40943,486
-South Carolina,Anderson County,2012,189355,0.0,39232,451
-South Carolina,Anderson County,2013,190641,0.0,41135,472
-South Carolina,Anderson County,2014,192810,0.0,42837,506
-South Carolina,Anderson County,2015,194692,0.0,43558,526
-South Carolina,Anderson County,2016,196569,0.0,45090,543
-South Carolina,Anderson County,2017,198759,0.0,48593,573
+Rhode Island,Washington County,2014,126653,,71229,900
+Rhode Island,Washington County,2015,126517,,72453,945
+Rhode Island,Washington County,2016,126288,,77813,981
+Rhode Island,Washington County,2017,126150,,79374,882
+Rhode Island,Washington County,2018,126179,,89847,963
+Rhode Island,Washington County,2019,125577,,90003,1074
+Rhode Island,Washington County,2021,130592,,90427,1101
+Rhode Island,Washington County,2022,130330,,100459,1153
+South Carolina,Aiken County,2005,148084,,42090,437
+South Carolina,Aiken County,2006,151800,,44128,425
+South Carolina,Aiken County,2007,152307,,45522,411
+South Carolina,Aiken County,2008,154071,,42445,465
+South Carolina,Aiken County,2009,156017,,43831,470
+South Carolina,Aiken County,2010,160565,,42377,514
+South Carolina,Aiken County,2011,160682,,41522,468
+South Carolina,Aiken County,2012,162812,,45658,529
+South Carolina,Aiken County,2013,164176,,42259,528
+South Carolina,Aiken County,2014,164753,,48882,518
+South Carolina,Aiken County,2015,165829,,47219,566
+South Carolina,Aiken County,2016,167458,,45945,595
+South Carolina,Aiken County,2017,168179,,50749,578
+South Carolina,Aiken County,2018,169401,,51932,595
+South Carolina,Aiken County,2019,170872,,55634,680
+South Carolina,Aiken County,2021,170776,,55138,716
+South Carolina,Aiken County,2022,174150,,68473,777
+South Carolina,Anderson County,2005,172748,,37955,429
+South Carolina,Anderson County,2006,177963,,41015,434
+South Carolina,Anderson County,2007,179981,,40778,455
+South Carolina,Anderson County,2008,182825,,45178,463
+South Carolina,Anderson County,2009,184901,,41246,451
+South Carolina,Anderson County,2010,187269,,36770,475
+South Carolina,Anderson County,2011,188488,,40943,486
+South Carolina,Anderson County,2012,189355,,39232,451
+South Carolina,Anderson County,2013,190641,,41135,472
+South Carolina,Anderson County,2014,192810,,42837,506
+South Carolina,Anderson County,2015,194692,,43558,526
+South Carolina,Anderson County,2016,196569,,45090,543
+South Carolina,Anderson County,2017,198759,,48593,573
 South Carolina,Anderson County,2018,200482,4072.0,51699,561
-South Carolina,Anderson County,2019,202558,0.0,54322,582
+South Carolina,Anderson County,2019,202558,,54322,582
 South Carolina,Anderson County,2021,206908,5891.0,59037,661
 South Carolina,Anderson County,2022,209581,6763.0,62720,700
-South Carolina,Beaufort County,2005,131695,0.0,48932,805
+South Carolina,Beaufort County,2005,131695,,48932,805
 South Carolina,Beaufort County,2006,142045,3626.0,50522,755
-South Carolina,Beaufort County,2007,147316,0.0,53838,829
+South Carolina,Beaufort County,2007,147316,,53838,829
 South Carolina,Beaufort County,2008,150415,5940.0,54109,815
 South Carolina,Beaufort County,2009,155215,4299.0,53939,896
-South Carolina,Beaufort County,2010,162989,0.0,56960,830
-South Carolina,Beaufort County,2011,164684,0.0,55439,847
-South Carolina,Beaufort County,2012,168049,0.0,54188,830
+South Carolina,Beaufort County,2010,162989,,56960,830
+South Carolina,Beaufort County,2011,164684,,55439,847
+South Carolina,Beaufort County,2012,168049,,54188,830
 South Carolina,Beaufort County,2013,171838,4256.0,57122,885
 South Carolina,Beaufort County,2014,175852,4510.0,54996,898
-South Carolina,Beaufort County,2015,179589,0.0,60257,897
+South Carolina,Beaufort County,2015,179589,,60257,897
 South Carolina,Beaufort County,2016,183149,6336.0,65919,965
 South Carolina,Beaufort County,2017,186844,6385.0,58847,940
 South Carolina,Beaufort County,2018,188715,6963.0,65607,1140
-South Carolina,Beaufort County,2019,192122,0.0,74127,1104
-South Carolina,Beaufort County,2021,191748,0.0,70501,1205
-South Carolina,Beaufort County,2022,196371,0.0,83323,1313
-South Carolina,Berkeley County,2005,146975,0.0,44833,525
-South Carolina,Berkeley County,2006,152282,0.0,48726,599
-South Carolina,Berkeley County,2007,163622,0.0,49048,629
-South Carolina,Berkeley County,2008,169327,0.0,48320,643
+South Carolina,Beaufort County,2019,192122,,74127,1104
+South Carolina,Beaufort County,2021,191748,,70501,1205
+South Carolina,Beaufort County,2022,196371,,83323,1313
+South Carolina,Berkeley County,2005,146975,,44833,525
+South Carolina,Berkeley County,2006,152282,,48726,599
+South Carolina,Berkeley County,2007,163622,,49048,629
+South Carolina,Berkeley County,2008,169327,,48320,643
 South Carolina,Berkeley County,2009,173498,2456.0,49808,694
 South Carolina,Berkeley County,2010,178783,3644.0,49427,719
 South Carolina,Berkeley County,2011,183525,1658.0,49553,766
 South Carolina,Berkeley County,2012,189781,2539.0,49500,766
 South Carolina,Berkeley County,2013,194020,2137.0,50475,804
-South Carolina,Berkeley County,2014,198205,0.0,52427,798
-South Carolina,Berkeley County,2015,202786,0.0,56548,824
-South Carolina,Berkeley County,2016,210898,0.0,59153,837
-South Carolina,Berkeley County,2017,217937,0.0,57147,846
+South Carolina,Berkeley County,2014,198205,,52427,798
+South Carolina,Berkeley County,2015,202786,,56548,824
+South Carolina,Berkeley County,2016,210898,,59153,837
+South Carolina,Berkeley County,2017,217937,,57147,846
 South Carolina,Berkeley County,2018,221091,5259.0,62994,959
 South Carolina,Berkeley County,2019,227907,7012.0,69398,1062
-South Carolina,Berkeley County,2021,236701,0.0,75004,1135
-South Carolina,Berkeley County,2022,245117,0.0,80185,1400
-South Carolina,Charleston County,2005,317770,0.0,43213,642
+South Carolina,Berkeley County,2021,236701,,75004,1135
+South Carolina,Berkeley County,2022,245117,,80185,1400
+South Carolina,Charleston County,2005,317770,,43213,642
 South Carolina,Charleston County,2006,331917,5579.0,43857,665
 South Carolina,Charleston County,2007,342973,5610.0,47901,670
 South Carolina,Charleston County,2008,348046,7844.0,50671,685
@@ -10499,40 +10499,40 @@ South Carolina,Charleston County,2018,405905,14696.0,63459,1038
 South Carolina,Charleston County,2019,411406,15540.0,71531,1083
 South Carolina,Charleston County,2021,413024,35652.0,72147,1158
 South Carolina,Charleston County,2022,419279,38612.0,80401,1300
-South Carolina,Dorchester County,2005,110552,0.0,50128,658
-South Carolina,Dorchester County,2006,118979,0.0,50332,592
-South Carolina,Dorchester County,2007,123505,0.0,53915,682
-South Carolina,Dorchester County,2008,127133,0.0,62003,704
-South Carolina,Dorchester County,2009,130417,0.0,52138,699
-South Carolina,Dorchester County,2010,137476,0.0,50908,711
-South Carolina,Dorchester County,2011,140892,0.0,50266,728
-South Carolina,Dorchester County,2012,142496,0.0,53637,741
-South Carolina,Dorchester County,2013,145397,0.0,54582,701
-South Carolina,Dorchester County,2014,148469,0.0,56277,790
-South Carolina,Dorchester County,2015,152478,0.0,54521,813
-South Carolina,Dorchester County,2016,153773,0.0,57637,865
-South Carolina,Dorchester County,2017,156456,0.0,64148,881
-South Carolina,Dorchester County,2018,160647,0.0,66438,959
-South Carolina,Dorchester County,2019,162809,0.0,68200,945
-South Carolina,Dorchester County,2021,163327,0.0,70009,1006
-South Carolina,Dorchester County,2022,166133,0.0,73791,1087
-South Carolina,Florence County,2005,127293,0.0,37066,425
-South Carolina,Florence County,2006,131297,0.0,38185,428
-South Carolina,Florence County,2007,131886,0.0,40436,414
+South Carolina,Dorchester County,2005,110552,,50128,658
+South Carolina,Dorchester County,2006,118979,,50332,592
+South Carolina,Dorchester County,2007,123505,,53915,682
+South Carolina,Dorchester County,2008,127133,,62003,704
+South Carolina,Dorchester County,2009,130417,,52138,699
+South Carolina,Dorchester County,2010,137476,,50908,711
+South Carolina,Dorchester County,2011,140892,,50266,728
+South Carolina,Dorchester County,2012,142496,,53637,741
+South Carolina,Dorchester County,2013,145397,,54582,701
+South Carolina,Dorchester County,2014,148469,,56277,790
+South Carolina,Dorchester County,2015,152478,,54521,813
+South Carolina,Dorchester County,2016,153773,,57637,865
+South Carolina,Dorchester County,2017,156456,,64148,881
+South Carolina,Dorchester County,2018,160647,,66438,959
+South Carolina,Dorchester County,2019,162809,,68200,945
+South Carolina,Dorchester County,2021,163327,,70009,1006
+South Carolina,Dorchester County,2022,166133,,73791,1087
+South Carolina,Florence County,2005,127293,,37066,425
+South Carolina,Florence County,2006,131297,,38185,428
+South Carolina,Florence County,2007,131886,,40436,414
 South Carolina,Florence County,2008,132800,1533.0,40995,449
-South Carolina,Florence County,2009,134208,0.0,40448,447
+South Carolina,Florence County,2009,134208,,40448,447
 South Carolina,Florence County,2010,137088,2065.0,38872,443
-South Carolina,Florence County,2011,137862,0.0,40232,455
-South Carolina,Florence County,2012,137948,0.0,41251,504
-South Carolina,Florence County,2013,138326,0.0,41331,507
-South Carolina,Florence County,2014,139231,0.0,43148,506
-South Carolina,Florence County,2015,138900,0.0,40883,531
-South Carolina,Florence County,2016,138742,0.0,46524,582
-South Carolina,Florence County,2017,138566,0.0,42929,574
-South Carolina,Florence County,2018,138159,0.0,48790,585
-South Carolina,Florence County,2019,138293,0.0,50082,588
-South Carolina,Florence County,2021,136504,0.0,51860,679
-South Carolina,Florence County,2022,136721,0.0,49527,603
+South Carolina,Florence County,2011,137862,,40232,455
+South Carolina,Florence County,2012,137948,,41251,504
+South Carolina,Florence County,2013,138326,,41331,507
+South Carolina,Florence County,2014,139231,,43148,506
+South Carolina,Florence County,2015,138900,,40883,531
+South Carolina,Florence County,2016,138742,,46524,582
+South Carolina,Florence County,2017,138566,,42929,574
+South Carolina,Florence County,2018,138159,,48790,585
+South Carolina,Florence County,2019,138293,,50082,588
+South Carolina,Florence County,2021,136504,,51860,679
+South Carolina,Florence County,2022,136721,,49527,603
 South Carolina,Greenville County,2005,396399,4794.0,42449,493
 South Carolina,Greenville County,2006,417166,4732.0,41850,508
 South Carolina,Greenville County,2007,428243,8292.0,47768,529
@@ -10550,146 +10550,146 @@ South Carolina,Greenville County,2018,514213,15120.0,61183,796
 South Carolina,Greenville County,2019,523542,15307.0,64412,797
 South Carolina,Greenville County,2021,533834,40438.0,68540,927
 South Carolina,Greenville County,2022,547950,36200.0,71728,995
-South Carolina,Greenwood County,2005,65436,0.0,35381,406
-South Carolina,Greenwood County,2006,68213,0.0,38793,379
-South Carolina,Greenwood County,2007,68259,0.0,41314,413
-South Carolina,Greenwood County,2008,68549,0.0,39225,426
-South Carolina,Greenwood County,2009,69671,0.0,41975,448
-South Carolina,Greenwood County,2010,69703,0.0,30808,455
-South Carolina,Greenwood County,2011,69835,0.0,35678,467
-South Carolina,Greenwood County,2012,69756,0.0,35923,486
-South Carolina,Greenwood County,2013,69723,0.0,34029,490
-South Carolina,Greenwood County,2014,69520,0.0,37831,476
-South Carolina,Greenwood County,2015,69838,0.0,43218,508
-South Carolina,Greenwood County,2016,70133,0.0,38200,511
-South Carolina,Greenwood County,2017,70355,0.0,40453,508
-South Carolina,Greenwood County,2018,70741,0.0,42245,564
-South Carolina,Greenwood County,2019,70811,0.0,42148,569
-South Carolina,Greenwood County,2021,69241,0.0,52636,601
-South Carolina,Greenwood County,2022,69267,0.0,47052,669
-South Carolina,Horry County,2005,224487,0.0,38789,583
+South Carolina,Greenwood County,2005,65436,,35381,406
+South Carolina,Greenwood County,2006,68213,,38793,379
+South Carolina,Greenwood County,2007,68259,,41314,413
+South Carolina,Greenwood County,2008,68549,,39225,426
+South Carolina,Greenwood County,2009,69671,,41975,448
+South Carolina,Greenwood County,2010,69703,,30808,455
+South Carolina,Greenwood County,2011,69835,,35678,467
+South Carolina,Greenwood County,2012,69756,,35923,486
+South Carolina,Greenwood County,2013,69723,,34029,490
+South Carolina,Greenwood County,2014,69520,,37831,476
+South Carolina,Greenwood County,2015,69838,,43218,508
+South Carolina,Greenwood County,2016,70133,,38200,511
+South Carolina,Greenwood County,2017,70355,,40453,508
+South Carolina,Greenwood County,2018,70741,,42245,564
+South Carolina,Greenwood County,2019,70811,,42148,569
+South Carolina,Greenwood County,2021,69241,,52636,601
+South Carolina,Greenwood County,2022,69267,,47052,669
+South Carolina,Horry County,2005,224487,,38789,583
 South Carolina,Horry County,2006,238493,3696.0,40816,622
-South Carolina,Horry County,2007,249925,0.0,43184,624
-South Carolina,Horry County,2008,257380,0.0,42327,671
-South Carolina,Horry County,2009,263868,0.0,41321,669
+South Carolina,Horry County,2007,249925,,43184,624
+South Carolina,Horry County,2008,257380,,42327,671
+South Carolina,Horry County,2009,263868,,41321,669
 South Carolina,Horry County,2010,270430,3232.0,41568,644
-South Carolina,Horry County,2011,276340,0.0,38775,662
+South Carolina,Horry County,2011,276340,,38775,662
 South Carolina,Horry County,2012,282285,4159.0,40353,681
 South Carolina,Horry County,2013,289650,3007.0,42075,658
-South Carolina,Horry County,2014,298832,0.0,43001,665
-South Carolina,Horry County,2015,309199,0.0,47541,743
+South Carolina,Horry County,2014,298832,,43001,665
+South Carolina,Horry County,2015,309199,,47541,743
 South Carolina,Horry County,2016,322342,6084.0,45621,732
 South Carolina,Horry County,2017,333268,8554.0,45680,774
 South Carolina,Horry County,2018,344147,8997.0,49047,772
 South Carolina,Horry County,2019,354081,12173.0,53694,869
 South Carolina,Horry County,2021,365579,14582.0,55819,881
 South Carolina,Horry County,2022,383101,20763.0,61063,1015
-South Carolina,Kershaw County,2017,65036,0.0,50010,505
-South Carolina,Kershaw County,2018,65592,0.0,51467,584
-South Carolina,Kershaw County,2019,66551,0.0,55198,545
-South Carolina,Kershaw County,2021,66130,0.0,47995,633
-South Carolina,Kershaw County,2022,67751,0.0,58684,737
-South Carolina,Lancaster County,2007,73393,0.0,35743,391
-South Carolina,Lancaster County,2008,75913,0.0,38327,408
-South Carolina,Lancaster County,2009,77767,0.0,40440,462
-South Carolina,Lancaster County,2010,76889,0.0,35634,418
-South Carolina,Lancaster County,2011,77908,0.0,40232,461
-South Carolina,Lancaster County,2012,79089,0.0,44959,439
-South Carolina,Lancaster County,2013,80458,0.0,38500,418
-South Carolina,Lancaster County,2014,83160,0.0,44412,465
-South Carolina,Lancaster County,2015,85842,0.0,45676,571
-South Carolina,Lancaster County,2016,89594,0.0,56216,463
-South Carolina,Lancaster County,2017,92550,0.0,61914,543
-South Carolina,Lancaster County,2018,95380,0.0,57224,569
-South Carolina,Lancaster County,2019,98012,0.0,63924,571
-South Carolina,Lancaster County,2021,100336,0.0,69796,561
-South Carolina,Lancaster County,2022,104577,0.0,68108,534
-South Carolina,Laurens County,2005,67556,0.0,34751,333
-South Carolina,Laurens County,2006,70374,0.0,34791,350
-South Carolina,Laurens County,2007,69582,0.0,34117,341
-South Carolina,Laurens County,2008,69681,0.0,42224,374
-South Carolina,Laurens County,2009,70045,0.0,37351,415
-South Carolina,Laurens County,2010,66500,0.0,36265,421
-South Carolina,Laurens County,2011,66528,0.0,35178,379
-South Carolina,Laurens County,2012,66223,0.0,34906,443
-South Carolina,Laurens County,2013,66229,0.0,35406,420
-South Carolina,Laurens County,2014,66533,0.0,37638,435
-South Carolina,Laurens County,2015,66623,0.0,39474,438
-South Carolina,Laurens County,2016,66777,0.0,44038,506
-South Carolina,Laurens County,2017,66848,0.0,40377,500
-South Carolina,Laurens County,2018,66994,0.0,41452,474
-South Carolina,Laurens County,2019,67493,0.0,47218,474
-South Carolina,Laurens County,2021,67803,0.0,56624,556
-South Carolina,Laurens County,2022,67965,0.0,54334,585
-South Carolina,Lexington County,2005,232350,0.0,46073,509
+South Carolina,Kershaw County,2017,65036,,50010,505
+South Carolina,Kershaw County,2018,65592,,51467,584
+South Carolina,Kershaw County,2019,66551,,55198,545
+South Carolina,Kershaw County,2021,66130,,47995,633
+South Carolina,Kershaw County,2022,67751,,58684,737
+South Carolina,Lancaster County,2007,73393,,35743,391
+South Carolina,Lancaster County,2008,75913,,38327,408
+South Carolina,Lancaster County,2009,77767,,40440,462
+South Carolina,Lancaster County,2010,76889,,35634,418
+South Carolina,Lancaster County,2011,77908,,40232,461
+South Carolina,Lancaster County,2012,79089,,44959,439
+South Carolina,Lancaster County,2013,80458,,38500,418
+South Carolina,Lancaster County,2014,83160,,44412,465
+South Carolina,Lancaster County,2015,85842,,45676,571
+South Carolina,Lancaster County,2016,89594,,56216,463
+South Carolina,Lancaster County,2017,92550,,61914,543
+South Carolina,Lancaster County,2018,95380,,57224,569
+South Carolina,Lancaster County,2019,98012,,63924,571
+South Carolina,Lancaster County,2021,100336,,69796,561
+South Carolina,Lancaster County,2022,104577,,68108,534
+South Carolina,Laurens County,2005,67556,,34751,333
+South Carolina,Laurens County,2006,70374,,34791,350
+South Carolina,Laurens County,2007,69582,,34117,341
+South Carolina,Laurens County,2008,69681,,42224,374
+South Carolina,Laurens County,2009,70045,,37351,415
+South Carolina,Laurens County,2010,66500,,36265,421
+South Carolina,Laurens County,2011,66528,,35178,379
+South Carolina,Laurens County,2012,66223,,34906,443
+South Carolina,Laurens County,2013,66229,,35406,420
+South Carolina,Laurens County,2014,66533,,37638,435
+South Carolina,Laurens County,2015,66623,,39474,438
+South Carolina,Laurens County,2016,66777,,44038,506
+South Carolina,Laurens County,2017,66848,,40377,500
+South Carolina,Laurens County,2018,66994,,41452,474
+South Carolina,Laurens County,2019,67493,,47218,474
+South Carolina,Laurens County,2021,67803,,56624,556
+South Carolina,Laurens County,2022,67965,,54334,585
+South Carolina,Lexington County,2005,232350,,46073,509
 South Carolina,Lexington County,2006,240160,5011.0,50103,493
 South Carolina,Lexington County,2007,243270,4239.0,50837,552
-South Carolina,Lexington County,2008,248518,0.0,52209,605
+South Carolina,Lexington County,2008,248518,,52209,605
 South Carolina,Lexington County,2009,255607,5008.0,52256,578
-South Carolina,Lexington County,2010,263406,0.0,51594,571
-South Carolina,Lexington County,2011,267129,0.0,50661,633
+South Carolina,Lexington County,2010,263406,,51594,571
+South Carolina,Lexington County,2011,267129,,50661,633
 South Carolina,Lexington County,2012,270406,5556.0,52314,609
 South Carolina,Lexington County,2013,273752,6377.0,53990,675
 South Carolina,Lexington County,2014,277888,4536.0,53980,654
 South Carolina,Lexington County,2015,281833,5781.0,55227,658
 South Carolina,Lexington County,2016,286196,4741.0,57382,681
-South Carolina,Lexington County,2017,290642,0.0,60181,687
+South Carolina,Lexington County,2017,290642,,60181,687
 South Carolina,Lexington County,2018,295032,6945.0,60154,718
 South Carolina,Lexington County,2019,298750,6803.0,61631,707
-South Carolina,Lexington County,2021,300137,0.0,64800,794
+South Carolina,Lexington County,2021,300137,,64800,794
 South Carolina,Lexington County,2022,304797,19008.0,72801,904
-South Carolina,Oconee County,2005,68937,0.0,38251,379
-South Carolina,Oconee County,2006,70567,0.0,39679,376
-South Carolina,Oconee County,2007,70753,0.0,40197,396
-South Carolina,Oconee County,2008,71274,0.0,41171,447
-South Carolina,Oconee County,2009,71514,0.0,36587,418
-South Carolina,Oconee County,2010,74359,0.0,42848,541
-South Carolina,Oconee County,2011,74418,0.0,41153,448
-South Carolina,Oconee County,2012,74627,0.0,37383,464
-South Carolina,Oconee County,2013,75045,0.0,40565,440
-South Carolina,Oconee County,2014,75192,0.0,35159,463
-South Carolina,Oconee County,2015,75713,0.0,43266,526
-South Carolina,Oconee County,2016,76355,0.0,43743,483
-South Carolina,Oconee County,2017,77270,0.0,50192,519
-South Carolina,Oconee County,2018,78374,0.0,47132,555
-South Carolina,Oconee County,2019,79546,0.0,48204,533
-South Carolina,Oconee County,2021,79203,0.0,50393,540
-South Carolina,Oconee County,2022,80180,0.0,55195,557
-South Carolina,Orangeburg County,2005,86924,0.0,30195,364
-South Carolina,Orangeburg County,2006,90845,0.0,29700,357
-South Carolina,Orangeburg County,2007,89952,0.0,31877,401
-South Carolina,Orangeburg County,2008,90336,0.0,30177,329
-South Carolina,Orangeburg County,2009,90112,0.0,34199,406
-South Carolina,Orangeburg County,2010,92346,0.0,31979,449
-South Carolina,Orangeburg County,2011,91910,0.0,31031,433
-South Carolina,Orangeburg County,2012,91476,0.0,34185,446
-South Carolina,Orangeburg County,2013,90942,0.0,31230,423
-South Carolina,Orangeburg County,2014,90090,0.0,28680,446
-South Carolina,Orangeburg County,2015,89208,0.0,38596,466
-South Carolina,Orangeburg County,2016,87903,0.0,32450,437
-South Carolina,Orangeburg County,2017,87476,0.0,35947,512
-South Carolina,Orangeburg County,2018,86934,0.0,36536,458
-South Carolina,Orangeburg County,2019,86175,0.0,37701,491
-South Carolina,Orangeburg County,2021,82962,0.0,34685,515
-South Carolina,Orangeburg County,2022,83094,0.0,40016,534
-South Carolina,Pickens County,2005,106583,0.0,41162,431
-South Carolina,Pickens County,2006,114446,0.0,40733,462
-South Carolina,Pickens County,2007,116003,0.0,42253,469
-South Carolina,Pickens County,2008,116915,0.0,40806,472
-South Carolina,Pickens County,2009,118144,0.0,39801,548
-South Carolina,Pickens County,2010,119217,0.0,39280,512
-South Carolina,Pickens County,2011,119574,0.0,39348,486
-South Carolina,Pickens County,2012,119670,0.0,39052,571
-South Carolina,Pickens County,2013,119829,0.0,41800,562
-South Carolina,Pickens County,2014,120368,0.0,40136,518
-South Carolina,Pickens County,2015,121691,0.0,42449,553
-South Carolina,Pickens County,2016,122863,0.0,45779,554
-South Carolina,Pickens County,2017,123479,0.0,47520,590
-South Carolina,Pickens County,2018,124937,0.0,47148,591
-South Carolina,Pickens County,2019,126884,0.0,52190,610
-South Carolina,Pickens County,2021,132229,0.0,48489,708
-South Carolina,Pickens County,2022,133462,0.0,53022,725
-South Carolina,Richland County,2005,310345,0.0,43463,537
+South Carolina,Oconee County,2005,68937,,38251,379
+South Carolina,Oconee County,2006,70567,,39679,376
+South Carolina,Oconee County,2007,70753,,40197,396
+South Carolina,Oconee County,2008,71274,,41171,447
+South Carolina,Oconee County,2009,71514,,36587,418
+South Carolina,Oconee County,2010,74359,,42848,541
+South Carolina,Oconee County,2011,74418,,41153,448
+South Carolina,Oconee County,2012,74627,,37383,464
+South Carolina,Oconee County,2013,75045,,40565,440
+South Carolina,Oconee County,2014,75192,,35159,463
+South Carolina,Oconee County,2015,75713,,43266,526
+South Carolina,Oconee County,2016,76355,,43743,483
+South Carolina,Oconee County,2017,77270,,50192,519
+South Carolina,Oconee County,2018,78374,,47132,555
+South Carolina,Oconee County,2019,79546,,48204,533
+South Carolina,Oconee County,2021,79203,,50393,540
+South Carolina,Oconee County,2022,80180,,55195,557
+South Carolina,Orangeburg County,2005,86924,,30195,364
+South Carolina,Orangeburg County,2006,90845,,29700,357
+South Carolina,Orangeburg County,2007,89952,,31877,401
+South Carolina,Orangeburg County,2008,90336,,30177,329
+South Carolina,Orangeburg County,2009,90112,,34199,406
+South Carolina,Orangeburg County,2010,92346,,31979,449
+South Carolina,Orangeburg County,2011,91910,,31031,433
+South Carolina,Orangeburg County,2012,91476,,34185,446
+South Carolina,Orangeburg County,2013,90942,,31230,423
+South Carolina,Orangeburg County,2014,90090,,28680,446
+South Carolina,Orangeburg County,2015,89208,,38596,466
+South Carolina,Orangeburg County,2016,87903,,32450,437
+South Carolina,Orangeburg County,2017,87476,,35947,512
+South Carolina,Orangeburg County,2018,86934,,36536,458
+South Carolina,Orangeburg County,2019,86175,,37701,491
+South Carolina,Orangeburg County,2021,82962,,34685,515
+South Carolina,Orangeburg County,2022,83094,,40016,534
+South Carolina,Pickens County,2005,106583,,41162,431
+South Carolina,Pickens County,2006,114446,,40733,462
+South Carolina,Pickens County,2007,116003,,42253,469
+South Carolina,Pickens County,2008,116915,,40806,472
+South Carolina,Pickens County,2009,118144,,39801,548
+South Carolina,Pickens County,2010,119217,,39280,512
+South Carolina,Pickens County,2011,119574,,39348,486
+South Carolina,Pickens County,2012,119670,,39052,571
+South Carolina,Pickens County,2013,119829,,41800,562
+South Carolina,Pickens County,2014,120368,,40136,518
+South Carolina,Pickens County,2015,121691,,42449,553
+South Carolina,Pickens County,2016,122863,,45779,554
+South Carolina,Pickens County,2017,123479,,47520,590
+South Carolina,Pickens County,2018,124937,,47148,591
+South Carolina,Pickens County,2019,126884,,52190,610
+South Carolina,Pickens County,2021,132229,,48489,708
+South Carolina,Pickens County,2022,133462,,53022,725
+South Carolina,Richland County,2005,310345,,43463,537
 South Carolina,Richland County,2006,348226,15423.0,45370,577
 South Carolina,Richland County,2007,357734,16868.0,47978,576
 South Carolina,Richland County,2008,364001,12683.0,50005,594
@@ -10706,60 +10706,60 @@ South Carolina,Richland County,2018,414576,6634.0,52159,786
 South Carolina,Richland County,2019,415759,6432.0,52293,801
 South Carolina,Richland County,2021,418307,24854.0,56439,847
 South Carolina,Richland County,2022,421566,24016.0,60442,946
-South Carolina,Spartanburg County,2005,259224,0.0,37347,445
+South Carolina,Spartanburg County,2005,259224,,37347,445
 South Carolina,Spartanburg County,2006,271087,2325.0,39694,445
 South Carolina,Spartanburg County,2007,275534,2463.0,40923,442
 South Carolina,Spartanburg County,2008,280738,2596.0,45185,486
 South Carolina,Spartanburg County,2009,286822,3118.0,39691,488
-South Carolina,Spartanburg County,2010,284713,0.0,41850,489
+South Carolina,Spartanburg County,2010,284713,,41850,489
 South Carolina,Spartanburg County,2011,286868,3549.0,40167,516
 South Carolina,Spartanburg County,2012,288745,3718.0,40879,535
 South Carolina,Spartanburg County,2013,290969,2483.0,42103,535
 South Carolina,Spartanburg County,2014,293542,2641.0,43688,544
-South Carolina,Spartanburg County,2015,297302,0.0,45125,540
+South Carolina,Spartanburg County,2015,297302,,45125,540
 South Carolina,Spartanburg County,2016,301463,3914.0,47371,565
 South Carolina,Spartanburg County,2017,306854,4079.0,50985,623
-South Carolina,Spartanburg County,2018,313888,0.0,53581,599
+South Carolina,Spartanburg County,2018,313888,,53581,599
 South Carolina,Spartanburg County,2019,319785,5165.0,55339,664
 South Carolina,Spartanburg County,2021,335864,14470.0,60472,728
 South Carolina,Spartanburg County,2022,345831,14845.0,57755,785
-South Carolina,Sumter County,2005,102146,0.0,33696,388
-South Carolina,Sumter County,2006,104430,0.0,35461,415
-South Carolina,Sumter County,2007,103943,0.0,39030,439
-South Carolina,Sumter County,2008,104148,0.0,37648,439
-South Carolina,Sumter County,2009,104495,0.0,37689,456
-South Carolina,Sumter County,2010,107570,0.0,36457,491
-South Carolina,Sumter County,2011,107460,0.0,42009,520
-South Carolina,Sumter County,2012,108052,0.0,39667,499
-South Carolina,Sumter County,2013,108123,0.0,39780,565
-South Carolina,Sumter County,2014,107919,0.0,36633,509
-South Carolina,Sumter County,2015,107480,0.0,41169,543
+South Carolina,Sumter County,2005,102146,,33696,388
+South Carolina,Sumter County,2006,104430,,35461,415
+South Carolina,Sumter County,2007,103943,,39030,439
+South Carolina,Sumter County,2008,104148,,37648,439
+South Carolina,Sumter County,2009,104495,,37689,456
+South Carolina,Sumter County,2010,107570,,36457,491
+South Carolina,Sumter County,2011,107460,,42009,520
+South Carolina,Sumter County,2012,108052,,39667,499
+South Carolina,Sumter County,2013,108123,,39780,565
+South Carolina,Sumter County,2014,107919,,36633,509
+South Carolina,Sumter County,2015,107480,,41169,543
 South Carolina,Sumter County,2016,107396,793.0,40614,492
-South Carolina,Sumter County,2017,106847,0.0,45585,568
-South Carolina,Sumter County,2018,106512,0.0,45994,569
-South Carolina,Sumter County,2019,106721,0.0,51025,612
-South Carolina,Sumter County,2021,104758,0.0,46003,628
-South Carolina,Sumter County,2022,104012,0.0,57775,932
-South Carolina,York County,2005,185731,0.0,46680,521
+South Carolina,Sumter County,2017,106847,,45585,568
+South Carolina,Sumter County,2018,106512,,45994,569
+South Carolina,Sumter County,2019,106721,,51025,612
+South Carolina,Sumter County,2021,104758,,46003,628
+South Carolina,Sumter County,2022,104012,,57775,932
+South Carolina,York County,2005,185731,,46680,521
 South Carolina,York County,2006,199035,3590.0,45739,529
 South Carolina,York County,2007,208827,4677.0,54397,563
 South Carolina,York County,2008,217448,3333.0,51190,580
 South Carolina,York County,2009,227003,5718.0,50133,593
-South Carolina,York County,2010,226971,0.0,50797,579
+South Carolina,York County,2010,226971,,50797,579
 South Carolina,York County,2011,230528,4737.0,49406,583
 South Carolina,York County,2012,234635,4716.0,50817,608
 South Carolina,York County,2013,239363,5927.0,54439,596
 South Carolina,York County,2014,245346,4291.0,52565,667
-South Carolina,York County,2015,251195,0.0,56359,675
+South Carolina,York County,2015,251195,,56359,675
 South Carolina,York County,2016,258526,7194.0,60767,701
 South Carolina,York County,2017,266439,7626.0,62217,713
 South Carolina,York County,2018,274118,9616.0,64319,781
 South Carolina,York County,2019,280979,9544.0,66949,861
-South Carolina,York County,2021,288595,0.0,72772,1004
+South Carolina,York County,2021,288595,,72772,1004
 South Carolina,York County,2022,294248,26359.0,83613,1142
-South Dakota,Lincoln County,2021,67870,0.0,82898,949
-South Dakota,Lincoln County,2022,70987,0.0,90600,966
-South Dakota,Minnehaha County,2005,154396,0.0,45196,520
+South Dakota,Lincoln County,2021,67870,,82898,949
+South Dakota,Lincoln County,2022,70987,,90600,966
+South Dakota,Minnehaha County,2005,154396,,45196,520
 South Dakota,Minnehaha County,2006,163281,2841.0,49810,555
 South Dakota,Minnehaha County,2007,175272,3348.0,48859,554
 South Dakota,Minnehaha County,2008,179180,3762.0,55597,592
@@ -10776,74 +10776,74 @@ South Dakota,Minnehaha County,2018,192876,3901.0,58742,717
 South Dakota,Minnehaha County,2019,193134,3695.0,61968,750
 South Dakota,Minnehaha County,2021,199685,16069.0,72748,776
 South Dakota,Minnehaha County,2022,203971,13254.0,74253,838
-South Dakota,Pennington County,2005,91040,0.0,42220,565
-South Dakota,Pennington County,2006,94338,0.0,43508,497
-South Dakota,Pennington County,2007,96280,0.0,43585,571
+South Dakota,Pennington County,2005,91040,,42220,565
+South Dakota,Pennington County,2006,94338,,43508,497
+South Dakota,Pennington County,2007,96280,,43585,571
 South Dakota,Pennington County,2008,98533,1388.0,46442,579
 South Dakota,Pennington County,2009,100850,2779.0,47323,590
-South Dakota,Pennington County,2010,101348,0.0,45704,602
-South Dakota,Pennington County,2011,102815,0.0,48981,643
-South Dakota,Pennington County,2012,104347,0.0,49546,688
-South Dakota,Pennington County,2013,105761,0.0,48906,645
-South Dakota,Pennington County,2014,108242,0.0,47838,688
-South Dakota,Pennington County,2015,108702,0.0,52611,715
-South Dakota,Pennington County,2016,109372,0.0,50950,652
-South Dakota,Pennington County,2017,110141,0.0,54836,701
-South Dakota,Pennington County,2018,111729,0.0,59006,722
-South Dakota,Pennington County,2019,113775,0.0,58085,742
-South Dakota,Pennington County,2021,111806,0.0,64057,874
-South Dakota,Pennington County,2022,114461,0.0,65801,908
-Tennessee,Anderson County,2005,71553,0.0,36020,437
-Tennessee,Anderson County,2006,73579,0.0,41652,457
-Tennessee,Anderson County,2007,73471,0.0,40117,425
-Tennessee,Anderson County,2008,74169,0.0,45015,447
-Tennessee,Anderson County,2009,74849,0.0,44294,504
-Tennessee,Anderson County,2010,75160,0.0,48310,462
-Tennessee,Anderson County,2011,75233,0.0,40756,487
-Tennessee,Anderson County,2012,75416,0.0,38421,501
-Tennessee,Anderson County,2013,75542,0.0,40907,531
-Tennessee,Anderson County,2014,75528,0.0,47821,528
-Tennessee,Anderson County,2015,75749,0.0,42744,505
-Tennessee,Anderson County,2016,75936,0.0,46055,574
-Tennessee,Anderson County,2017,76257,0.0,48109,531
-Tennessee,Anderson County,2018,76482,0.0,50616,591
-Tennessee,Anderson County,2019,76978,0.0,49044,629
-Tennessee,Anderson County,2021,77576,0.0,60364,714
-Tennessee,Anderson County,2022,78913,0.0,67746,767
-Tennessee,Blount County,2005,113393,0.0,42551,447
-Tennessee,Blount County,2006,118186,0.0,42909,501
-Tennessee,Blount County,2007,119855,0.0,47722,481
-Tennessee,Blount County,2008,121511,0.0,47215,486
-Tennessee,Blount County,2009,122784,0.0,45516,487
-Tennessee,Blount County,2010,123119,0.0,40846,541
-Tennessee,Blount County,2011,123901,0.0,45858,543
-Tennessee,Blount County,2012,124177,0.0,46095,570
-Tennessee,Blount County,2013,125099,0.0,44351,549
-Tennessee,Blount County,2014,126339,0.0,46819,596
-Tennessee,Blount County,2015,127253,0.0,49134,537
-Tennessee,Blount County,2016,128670,0.0,51183,587
-Tennessee,Blount County,2017,129929,0.0,50675,584
-Tennessee,Blount County,2018,131349,0.0,58809,688
-Tennessee,Blount County,2019,133088,0.0,59276,704
-Tennessee,Blount County,2021,137605,0.0,62102,734
-Tennessee,Blount County,2022,139958,0.0,69756,743
-Tennessee,Bradley County,2005,90039,0.0,40148,443
-Tennessee,Bradley County,2006,93538,0.0,37185,410
-Tennessee,Bradley County,2007,95443,0.0,38793,452
-Tennessee,Bradley County,2008,96472,0.0,39948,482
-Tennessee,Bradley County,2009,97710,0.0,39347,474
-Tennessee,Bradley County,2010,99078,0.0,36978,513
-Tennessee,Bradley County,2011,100055,0.0,37149,480
-Tennessee,Bradley County,2012,101134,0.0,38505,524
-Tennessee,Bradley County,2013,101848,0.0,42722,513
-Tennessee,Bradley County,2014,102975,0.0,42563,540
-Tennessee,Bradley County,2015,104091,0.0,42922,524
-Tennessee,Bradley County,2016,104490,0.0,44853,551
-Tennessee,Bradley County,2017,105560,0.0,48857,598
-Tennessee,Bradley County,2018,106727,0.0,50560,594
-Tennessee,Bradley County,2019,108110,0.0,52468,601
-Tennessee,Bradley County,2021,110162,0.0,56139,648
-Tennessee,Bradley County,2022,110616,0.0,63659,734
+South Dakota,Pennington County,2010,101348,,45704,602
+South Dakota,Pennington County,2011,102815,,48981,643
+South Dakota,Pennington County,2012,104347,,49546,688
+South Dakota,Pennington County,2013,105761,,48906,645
+South Dakota,Pennington County,2014,108242,,47838,688
+South Dakota,Pennington County,2015,108702,,52611,715
+South Dakota,Pennington County,2016,109372,,50950,652
+South Dakota,Pennington County,2017,110141,,54836,701
+South Dakota,Pennington County,2018,111729,,59006,722
+South Dakota,Pennington County,2019,113775,,58085,742
+South Dakota,Pennington County,2021,111806,,64057,874
+South Dakota,Pennington County,2022,114461,,65801,908
+Tennessee,Anderson County,2005,71553,,36020,437
+Tennessee,Anderson County,2006,73579,,41652,457
+Tennessee,Anderson County,2007,73471,,40117,425
+Tennessee,Anderson County,2008,74169,,45015,447
+Tennessee,Anderson County,2009,74849,,44294,504
+Tennessee,Anderson County,2010,75160,,48310,462
+Tennessee,Anderson County,2011,75233,,40756,487
+Tennessee,Anderson County,2012,75416,,38421,501
+Tennessee,Anderson County,2013,75542,,40907,531
+Tennessee,Anderson County,2014,75528,,47821,528
+Tennessee,Anderson County,2015,75749,,42744,505
+Tennessee,Anderson County,2016,75936,,46055,574
+Tennessee,Anderson County,2017,76257,,48109,531
+Tennessee,Anderson County,2018,76482,,50616,591
+Tennessee,Anderson County,2019,76978,,49044,629
+Tennessee,Anderson County,2021,77576,,60364,714
+Tennessee,Anderson County,2022,78913,,67746,767
+Tennessee,Blount County,2005,113393,,42551,447
+Tennessee,Blount County,2006,118186,,42909,501
+Tennessee,Blount County,2007,119855,,47722,481
+Tennessee,Blount County,2008,121511,,47215,486
+Tennessee,Blount County,2009,122784,,45516,487
+Tennessee,Blount County,2010,123119,,40846,541
+Tennessee,Blount County,2011,123901,,45858,543
+Tennessee,Blount County,2012,124177,,46095,570
+Tennessee,Blount County,2013,125099,,44351,549
+Tennessee,Blount County,2014,126339,,46819,596
+Tennessee,Blount County,2015,127253,,49134,537
+Tennessee,Blount County,2016,128670,,51183,587
+Tennessee,Blount County,2017,129929,,50675,584
+Tennessee,Blount County,2018,131349,,58809,688
+Tennessee,Blount County,2019,133088,,59276,704
+Tennessee,Blount County,2021,137605,,62102,734
+Tennessee,Blount County,2022,139958,,69756,743
+Tennessee,Bradley County,2005,90039,,40148,443
+Tennessee,Bradley County,2006,93538,,37185,410
+Tennessee,Bradley County,2007,95443,,38793,452
+Tennessee,Bradley County,2008,96472,,39948,482
+Tennessee,Bradley County,2009,97710,,39347,474
+Tennessee,Bradley County,2010,99078,,36978,513
+Tennessee,Bradley County,2011,100055,,37149,480
+Tennessee,Bradley County,2012,101134,,38505,524
+Tennessee,Bradley County,2013,101848,,42722,513
+Tennessee,Bradley County,2014,102975,,42563,540
+Tennessee,Bradley County,2015,104091,,42922,524
+Tennessee,Bradley County,2016,104490,,44853,551
+Tennessee,Bradley County,2017,105560,,48857,598
+Tennessee,Bradley County,2018,106727,,50560,594
+Tennessee,Bradley County,2019,108110,,52468,601
+Tennessee,Bradley County,2021,110162,,56139,648
+Tennessee,Bradley County,2022,110616,,63659,734
 Tennessee,Davidson County,2005,549850,9207.0,40652,568
 Tennessee,Davidson County,2006,578698,9713.0,41994,600
 Tennessee,Davidson County,2007,619626,14990.0,46359,605
@@ -10861,25 +10861,25 @@ Tennessee,Davidson County,2018,692587,21885.0,60856,967
 Tennessee,Davidson County,2019,694144,32041.0,63938,1042
 Tennessee,Davidson County,2021,703953,87456.0,65348,1180
 Tennessee,Davidson County,2022,708144,86729.0,72473,1310
-Tennessee,Greene County,2005,67268,0.0,32071,355
-Tennessee,Greene County,2006,68109,0.0,34291,349
-Tennessee,Greene County,2007,69943,0.0,33946,351
-Tennessee,Greene County,2008,66911,0.0,35062,432
-Tennessee,Greene County,2009,66282,0.0,33601,375
-Tennessee,Greene County,2010,68797,0.0,35196,356
-Tennessee,Greene County,2011,69339,0.0,31873,392
-Tennessee,Greene County,2012,68819,0.0,34536,423
-Tennessee,Greene County,2013,68267,0.0,35981,385
-Tennessee,Greene County,2014,68335,0.0,36694,423
-Tennessee,Greene County,2015,68580,0.0,34768,461
-Tennessee,Greene County,2016,68615,0.0,41109,426
-Tennessee,Greene County,2017,68808,0.0,37920,448
-Tennessee,Greene County,2018,69087,0.0,47383,516
-Tennessee,Greene County,2019,69069,0.0,44722,513
-Tennessee,Greene County,2021,70621,0.0,56488,516
-Tennessee,Greene County,2022,71405,0.0,48918,483
-Tennessee,Hamblen County,2022,65168,0.0,59418,569
-Tennessee,Hamilton County,2005,302475,0.0,40593,479
+Tennessee,Greene County,2005,67268,,32071,355
+Tennessee,Greene County,2006,68109,,34291,349
+Tennessee,Greene County,2007,69943,,33946,351
+Tennessee,Greene County,2008,66911,,35062,432
+Tennessee,Greene County,2009,66282,,33601,375
+Tennessee,Greene County,2010,68797,,35196,356
+Tennessee,Greene County,2011,69339,,31873,392
+Tennessee,Greene County,2012,68819,,34536,423
+Tennessee,Greene County,2013,68267,,35981,385
+Tennessee,Greene County,2014,68335,,36694,423
+Tennessee,Greene County,2015,68580,,34768,461
+Tennessee,Greene County,2016,68615,,41109,426
+Tennessee,Greene County,2017,68808,,37920,448
+Tennessee,Greene County,2018,69087,,47383,516
+Tennessee,Greene County,2019,69069,,44722,513
+Tennessee,Greene County,2021,70621,,56488,516
+Tennessee,Greene County,2022,71405,,48918,483
+Tennessee,Hamblen County,2022,65168,,59418,569
+Tennessee,Hamilton County,2005,302475,,40593,479
 Tennessee,Hamilton County,2006,312905,3319.0,41855,500
 Tennessee,Hamilton County,2007,330168,4251.0,45491,490
 Tennessee,Hamilton County,2008,332848,4193.0,47779,554
@@ -10896,7 +10896,7 @@ Tennessee,Hamilton County,2018,364286,12502.0,57280,719
 Tennessee,Hamilton County,2019,367804,12165.0,57502,750
 Tennessee,Hamilton County,2021,369135,28470.0,66096,873
 Tennessee,Hamilton County,2022,374682,29997.0,76219,1015
-Tennessee,Knox County,2005,392382,0.0,42052,483
+Tennessee,Knox County,2005,392382,,42052,483
 Tennessee,Knox County,2006,411967,7741.0,44184,495
 Tennessee,Knox County,2007,423874,6700.0,44961,553
 Tennessee,Knox County,2008,430019,7564.0,45673,557
@@ -10913,47 +10913,47 @@ Tennessee,Knox County,2018,465289,13257.0,55632,715
 Tennessee,Knox County,2019,470313,14310.0,60283,763
 Tennessee,Knox County,2021,486677,35227.0,64894,876
 Tennessee,Knox County,2022,494574,34030.0,69999,941
-Tennessee,Madison County,2005,91316,0.0,39619,445
-Tennessee,Madison County,2006,95894,0.0,35216,471
-Tennessee,Madison County,2007,96518,0.0,39355,445
-Tennessee,Madison County,2008,96376,0.0,43164,491
-Tennessee,Madison County,2009,97317,0.0,38579,460
-Tennessee,Madison County,2010,98395,0.0,40438,485
-Tennessee,Madison County,2011,98255,0.0,38743,455
-Tennessee,Madison County,2012,98656,0.0,43161,532
-Tennessee,Madison County,2013,98733,0.0,39523,485
-Tennessee,Madison County,2014,98178,0.0,42412,531
-Tennessee,Madison County,2015,97610,0.0,47801,619
-Tennessee,Madison County,2016,97663,0.0,41791,583
-Tennessee,Madison County,2017,97643,0.0,45013,593
-Tennessee,Madison County,2018,97605,0.0,45360,540
-Tennessee,Madison County,2019,97984,0.0,49820,634
-Tennessee,Madison County,2021,98775,0.0,53720,719
-Tennessee,Madison County,2022,99245,0.0,55666,776
-Tennessee,Maury County,2005,75054,0.0,40992,448
-Tennessee,Maury County,2006,78309,0.0,44769,489
-Tennessee,Maury County,2007,79966,0.0,45354,513
-Tennessee,Maury County,2008,81938,0.0,46596,498
-Tennessee,Maury County,2009,84302,0.0,42806,492
-Tennessee,Maury County,2010,81141,0.0,45435,526
-Tennessee,Maury County,2011,81509,0.0,40518,522
-Tennessee,Maury County,2012,81990,0.0,41953,503
-Tennessee,Maury County,2013,83761,0.0,45712,510
-Tennessee,Maury County,2014,85515,0.0,53990,557
-Tennessee,Maury County,2015,87757,0.0,50707,606
-Tennessee,Maury County,2016,89981,0.0,50591,603
-Tennessee,Maury County,2017,92163,0.0,57258,779
-Tennessee,Maury County,2018,94340,0.0,53794,681
-Tennessee,Maury County,2019,96387,0.0,66781,729
-Tennessee,Maury County,2021,104760,0.0,68840,863
-Tennessee,Maury County,2022,108159,0.0,68157,977
-Tennessee,Montgomery County,2005,142799,0.0,45737,514
-Tennessee,Montgomery County,2006,147114,0.0,47864,565
+Tennessee,Madison County,2005,91316,,39619,445
+Tennessee,Madison County,2006,95894,,35216,471
+Tennessee,Madison County,2007,96518,,39355,445
+Tennessee,Madison County,2008,96376,,43164,491
+Tennessee,Madison County,2009,97317,,38579,460
+Tennessee,Madison County,2010,98395,,40438,485
+Tennessee,Madison County,2011,98255,,38743,455
+Tennessee,Madison County,2012,98656,,43161,532
+Tennessee,Madison County,2013,98733,,39523,485
+Tennessee,Madison County,2014,98178,,42412,531
+Tennessee,Madison County,2015,97610,,47801,619
+Tennessee,Madison County,2016,97663,,41791,583
+Tennessee,Madison County,2017,97643,,45013,593
+Tennessee,Madison County,2018,97605,,45360,540
+Tennessee,Madison County,2019,97984,,49820,634
+Tennessee,Madison County,2021,98775,,53720,719
+Tennessee,Madison County,2022,99245,,55666,776
+Tennessee,Maury County,2005,75054,,40992,448
+Tennessee,Maury County,2006,78309,,44769,489
+Tennessee,Maury County,2007,79966,,45354,513
+Tennessee,Maury County,2008,81938,,46596,498
+Tennessee,Maury County,2009,84302,,42806,492
+Tennessee,Maury County,2010,81141,,45435,526
+Tennessee,Maury County,2011,81509,,40518,522
+Tennessee,Maury County,2012,81990,,41953,503
+Tennessee,Maury County,2013,83761,,45712,510
+Tennessee,Maury County,2014,85515,,53990,557
+Tennessee,Maury County,2015,87757,,50707,606
+Tennessee,Maury County,2016,89981,,50591,603
+Tennessee,Maury County,2017,92163,,57258,779
+Tennessee,Maury County,2018,94340,,53794,681
+Tennessee,Maury County,2019,96387,,66781,729
+Tennessee,Maury County,2021,104760,,68840,863
+Tennessee,Maury County,2022,108159,,68157,977
+Tennessee,Montgomery County,2005,142799,,45737,514
+Tennessee,Montgomery County,2006,147114,,47864,565
 Tennessee,Montgomery County,2007,154460,1912.0,49016,536
 Tennessee,Montgomery County,2008,154756,1870.0,47136,578
-Tennessee,Montgomery County,2009,160978,0.0,46611,596
-Tennessee,Montgomery County,2010,173307,0.0,46703,607
-Tennessee,Montgomery County,2011,176619,0.0,47154,661
+Tennessee,Montgomery County,2009,160978,,46611,596
+Tennessee,Montgomery County,2010,173307,,46703,607
+Tennessee,Montgomery County,2011,176619,,47154,661
 Tennessee,Montgomery County,2012,184468,1708.0,47850,663
 Tennessee,Montgomery County,2013,184119,2741.0,51017,712
 Tennessee,Montgomery County,2014,189961,1744.0,50941,689
@@ -10962,39 +10962,39 @@ Tennessee,Montgomery County,2016,195734,2819.0,56112,758
 Tennessee,Montgomery County,2017,200182,2635.0,58381,792
 Tennessee,Montgomery County,2018,205950,3662.0,56019,766
 Tennessee,Montgomery County,2019,208993,3018.0,56948,732
-Tennessee,Montgomery County,2021,227900,0.0,63331,934
+Tennessee,Montgomery County,2021,227900,,63331,934
 Tennessee,Montgomery County,2022,235201,11455.0,67264,1028
-Tennessee,Putnam County,2005,63749,0.0,30864,378
-Tennessee,Putnam County,2006,68284,0.0,35139,402
-Tennessee,Putnam County,2007,69916,0.0,35081,461
-Tennessee,Putnam County,2008,71160,0.0,35445,398
-Tennessee,Putnam County,2009,72431,0.0,30983,438
-Tennessee,Putnam County,2010,72564,0.0,32983,453
-Tennessee,Putnam County,2011,72958,0.0,32874,436
-Tennessee,Putnam County,2012,73229,0.0,31563,457
-Tennessee,Putnam County,2013,73525,0.0,31448,470
-Tennessee,Putnam County,2014,74165,0.0,35516,495
-Tennessee,Putnam County,2015,74553,0.0,40623,543
-Tennessee,Putnam County,2016,75931,0.0,37437,511
-Tennessee,Putnam County,2017,77674,0.0,39647,546
-Tennessee,Putnam County,2018,78843,0.0,45199,598
-Tennessee,Putnam County,2019,80245,0.0,49282,615
-Tennessee,Putnam County,2021,81188,0.0,52278,639
-Tennessee,Putnam County,2022,82382,0.0,54373,731
-Tennessee,Robertson County,2009,66581,0.0,50699,510
-Tennessee,Robertson County,2010,66469,0.0,51687,604
-Tennessee,Robertson County,2011,67106,0.0,47785,545
-Tennessee,Robertson County,2012,66931,0.0,56234,625
-Tennessee,Robertson County,2013,67383,0.0,50510,592
-Tennessee,Robertson County,2014,68079,0.0,51883,647
-Tennessee,Robertson County,2015,68570,0.0,53204,672
-Tennessee,Robertson County,2016,69165,0.0,60423,689
-Tennessee,Robertson County,2017,70177,0.0,60474,638
-Tennessee,Robertson County,2018,71012,0.0,69079,662
-Tennessee,Robertson County,2019,71813,0.0,66939,756
-Tennessee,Robertson County,2021,74098,0.0,65139,760
-Tennessee,Robertson County,2022,75470,0.0,79171,897
-Tennessee,Rutherford County,2005,212434,0.0,47372,581
+Tennessee,Putnam County,2005,63749,,30864,378
+Tennessee,Putnam County,2006,68284,,35139,402
+Tennessee,Putnam County,2007,69916,,35081,461
+Tennessee,Putnam County,2008,71160,,35445,398
+Tennessee,Putnam County,2009,72431,,30983,438
+Tennessee,Putnam County,2010,72564,,32983,453
+Tennessee,Putnam County,2011,72958,,32874,436
+Tennessee,Putnam County,2012,73229,,31563,457
+Tennessee,Putnam County,2013,73525,,31448,470
+Tennessee,Putnam County,2014,74165,,35516,495
+Tennessee,Putnam County,2015,74553,,40623,543
+Tennessee,Putnam County,2016,75931,,37437,511
+Tennessee,Putnam County,2017,77674,,39647,546
+Tennessee,Putnam County,2018,78843,,45199,598
+Tennessee,Putnam County,2019,80245,,49282,615
+Tennessee,Putnam County,2021,81188,,52278,639
+Tennessee,Putnam County,2022,82382,,54373,731
+Tennessee,Robertson County,2009,66581,,50699,510
+Tennessee,Robertson County,2010,66469,,51687,604
+Tennessee,Robertson County,2011,67106,,47785,545
+Tennessee,Robertson County,2012,66931,,56234,625
+Tennessee,Robertson County,2013,67383,,50510,592
+Tennessee,Robertson County,2014,68079,,51883,647
+Tennessee,Robertson County,2015,68570,,53204,672
+Tennessee,Robertson County,2016,69165,,60423,689
+Tennessee,Robertson County,2017,70177,,60474,638
+Tennessee,Robertson County,2018,71012,,69079,662
+Tennessee,Robertson County,2019,71813,,66939,756
+Tennessee,Robertson County,2021,74098,,65139,760
+Tennessee,Robertson County,2022,75470,,79171,897
+Tennessee,Rutherford County,2005,212434,,47372,581
 Tennessee,Rutherford County,2006,228829,3164.0,47254,611
 Tennessee,Rutherford County,2007,241462,2516.0,50364,642
 Tennessee,Rutherford County,2008,249270,3582.0,54012,663
@@ -11005,29 +11005,29 @@ Tennessee,Rutherford County,2012,274454,3819.0,53132,712
 Tennessee,Rutherford County,2013,281029,4100.0,57174,741
 Tennessee,Rutherford County,2014,288906,3821.0,52502,751
 Tennessee,Rutherford County,2015,298612,5611.0,60043,783
-Tennessee,Rutherford County,2016,308251,0.0,61157,877
+Tennessee,Rutherford County,2016,308251,,61157,877
 Tennessee,Rutherford County,2017,317157,8447.0,68514,843
 Tennessee,Rutherford County,2018,324890,9732.0,63739,939
 Tennessee,Rutherford County,2019,332285,10276.0,69397,1018
-Tennessee,Rutherford County,2021,352182,0.0,78201,1090
+Tennessee,Rutherford County,2021,352182,,78201,1090
 Tennessee,Rutherford County,2022,360619,27882.0,76857,1178
-Tennessee,Sevier County,2005,78645,0.0,37598,470
-Tennessee,Sevier County,2006,81382,0.0,39555,523
-Tennessee,Sevier County,2007,83527,0.0,39552,523
-Tennessee,Sevier County,2008,84835,0.0,39765,491
-Tennessee,Sevier County,2009,86243,0.0,42099,521
-Tennessee,Sevier County,2010,90072,0.0,40402,504
-Tennessee,Sevier County,2011,91466,0.0,42066,581
-Tennessee,Sevier County,2012,92512,0.0,43292,569
-Tennessee,Sevier County,2013,93570,0.0,40715,557
-Tennessee,Sevier County,2014,95110,0.0,39175,600
-Tennessee,Sevier County,2015,95946,0.0,42107,598
-Tennessee,Sevier County,2016,96673,0.0,45609,597
-Tennessee,Sevier County,2017,97638,0.0,49963,576
-Tennessee,Sevier County,2018,97892,0.0,47411,647
-Tennessee,Sevier County,2019,98250,0.0,57741,708
-Tennessee,Sevier County,2021,99517,0.0,50239,694
-Tennessee,Sevier County,2022,98789,0.0,59315,859
+Tennessee,Sevier County,2005,78645,,37598,470
+Tennessee,Sevier County,2006,81382,,39555,523
+Tennessee,Sevier County,2007,83527,,39552,523
+Tennessee,Sevier County,2008,84835,,39765,491
+Tennessee,Sevier County,2009,86243,,42099,521
+Tennessee,Sevier County,2010,90072,,40402,504
+Tennessee,Sevier County,2011,91466,,42066,581
+Tennessee,Sevier County,2012,92512,,43292,569
+Tennessee,Sevier County,2013,93570,,40715,557
+Tennessee,Sevier County,2014,95110,,39175,600
+Tennessee,Sevier County,2015,95946,,42107,598
+Tennessee,Sevier County,2016,96673,,45609,597
+Tennessee,Sevier County,2017,97638,,49963,576
+Tennessee,Sevier County,2018,97892,,47411,647
+Tennessee,Sevier County,2019,98250,,57741,708
+Tennessee,Sevier County,2021,99517,,50239,694
+Tennessee,Sevier County,2022,98789,,59315,859
 Tennessee,Shelby County,2005,889955,8109.0,40839,539
 Tennessee,Shelby County,2006,911438,9184.0,41175,530
 Tennessee,Shelby County,2007,910100,8459.0,44282,574
@@ -11045,132 +11045,132 @@ Tennessee,Shelby County,2018,935764,10467.0,47500,694
 Tennessee,Shelby County,2019,937166,14770.0,52614,733
 Tennessee,Shelby County,2021,924454,52488.0,54841,788
 Tennessee,Shelby County,2022,916371,51953.0,61516,857
-Tennessee,Sullivan County,2005,150027,0.0,34555,360
-Tennessee,Sullivan County,2006,153239,0.0,36289,393
-Tennessee,Sullivan County,2007,153519,0.0,38931,398
-Tennessee,Sullivan County,2008,153900,0.0,41296,449
-Tennessee,Sullivan County,2009,154552,0.0,36911,458
-Tennessee,Sullivan County,2010,156794,0.0,34590,426
-Tennessee,Sullivan County,2011,157419,0.0,39541,449
+Tennessee,Sullivan County,2005,150027,,34555,360
+Tennessee,Sullivan County,2006,153239,,36289,393
+Tennessee,Sullivan County,2007,153519,,38931,398
+Tennessee,Sullivan County,2008,153900,,41296,449
+Tennessee,Sullivan County,2009,154552,,36911,458
+Tennessee,Sullivan County,2010,156794,,34590,426
+Tennessee,Sullivan County,2011,157419,,39541,449
 Tennessee,Sullivan County,2012,156786,2501.0,37890,502
-Tennessee,Sullivan County,2013,156595,0.0,40148,475
-Tennessee,Sullivan County,2014,157047,0.0,38251,440
-Tennessee,Sullivan County,2015,156791,0.0,42012,500
-Tennessee,Sullivan County,2016,156667,0.0,42859,497
-Tennessee,Sullivan County,2017,157158,0.0,44909,489
-Tennessee,Sullivan County,2018,157668,0.0,44652,470
-Tennessee,Sullivan County,2019,158348,0.0,51860,538
-Tennessee,Sullivan County,2021,159265,0.0,48063,602
-Tennessee,Sullivan County,2022,160820,0.0,53585,629
-Tennessee,Sumner County,2005,143618,0.0,51890,549
-Tennessee,Sumner County,2006,149416,0.0,53306,551
-Tennessee,Sumner County,2007,152721,0.0,50688,596
-Tennessee,Sumner County,2008,155474,0.0,55167,641
-Tennessee,Sumner County,2009,158759,0.0,54090,611
-Tennessee,Sumner County,2010,161250,0.0,47110,618
-Tennessee,Sumner County,2011,163686,0.0,52115,613
-Tennessee,Sumner County,2012,166123,0.0,55105,687
+Tennessee,Sullivan County,2013,156595,,40148,475
+Tennessee,Sullivan County,2014,157047,,38251,440
+Tennessee,Sullivan County,2015,156791,,42012,500
+Tennessee,Sullivan County,2016,156667,,42859,497
+Tennessee,Sullivan County,2017,157158,,44909,489
+Tennessee,Sullivan County,2018,157668,,44652,470
+Tennessee,Sullivan County,2019,158348,,51860,538
+Tennessee,Sullivan County,2021,159265,,48063,602
+Tennessee,Sullivan County,2022,160820,,53585,629
+Tennessee,Sumner County,2005,143618,,51890,549
+Tennessee,Sumner County,2006,149416,,53306,551
+Tennessee,Sumner County,2007,152721,,50688,596
+Tennessee,Sumner County,2008,155474,,55167,641
+Tennessee,Sumner County,2009,158759,,54090,611
+Tennessee,Sumner County,2010,161250,,47110,618
+Tennessee,Sumner County,2011,163686,,52115,613
+Tennessee,Sumner County,2012,166123,,55105,687
 Tennessee,Sumner County,2013,168888,3534.0,55917,678
 Tennessee,Sumner County,2014,172706,3164.0,58316,729
-Tennessee,Sumner County,2015,175989,0.0,59753,788
+Tennessee,Sumner County,2015,175989,,59753,788
 Tennessee,Sumner County,2016,180063,4571.0,60503,742
-Tennessee,Sumner County,2017,183545,0.0,65014,844
-Tennessee,Sumner County,2018,187149,0.0,65948,843
-Tennessee,Sumner County,2019,191283,0.0,68743,912
-Tennessee,Sumner County,2021,200557,0.0,70092,1034
+Tennessee,Sumner County,2017,183545,,65014,844
+Tennessee,Sumner County,2018,187149,,65948,843
+Tennessee,Sumner County,2019,191283,,68743,912
+Tennessee,Sumner County,2021,200557,,70092,1034
 Tennessee,Sumner County,2022,203858,19713.0,88764,1192
-Tennessee,Washington County,2005,108537,0.0,39348,444
-Tennessee,Washington County,2006,114316,0.0,36551,420
-Tennessee,Washington County,2007,116657,0.0,39930,450
-Tennessee,Washington County,2008,118639,0.0,43021,500
-Tennessee,Washington County,2009,120598,0.0,39362,485
-Tennessee,Washington County,2010,123338,0.0,42213,506
-Tennessee,Washington County,2011,124353,0.0,41564,505
-Tennessee,Washington County,2012,125094,0.0,42448,535
-Tennessee,Washington County,2013,125546,0.0,41349,508
-Tennessee,Washington County,2014,126242,0.0,42950,559
-Tennessee,Washington County,2015,126302,0.0,45484,585
-Tennessee,Washington County,2016,127440,0.0,46276,585
-Tennessee,Washington County,2017,127806,0.0,40697,590
-Tennessee,Washington County,2018,128607,0.0,48765,582
-Tennessee,Washington County,2019,129375,0.0,51428,651
-Tennessee,Washington County,2021,134236,0.0,56009,724
-Tennessee,Washington County,2022,136172,0.0,64899,777
-Tennessee,Williamson County,2005,152604,0.0,78369,777
-Tennessee,Williamson County,2006,160781,0.0,81449,806
-Tennessee,Williamson County,2007,166128,0.0,81954,912
-Tennessee,Williamson County,2008,171452,0.0,93321,910
-Tennessee,Williamson County,2009,176838,0.0,85403,889
-Tennessee,Williamson County,2010,184035,0.0,80533,866
-Tennessee,Williamson County,2011,188560,0.0,86962,868
-Tennessee,Williamson County,2012,192911,0.0,90759,962
-Tennessee,Williamson County,2013,198901,0.0,88759,980
-Tennessee,Williamson County,2014,205226,0.0,93337,1122
-Tennessee,Williamson County,2015,211672,0.0,102881,1199
+Tennessee,Washington County,2005,108537,,39348,444
+Tennessee,Washington County,2006,114316,,36551,420
+Tennessee,Washington County,2007,116657,,39930,450
+Tennessee,Washington County,2008,118639,,43021,500
+Tennessee,Washington County,2009,120598,,39362,485
+Tennessee,Washington County,2010,123338,,42213,506
+Tennessee,Washington County,2011,124353,,41564,505
+Tennessee,Washington County,2012,125094,,42448,535
+Tennessee,Washington County,2013,125546,,41349,508
+Tennessee,Washington County,2014,126242,,42950,559
+Tennessee,Washington County,2015,126302,,45484,585
+Tennessee,Washington County,2016,127440,,46276,585
+Tennessee,Washington County,2017,127806,,40697,590
+Tennessee,Washington County,2018,128607,,48765,582
+Tennessee,Washington County,2019,129375,,51428,651
+Tennessee,Washington County,2021,134236,,56009,724
+Tennessee,Washington County,2022,136172,,64899,777
+Tennessee,Williamson County,2005,152604,,78369,777
+Tennessee,Williamson County,2006,160781,,81449,806
+Tennessee,Williamson County,2007,166128,,81954,912
+Tennessee,Williamson County,2008,171452,,93321,910
+Tennessee,Williamson County,2009,176838,,85403,889
+Tennessee,Williamson County,2010,184035,,80533,866
+Tennessee,Williamson County,2011,188560,,86962,868
+Tennessee,Williamson County,2012,192911,,90759,962
+Tennessee,Williamson County,2013,198901,,88759,980
+Tennessee,Williamson County,2014,205226,,93337,1122
+Tennessee,Williamson County,2015,211672,,102881,1199
 Tennessee,Williamson County,2016,219107,9286.0,106054,1248
-Tennessee,Williamson County,2017,226257,0.0,105622,1311
-Tennessee,Williamson County,2018,231729,0.0,110700,1389
+Tennessee,Williamson County,2017,226257,,105622,1311
+Tennessee,Williamson County,2018,231729,,110700,1389
 Tennessee,Williamson County,2019,238412,16371.0,115507,1461
-Tennessee,Williamson County,2021,255735,0.0,117927,1492
-Tennessee,Williamson County,2022,260815,0.0,129275,1752
-Tennessee,Wilson County,2005,99204,0.0,56138,548
-Tennessee,Wilson County,2006,104035,0.0,60278,581
-Tennessee,Wilson County,2007,106356,0.0,59831,585
-Tennessee,Wilson County,2008,109803,0.0,57713,635
+Tennessee,Williamson County,2021,255735,,117927,1492
+Tennessee,Williamson County,2022,260815,,129275,1752
+Tennessee,Wilson County,2005,99204,,56138,548
+Tennessee,Wilson County,2006,104035,,60278,581
+Tennessee,Wilson County,2007,106356,,59831,585
+Tennessee,Wilson County,2008,109803,,57713,635
 Tennessee,Wilson County,2009,112377,2060.0,61082,623
-Tennessee,Wilson County,2010,114537,0.0,55343,607
-Tennessee,Wilson County,2011,116617,0.0,59987,670
-Tennessee,Wilson County,2012,118961,0.0,56485,678
-Tennessee,Wilson County,2013,121945,0.0,56278,708
-Tennessee,Wilson County,2014,125376,0.0,59685,682
-Tennessee,Wilson County,2015,128911,0.0,64476,687
-Tennessee,Wilson County,2016,132781,0.0,71153,834
-Tennessee,Wilson County,2017,136442,0.0,69959,849
-Tennessee,Wilson County,2018,140625,0.0,76756,922
-Tennessee,Wilson County,2019,144657,0.0,80071,892
-Tennessee,Wilson County,2021,151917,0.0,80960,1090
-Tennessee,Wilson County,2022,158555,0.0,87003,1179
-Texas,Angelina County,2005,78839,0.0,37236,421
-Texas,Angelina County,2006,82524,0.0,40670,402
-Texas,Angelina County,2007,82812,0.0,36464,463
-Texas,Angelina County,2008,83038,0.0,33796,470
-Texas,Angelina County,2009,83675,0.0,37931,473
-Texas,Angelina County,2010,86953,0.0,37775,461
-Texas,Angelina County,2011,87669,0.0,39007,551
-Texas,Angelina County,2012,87597,0.0,39489,528
-Texas,Angelina County,2013,87441,0.0,42750,542
-Texas,Angelina County,2014,87750,0.0,42156,578
-Texas,Angelina County,2015,88255,0.0,49768,624
-Texas,Angelina County,2016,87791,0.0,41161,584
-Texas,Angelina County,2017,87805,0.0,45326,608
-Texas,Angelina County,2018,87092,0.0,47519,595
-Texas,Angelina County,2019,86715,0.0,53320,647
-Texas,Angelina County,2021,86506,0.0,50045,739
-Texas,Angelina County,2022,87101,0.0,58180,759
-Texas,Bastrop County,2005,61724,0.0,46097,541
-Texas,Bastrop County,2006,64544,0.0,53157,651
-Texas,Bastrop County,2007,67487,0.0,51823,692
-Texas,Bastrop County,2008,71776,0.0,50492,590
-Texas,Bastrop County,2009,74876,0.0,48185,641
-Texas,Bastrop County,2010,74403,0.0,49880,561
-Texas,Bastrop County,2011,75115,0.0,55599,685
-Texas,Bastrop County,2012,74763,0.0,49364,646
-Texas,Bastrop County,2013,75825,0.0,48652,719
-Texas,Bastrop County,2014,78069,0.0,53631,680
-Texas,Bastrop County,2015,80527,0.0,63129,731
-Texas,Bastrop County,2016,82733,0.0,56508,701
-Texas,Bastrop County,2017,84761,0.0,72107,749
-Texas,Bastrop County,2018,86976,0.0,69067,882
-Texas,Bastrop County,2019,88723,0.0,57938,1036
-Texas,Bastrop County,2021,102058,0.0,80423,820
-Texas,Bastrop County,2022,106188,0.0,72663,905
-Texas,Bell County,2005,246592,0.0,42019,557
+Tennessee,Wilson County,2010,114537,,55343,607
+Tennessee,Wilson County,2011,116617,,59987,670
+Tennessee,Wilson County,2012,118961,,56485,678
+Tennessee,Wilson County,2013,121945,,56278,708
+Tennessee,Wilson County,2014,125376,,59685,682
+Tennessee,Wilson County,2015,128911,,64476,687
+Tennessee,Wilson County,2016,132781,,71153,834
+Tennessee,Wilson County,2017,136442,,69959,849
+Tennessee,Wilson County,2018,140625,,76756,922
+Tennessee,Wilson County,2019,144657,,80071,892
+Tennessee,Wilson County,2021,151917,,80960,1090
+Tennessee,Wilson County,2022,158555,,87003,1179
+Texas,Angelina County,2005,78839,,37236,421
+Texas,Angelina County,2006,82524,,40670,402
+Texas,Angelina County,2007,82812,,36464,463
+Texas,Angelina County,2008,83038,,33796,470
+Texas,Angelina County,2009,83675,,37931,473
+Texas,Angelina County,2010,86953,,37775,461
+Texas,Angelina County,2011,87669,,39007,551
+Texas,Angelina County,2012,87597,,39489,528
+Texas,Angelina County,2013,87441,,42750,542
+Texas,Angelina County,2014,87750,,42156,578
+Texas,Angelina County,2015,88255,,49768,624
+Texas,Angelina County,2016,87791,,41161,584
+Texas,Angelina County,2017,87805,,45326,608
+Texas,Angelina County,2018,87092,,47519,595
+Texas,Angelina County,2019,86715,,53320,647
+Texas,Angelina County,2021,86506,,50045,739
+Texas,Angelina County,2022,87101,,58180,759
+Texas,Bastrop County,2005,61724,,46097,541
+Texas,Bastrop County,2006,64544,,53157,651
+Texas,Bastrop County,2007,67487,,51823,692
+Texas,Bastrop County,2008,71776,,50492,590
+Texas,Bastrop County,2009,74876,,48185,641
+Texas,Bastrop County,2010,74403,,49880,561
+Texas,Bastrop County,2011,75115,,55599,685
+Texas,Bastrop County,2012,74763,,49364,646
+Texas,Bastrop County,2013,75825,,48652,719
+Texas,Bastrop County,2014,78069,,53631,680
+Texas,Bastrop County,2015,80527,,63129,731
+Texas,Bastrop County,2016,82733,,56508,701
+Texas,Bastrop County,2017,84761,,72107,749
+Texas,Bastrop County,2018,86976,,69067,882
+Texas,Bastrop County,2019,88723,,57938,1036
+Texas,Bastrop County,2021,102058,,80423,820
+Texas,Bastrop County,2022,106188,,72663,905
+Texas,Bell County,2005,246592,,42019,557
 Texas,Bell County,2006,257897,3102.0,43231,550
 Texas,Bell County,2007,276975,3859.0,48081,557
 Texas,Bell County,2008,285084,4518.0,49967,612
 Texas,Bell County,2009,285787,3558.0,45966,631
 Texas,Bell County,2010,313000,2856.0,50175,634
-Texas,Bell County,2011,315196,0.0,45309,662
+Texas,Bell County,2011,315196,,45309,662
 Texas,Bell County,2012,323037,3411.0,49091,649
 Texas,Bell County,2013,326843,4286.0,50656,671
 Texas,Bell County,2014,329140,5489.0,51221,698
@@ -11198,24 +11198,24 @@ Texas,Bexar County,2018,1986049,36819.0,54149,848
 Texas,Bexar County,2019,2003554,40762.0,58964,890
 Texas,Bexar County,2021,2028236,152574.0,63057,984
 Texas,Bexar County,2022,2059530,147747.0,65854,1083
-Texas,Bowie County,2005,83813,0.0,32626,392
-Texas,Bowie County,2006,91455,0.0,39430,433
-Texas,Bowie County,2007,91553,0.0,43667,397
-Texas,Bowie County,2008,92283,0.0,38420,488
-Texas,Bowie County,2009,93964,0.0,40860,440
-Texas,Bowie County,2010,92723,0.0,43760,547
-Texas,Bowie County,2011,92793,0.0,45035,491
-Texas,Bowie County,2012,93148,0.0,38924,527
-Texas,Bowie County,2013,93487,0.0,41142,528
-Texas,Bowie County,2014,93275,0.0,40493,569
-Texas,Bowie County,2015,93389,0.0,40662,560
-Texas,Bowie County,2016,93860,0.0,45997,584
-Texas,Bowie County,2017,94012,0.0,50573,548
-Texas,Bowie County,2018,94324,0.0,47134,620
-Texas,Bowie County,2019,93245,0.0,51802,603
-Texas,Bowie County,2021,92581,0.0,54154,663
-Texas,Bowie County,2022,92035,0.0,49771,655
-Texas,Brazoria County,2005,267376,0.0,49690,466
+Texas,Bowie County,2005,83813,,32626,392
+Texas,Bowie County,2006,91455,,39430,433
+Texas,Bowie County,2007,91553,,43667,397
+Texas,Bowie County,2008,92283,,38420,488
+Texas,Bowie County,2009,93964,,40860,440
+Texas,Bowie County,2010,92723,,43760,547
+Texas,Bowie County,2011,92793,,45035,491
+Texas,Bowie County,2012,93148,,38924,527
+Texas,Bowie County,2013,93487,,41142,528
+Texas,Bowie County,2014,93275,,40493,569
+Texas,Bowie County,2015,93389,,40662,560
+Texas,Bowie County,2016,93860,,45997,584
+Texas,Bowie County,2017,94012,,50573,548
+Texas,Bowie County,2018,94324,,47134,620
+Texas,Bowie County,2019,93245,,51802,603
+Texas,Bowie County,2021,92581,,54154,663
+Texas,Bowie County,2022,92035,,49771,655
+Texas,Brazoria County,2005,267376,,49690,466
 Texas,Brazoria County,2006,287898,2750.0,56774,539
 Texas,Brazoria County,2007,294233,3954.0,60864,590
 Texas,Brazoria County,2008,301044,3608.0,64076,600
@@ -11225,14 +11225,14 @@ Texas,Brazoria County,2011,319973,2753.0,61924,625
 Texas,Brazoria County,2012,324769,3583.0,65024,714
 Texas,Brazoria County,2013,330242,4851.0,66250,688
 Texas,Brazoria County,2014,338124,3521.0,74799,784
-Texas,Brazoria County,2015,346312,0.0,71251,854
+Texas,Brazoria County,2015,346312,,71251,854
 Texas,Brazoria County,2016,354195,3304.0,74799,829
 Texas,Brazoria County,2017,362457,6015.0,82229,959
 Texas,Brazoria County,2018,370200,10094.0,73623,1014
 Texas,Brazoria County,2019,374264,8525.0,84904,1052
-Texas,Brazoria County,2021,379689,0.0,82460,1062
-Texas,Brazoria County,2022,388181,0.0,86083,1103
-Texas,Brazos County,2005,143502,0.0,30010,545
+Texas,Brazoria County,2021,379689,,82460,1062
+Texas,Brazoria County,2022,388181,,86083,1103
+Texas,Brazos County,2005,143502,,30010,545
 Texas,Brazos County,2006,159006,1869.0,35899,542
 Texas,Brazos County,2007,170954,2760.0,37783,561
 Texas,Brazos County,2008,175122,2575.0,37634,586
@@ -11249,7 +11249,7 @@ Texas,Brazos County,2018,226758,2749.0,50110,800
 Texas,Brazos County,2019,229211,4895.0,55121,808
 Texas,Brazos County,2021,237032,13154.0,49362,887
 Texas,Brazos County,2022,242014,15326.0,60393,917
-Texas,Cameron County,2005,374081,0.0,24684,374
+Texas,Cameron County,2005,374081,,24684,374
 Texas,Cameron County,2006,387717,3282.0,27672,382
 Texas,Cameron County,2007,387210,3803.0,29347,372
 Texas,Cameron County,2008,392736,3154.0,30622,427
@@ -11283,40 +11283,40 @@ Texas,Collin County,2018,1005146,47243.0,96051,1238
 Texas,Collin County,2019,1034730,51409.0,96134,1303
 Texas,Collin County,2021,1109462,184438.0,101494,1403
 Texas,Collin County,2022,1158696,177517.0,113305,1578
-Texas,Comal County,2005,94794,0.0,55712,625
-Texas,Comal County,2006,101181,0.0,60511,621
-Texas,Comal County,2007,105187,0.0,58670,599
-Texas,Comal County,2008,109635,0.0,61612,698
-Texas,Comal County,2009,114525,0.0,66560,705
-Texas,Comal County,2010,109382,0.0,62735,716
-Texas,Comal County,2011,111963,0.0,59234,760
-Texas,Comal County,2012,114384,0.0,56203,744
-Texas,Comal County,2013,118480,0.0,72759,845
-Texas,Comal County,2014,123694,0.0,62389,816
-Texas,Comal County,2015,129048,0.0,67363,883
-Texas,Comal County,2016,134788,0.0,77425,935
-Texas,Comal County,2017,141009,0.0,71060,939
-Texas,Comal County,2018,148373,0.0,76203,1042
-Texas,Comal County,2019,156209,0.0,89315,1010
-Texas,Comal County,2021,174986,0.0,93829,1173
-Texas,Comal County,2022,184642,0.0,91171,1388
-Texas,Coryell County,2005,58930,0.0,41377,490
-Texas,Coryell County,2006,72667,0.0,41783,631
-Texas,Coryell County,2007,72156,0.0,45480,597
-Texas,Coryell County,2008,72654,0.0,49779,583
-Texas,Coryell County,2009,72529,0.0,41228,599
-Texas,Coryell County,2010,75645,0.0,48794,657
-Texas,Coryell County,2011,76508,0.0,49808,687
-Texas,Coryell County,2012,77231,0.0,47139,730
-Texas,Coryell County,2013,76192,0.0,51217,652
-Texas,Coryell County,2014,75562,0.0,47042,700
-Texas,Coryell County,2015,75503,0.0,45998,716
-Texas,Coryell County,2016,74686,0.0,51125,689
-Texas,Coryell County,2017,74913,0.0,52769,749
-Texas,Coryell County,2018,74808,0.0,46131,619
-Texas,Coryell County,2019,75951,0.0,53504,662
-Texas,Coryell County,2021,84232,0.0,62737,851
-Texas,Coryell County,2022,85057,0.0,65846,862
+Texas,Comal County,2005,94794,,55712,625
+Texas,Comal County,2006,101181,,60511,621
+Texas,Comal County,2007,105187,,58670,599
+Texas,Comal County,2008,109635,,61612,698
+Texas,Comal County,2009,114525,,66560,705
+Texas,Comal County,2010,109382,,62735,716
+Texas,Comal County,2011,111963,,59234,760
+Texas,Comal County,2012,114384,,56203,744
+Texas,Comal County,2013,118480,,72759,845
+Texas,Comal County,2014,123694,,62389,816
+Texas,Comal County,2015,129048,,67363,883
+Texas,Comal County,2016,134788,,77425,935
+Texas,Comal County,2017,141009,,71060,939
+Texas,Comal County,2018,148373,,76203,1042
+Texas,Comal County,2019,156209,,89315,1010
+Texas,Comal County,2021,174986,,93829,1173
+Texas,Comal County,2022,184642,,91171,1388
+Texas,Coryell County,2005,58930,,41377,490
+Texas,Coryell County,2006,72667,,41783,631
+Texas,Coryell County,2007,72156,,45480,597
+Texas,Coryell County,2008,72654,,49779,583
+Texas,Coryell County,2009,72529,,41228,599
+Texas,Coryell County,2010,75645,,48794,657
+Texas,Coryell County,2011,76508,,49808,687
+Texas,Coryell County,2012,77231,,47139,730
+Texas,Coryell County,2013,76192,,51217,652
+Texas,Coryell County,2014,75562,,47042,700
+Texas,Coryell County,2015,75503,,45998,716
+Texas,Coryell County,2016,74686,,51125,689
+Texas,Coryell County,2017,74913,,52769,749
+Texas,Coryell County,2018,74808,,46131,619
+Texas,Coryell County,2019,75951,,53504,662
+Texas,Coryell County,2021,84232,,62737,851
+Texas,Coryell County,2022,85057,,65846,862
 Texas,Dallas County,2005,2267080,37050.0,42598,618
 Texas,Dallas County,2006,2345815,35317.0,44815,623
 Texas,Dallas County,2007,2366511,36479.0,46372,643
@@ -11351,40 +11351,40 @@ Texas,Denton County,2018,859064,33159.0,88117,1093
 Texas,Denton County,2019,887207,41804.0,90523,1145
 Texas,Denton County,2021,941647,137677.0,97671,1206
 Texas,Denton County,2022,977281,126702.0,102428,1412
-Texas,Ector County,2005,123331,0.0,35978,388
-Texas,Ector County,2006,127462,0.0,40348,409
-Texas,Ector County,2007,129570,0.0,46575,431
-Texas,Ector County,2008,131941,0.0,50241,507
-Texas,Ector County,2009,134625,0.0,44097,552
-Texas,Ector County,2010,137145,0.0,42282,509
-Texas,Ector County,2011,140111,0.0,49967,581
-Texas,Ector County,2012,144325,0.0,51946,630
+Texas,Ector County,2005,123331,,35978,388
+Texas,Ector County,2006,127462,,40348,409
+Texas,Ector County,2007,129570,,46575,431
+Texas,Ector County,2008,131941,,50241,507
+Texas,Ector County,2009,134625,,44097,552
+Texas,Ector County,2010,137145,,42282,509
+Texas,Ector County,2011,140111,,49967,581
+Texas,Ector County,2012,144325,,51946,630
 Texas,Ector County,2013,149378,1086.0,55710,768
-Texas,Ector County,2014,153904,0.0,58701,887
-Texas,Ector County,2015,159436,0.0,65454,867
-Texas,Ector County,2016,157462,0.0,53254,739
-Texas,Ector County,2017,157087,0.0,55380,777
-Texas,Ector County,2018,162124,0.0,64165,886
-Texas,Ector County,2019,166223,0.0,67205,984
-Texas,Ector County,2021,161091,0.0,57473,931
-Texas,Ector County,2022,160869,0.0,68071,949
-Texas,Ellis County,2005,131480,0.0,50585,585
-Texas,Ellis County,2006,139300,0.0,54370,587
+Texas,Ector County,2014,153904,,58701,887
+Texas,Ector County,2015,159436,,65454,867
+Texas,Ector County,2016,157462,,53254,739
+Texas,Ector County,2017,157087,,55380,777
+Texas,Ector County,2018,162124,,64165,886
+Texas,Ector County,2019,166223,,67205,984
+Texas,Ector County,2021,161091,,57473,931
+Texas,Ector County,2022,160869,,68071,949
+Texas,Ellis County,2005,131480,,50585,585
+Texas,Ellis County,2006,139300,,54370,587
 Texas,Ellis County,2007,143468,2459.0,54330,617
-Texas,Ellis County,2008,148186,0.0,65574,616
-Texas,Ellis County,2009,151737,0.0,57777,626
-Texas,Ellis County,2010,150462,0.0,58063,651
-Texas,Ellis County,2011,152753,0.0,61570,666
-Texas,Ellis County,2012,153969,0.0,57097,692
-Texas,Ellis County,2013,155976,0.0,57880,677
-Texas,Ellis County,2014,159317,0.0,60294,738
-Texas,Ellis County,2015,163632,0.0,68095,744
-Texas,Ellis County,2016,168499,0.0,70210,793
-Texas,Ellis County,2017,173620,0.0,72138,802
+Texas,Ellis County,2008,148186,,65574,616
+Texas,Ellis County,2009,151737,,57777,626
+Texas,Ellis County,2010,150462,,58063,651
+Texas,Ellis County,2011,152753,,61570,666
+Texas,Ellis County,2012,153969,,57097,692
+Texas,Ellis County,2013,155976,,57880,677
+Texas,Ellis County,2014,159317,,60294,738
+Texas,Ellis County,2015,163632,,68095,744
+Texas,Ellis County,2016,168499,,70210,793
+Texas,Ellis County,2017,173620,,72138,802
 Texas,Ellis County,2018,179436,4600.0,77794,900
-Texas,Ellis County,2019,184826,0.0,78797,981
-Texas,Ellis County,2021,202678,0.0,89799,994
-Texas,Ellis County,2022,212182,0.0,89856,1203
+Texas,Ellis County,2019,184826,,78797,981
+Texas,Ellis County,2021,202678,,89799,994
+Texas,Ellis County,2022,212182,,89856,1203
 Texas,El Paso County,2005,708319,5924.0,30968,435
 Texas,El Paso County,2006,736310,8987.0,32111,456
 Texas,El Paso County,2007,734669,7498.0,34980,472
@@ -11436,57 +11436,57 @@ Texas,Galveston County,2018,337890,5450.0,73840,958
 Texas,Galveston County,2019,342139,8972.0,74977,987
 Texas,Galveston County,2021,355062,22826.0,78336,1033
 Texas,Galveston County,2022,357117,17806.0,75565,1143
-Texas,Grayson County,2005,113899,0.0,38877,478
+Texas,Grayson County,2005,113899,,38877,478
 Texas,Grayson County,2006,118478,1845.0,43328,490
-Texas,Grayson County,2007,118675,0.0,44802,501
-Texas,Grayson County,2008,118804,0.0,45882,520
-Texas,Grayson County,2009,120030,0.0,43261,522
-Texas,Grayson County,2010,121145,0.0,45577,579
-Texas,Grayson County,2011,121419,0.0,44574,581
-Texas,Grayson County,2012,121935,0.0,47475,596
-Texas,Grayson County,2013,122353,0.0,44378,587
-Texas,Grayson County,2014,123534,0.0,52058,619
+Texas,Grayson County,2007,118675,,44802,501
+Texas,Grayson County,2008,118804,,45882,520
+Texas,Grayson County,2009,120030,,43261,522
+Texas,Grayson County,2010,121145,,45577,579
+Texas,Grayson County,2011,121419,,44574,581
+Texas,Grayson County,2012,121935,,47475,596
+Texas,Grayson County,2013,122353,,44378,587
+Texas,Grayson County,2014,123534,,52058,619
 Texas,Grayson County,2015,125467,3029.0,48126,624
-Texas,Grayson County,2016,128235,0.0,52095,665
-Texas,Grayson County,2017,131140,0.0,56718,715
-Texas,Grayson County,2018,133991,0.0,51158,735
-Texas,Grayson County,2019,136212,0.0,57476,743
-Texas,Grayson County,2021,139336,0.0,62919,841
-Texas,Grayson County,2022,143131,0.0,66106,1040
-Texas,Gregg County,2005,112357,0.0,36264,455
-Texas,Gregg County,2006,117090,0.0,39263,482
-Texas,Gregg County,2007,117119,0.0,39660,509
-Texas,Gregg County,2008,117528,0.0,46054,526
-Texas,Gregg County,2009,119637,0.0,42634,547
-Texas,Gregg County,2010,121854,0.0,40348,569
-Texas,Gregg County,2011,123081,0.0,42572,607
-Texas,Gregg County,2012,122658,0.0,42153,607
-Texas,Gregg County,2013,123024,0.0,45461,621
-Texas,Gregg County,2014,123204,0.0,50917,627
-Texas,Gregg County,2015,124108,0.0,47727,647
-Texas,Gregg County,2016,123745,0.0,44219,671
-Texas,Gregg County,2017,123367,0.0,47095,702
-Texas,Gregg County,2018,123707,0.0,51361,674
-Texas,Gregg County,2019,123945,0.0,53793,708
-Texas,Gregg County,2021,124201,0.0,59869,752
-Texas,Gregg County,2022,125443,0.0,61496,872
-Texas,Guadalupe County,2005,101236,0.0,49198,498
-Texas,Guadalupe County,2006,108410,0.0,53285,563
-Texas,Guadalupe County,2007,112777,0.0,52192,523
-Texas,Guadalupe County,2008,117172,0.0,64737,639
-Texas,Guadalupe County,2009,121432,0.0,58171,611
-Texas,Guadalupe County,2010,132431,0.0,59801,609
-Texas,Guadalupe County,2011,135757,0.0,57326,545
-Texas,Guadalupe County,2012,139841,0.0,63608,761
-Texas,Guadalupe County,2013,143183,0.0,58270,765
-Texas,Guadalupe County,2014,147250,0.0,61538,738
-Texas,Guadalupe County,2015,151249,0.0,64343,831
-Texas,Guadalupe County,2016,155265,0.0,68157,902
+Texas,Grayson County,2016,128235,,52095,665
+Texas,Grayson County,2017,131140,,56718,715
+Texas,Grayson County,2018,133991,,51158,735
+Texas,Grayson County,2019,136212,,57476,743
+Texas,Grayson County,2021,139336,,62919,841
+Texas,Grayson County,2022,143131,,66106,1040
+Texas,Gregg County,2005,112357,,36264,455
+Texas,Gregg County,2006,117090,,39263,482
+Texas,Gregg County,2007,117119,,39660,509
+Texas,Gregg County,2008,117528,,46054,526
+Texas,Gregg County,2009,119637,,42634,547
+Texas,Gregg County,2010,121854,,40348,569
+Texas,Gregg County,2011,123081,,42572,607
+Texas,Gregg County,2012,122658,,42153,607
+Texas,Gregg County,2013,123024,,45461,621
+Texas,Gregg County,2014,123204,,50917,627
+Texas,Gregg County,2015,124108,,47727,647
+Texas,Gregg County,2016,123745,,44219,671
+Texas,Gregg County,2017,123367,,47095,702
+Texas,Gregg County,2018,123707,,51361,674
+Texas,Gregg County,2019,123945,,53793,708
+Texas,Gregg County,2021,124201,,59869,752
+Texas,Gregg County,2022,125443,,61496,872
+Texas,Guadalupe County,2005,101236,,49198,498
+Texas,Guadalupe County,2006,108410,,53285,563
+Texas,Guadalupe County,2007,112777,,52192,523
+Texas,Guadalupe County,2008,117172,,64737,639
+Texas,Guadalupe County,2009,121432,,58171,611
+Texas,Guadalupe County,2010,132431,,59801,609
+Texas,Guadalupe County,2011,135757,,57326,545
+Texas,Guadalupe County,2012,139841,,63608,761
+Texas,Guadalupe County,2013,143183,,58270,765
+Texas,Guadalupe County,2014,147250,,61538,738
+Texas,Guadalupe County,2015,151249,,64343,831
+Texas,Guadalupe County,2016,155265,,68157,902
 Texas,Guadalupe County,2017,159659,2845.0,66486,900
-Texas,Guadalupe County,2018,163694,0.0,74459,907
-Texas,Guadalupe County,2019,166847,0.0,79768,986
-Texas,Guadalupe County,2021,177036,0.0,80464,1018
-Texas,Guadalupe County,2022,182760,0.0,87030,1447
+Texas,Guadalupe County,2018,163694,,74459,907
+Texas,Guadalupe County,2019,166847,,79768,986
+Texas,Guadalupe County,2021,177036,,80464,1018
+Texas,Guadalupe County,2022,182760,,87030,1447
 Texas,Harris County,2005,3647656,45593.0,44002,581
 Texas,Harris County,2006,3886207,55081.0,47129,603
 Texas,Harris County,2007,3935855,57269.0,49936,620
@@ -11504,53 +11504,53 @@ Texas,Harris County,2018,4698619,97033.0,60232,915
 Texas,Harris County,2019,4713325,101249.0,61618,961
 Texas,Harris County,2021,4728030,328525.0,63498,1012
 Texas,Harris County,2022,4780913,285970.0,68706,1117
-Texas,Harrison County,2010,65766,0.0,47801,491
-Texas,Harrison County,2011,66296,0.0,44334,404
-Texas,Harrison County,2012,67450,0.0,43131,565
-Texas,Harrison County,2013,66886,0.0,39701,523
-Texas,Harrison County,2014,67336,0.0,49490,598
-Texas,Harrison County,2015,66746,0.0,42958,566
-Texas,Harrison County,2016,66534,0.0,46548,665
-Texas,Harrison County,2017,66661,0.0,53394,659
-Texas,Harrison County,2018,66726,0.0,50561,538
-Texas,Harrison County,2019,66553,0.0,58817,654
-Texas,Harrison County,2021,69150,0.0,59405,706
-Texas,Harrison County,2022,69955,0.0,69212,734
-Texas,Hays County,2005,115030,0.0,43207,624
+Texas,Harrison County,2010,65766,,47801,491
+Texas,Harrison County,2011,66296,,44334,404
+Texas,Harrison County,2012,67450,,43131,565
+Texas,Harrison County,2013,66886,,39701,523
+Texas,Harrison County,2014,67336,,49490,598
+Texas,Harrison County,2015,66746,,42958,566
+Texas,Harrison County,2016,66534,,46548,665
+Texas,Harrison County,2017,66661,,53394,659
+Texas,Harrison County,2018,66726,,50561,538
+Texas,Harrison County,2019,66553,,58817,654
+Texas,Harrison County,2021,69150,,59405,706
+Texas,Harrison County,2022,69955,,69212,734
+Texas,Hays County,2005,115030,,43207,624
 Texas,Hays County,2006,130325,3312.0,52703,547
 Texas,Hays County,2007,141480,5197.0,55026,643
-Texas,Hays County,2008,149476,0.0,56159,620
-Texas,Hays County,2009,155545,0.0,51959,675
-Texas,Hays County,2010,158312,0.0,57332,700
-Texas,Hays County,2011,164050,0.0,55160,754
+Texas,Hays County,2008,149476,,56159,620
+Texas,Hays County,2009,155545,,51959,675
+Texas,Hays County,2010,158312,,57332,700
+Texas,Hays County,2011,164050,,55160,754
 Texas,Hays County,2012,168990,4113.0,52615,765
 Texas,Hays County,2013,176026,4636.0,58987,819
 Texas,Hays County,2014,185025,5112.0,59085,807
 Texas,Hays County,2015,194739,4965.0,58870,873
 Texas,Hays County,2016,204470,8480.0,64658,952
-Texas,Hays County,2017,214485,0.0,65667,925
-Texas,Hays County,2018,222631,0.0,65943,1022
+Texas,Hays County,2017,214485,,65667,925
+Texas,Hays County,2018,222631,,65943,1022
 Texas,Hays County,2019,230191,10223.0,72058,1035
-Texas,Hays County,2021,255397,0.0,76842,1196
+Texas,Hays County,2021,255397,,76842,1196
 Texas,Hays County,2022,269225,27003.0,88617,1181
-Texas,Henderson County,2005,78744,0.0,32906,381
-Texas,Henderson County,2006,80222,0.0,34041,395
-Texas,Henderson County,2007,78897,0.0,39619,457
-Texas,Henderson County,2008,78814,0.0,42139,423
-Texas,Henderson County,2009,78921,0.0,42289,488
-Texas,Henderson County,2010,78647,0.0,36570,397
-Texas,Henderson County,2011,78826,0.0,38278,482
-Texas,Henderson County,2012,79094,0.0,37077,512
-Texas,Henderson County,2013,78675,0.0,38493,583
-Texas,Henderson County,2014,79290,0.0,41112,578
-Texas,Henderson County,2015,79545,0.0,47906,524
-Texas,Henderson County,2016,79901,0.0,44088,544
-Texas,Henderson County,2017,81064,0.0,44971,611
-Texas,Henderson County,2018,82299,0.0,42020,556
-Texas,Henderson County,2019,82737,0.0,51521,631
-Texas,Henderson County,2021,83667,0.0,49830,642
-Texas,Henderson County,2022,84511,0.0,65283,878
-Texas,Hidalgo County,2005,671967,0.0,24501,392
+Texas,Henderson County,2005,78744,,32906,381
+Texas,Henderson County,2006,80222,,34041,395
+Texas,Henderson County,2007,78897,,39619,457
+Texas,Henderson County,2008,78814,,42139,423
+Texas,Henderson County,2009,78921,,42289,488
+Texas,Henderson County,2010,78647,,36570,397
+Texas,Henderson County,2011,78826,,38278,482
+Texas,Henderson County,2012,79094,,37077,512
+Texas,Henderson County,2013,78675,,38493,583
+Texas,Henderson County,2014,79290,,41112,578
+Texas,Henderson County,2015,79545,,47906,524
+Texas,Henderson County,2016,79901,,44088,544
+Texas,Henderson County,2017,81064,,44971,611
+Texas,Henderson County,2018,82299,,42020,556
+Texas,Henderson County,2019,82737,,51521,631
+Texas,Henderson County,2021,83667,,49830,642
+Texas,Henderson County,2022,84511,,65283,878
+Texas,Hidalgo County,2005,671967,,24501,392
 Texas,Hidalgo County,2006,700634,9579.0,28660,387
 Texas,Hidalgo County,2007,710514,8342.0,30295,421
 Texas,Hidalgo County,2008,726604,7285.0,30235,461
@@ -11567,25 +11567,25 @@ Texas,Hidalgo County,2018,865939,21150.0,39165,557
 Texas,Hidalgo County,2019,868707,20730.0,41800,604
 Texas,Hidalgo County,2021,880356,32049.0,44818,672
 Texas,Hidalgo County,2022,888367,31963.0,49142,705
-Texas,Hood County,2022,66373,0.0,69462,1221
-Texas,Hunt County,2005,80052,0.0,42129,482
-Texas,Hunt County,2006,83338,0.0,36461,478
-Texas,Hunt County,2007,82945,0.0,43163,501
-Texas,Hunt County,2008,82805,0.0,46189,456
-Texas,Hunt County,2009,82831,0.0,41267,565
-Texas,Hunt County,2010,86353,0.0,40218,563
-Texas,Hunt County,2011,86531,0.0,50272,564
-Texas,Hunt County,2012,87079,0.0,42376,520
-Texas,Hunt County,2013,87048,0.0,44303,645
-Texas,Hunt County,2014,88493,0.0,42038,543
-Texas,Hunt County,2015,89844,0.0,46048,609
+Texas,Hood County,2022,66373,,69462,1221
+Texas,Hunt County,2005,80052,,42129,482
+Texas,Hunt County,2006,83338,,36461,478
+Texas,Hunt County,2007,82945,,43163,501
+Texas,Hunt County,2008,82805,,46189,456
+Texas,Hunt County,2009,82831,,41267,565
+Texas,Hunt County,2010,86353,,40218,563
+Texas,Hunt County,2011,86531,,50272,564
+Texas,Hunt County,2012,87079,,42376,520
+Texas,Hunt County,2013,87048,,44303,645
+Texas,Hunt County,2014,88493,,42038,543
+Texas,Hunt County,2015,89844,,46048,609
 Texas,Hunt County,2016,92073,2116.0,53962,679
-Texas,Hunt County,2017,93872,0.0,55786,697
-Texas,Hunt County,2018,96493,0.0,55248,736
-Texas,Hunt County,2019,98594,0.0,58063,739
-Texas,Hunt County,2021,103394,0.0,56761,833
-Texas,Hunt County,2022,108282,0.0,69253,1023
-Texas,Jefferson County,2005,231311,0.0,35953,425
+Texas,Hunt County,2017,93872,,55786,697
+Texas,Hunt County,2018,96493,,55248,736
+Texas,Hunt County,2019,98594,,58063,739
+Texas,Hunt County,2021,103394,,56761,833
+Texas,Hunt County,2022,108282,,69253,1023
+Texas,Jefferson County,2005,231311,,35953,425
 Texas,Jefferson County,2006,243914,853.0,38584,439
 Texas,Jefferson County,2007,241975,1865.0,39182,517
 Texas,Jefferson County,2008,243090,1420.0,44984,532
@@ -11595,65 +11595,65 @@ Texas,Jefferson County,2011,252802,2276.0,41256,590
 Texas,Jefferson County,2012,251813,1259.0,40795,552
 Texas,Jefferson County,2013,252358,1468.0,41838,593
 Texas,Jefferson County,2014,252235,1732.0,40652,597
-Texas,Jefferson County,2015,254308,0.0,48005,660
+Texas,Jefferson County,2015,254308,,48005,660
 Texas,Jefferson County,2016,254679,1051.0,45390,661
 Texas,Jefferson County,2017,256299,2794.0,47657,705
 Texas,Jefferson County,2018,255001,2085.0,47177,700
 Texas,Jefferson County,2019,251565,2420.0,55797,737
-Texas,Jefferson County,2021,253704,0.0,56904,780
-Texas,Jefferson County,2022,250830,0.0,54797,823
-Texas,Johnson County,2005,143757,0.0,42854,499
-Texas,Johnson County,2006,149016,0.0,50864,521
-Texas,Johnson County,2007,149797,0.0,53289,597
-Texas,Johnson County,2008,153630,0.0,53244,608
-Texas,Johnson County,2009,156997,0.0,56579,604
-Texas,Johnson County,2010,151211,0.0,52275,658
-Texas,Johnson County,2011,152734,0.0,54664,551
-Texas,Johnson County,2012,153441,0.0,57569,711
-Texas,Johnson County,2013,154707,0.0,56253,696
-Texas,Johnson County,2014,157456,0.0,55739,664
-Texas,Johnson County,2015,159990,0.0,58758,744
-Texas,Johnson County,2016,163274,0.0,59895,738
-Texas,Johnson County,2017,167301,0.0,62482,747
-Texas,Johnson County,2018,171361,0.0,62390,821
-Texas,Johnson County,2019,175817,0.0,66319,890
-Texas,Johnson County,2021,187280,0.0,77933,962
-Texas,Johnson County,2022,195506,0.0,76320,1042
-Texas,Kaufman County,2005,87655,0.0,51254,494
-Texas,Kaufman County,2006,93241,0.0,53182,522
-Texas,Kaufman County,2007,96373,0.0,54125,646
-Texas,Kaufman County,2008,100527,0.0,59317,619
-Texas,Kaufman County,2009,103038,0.0,55474,662
-Texas,Kaufman County,2010,103927,0.0,57790,637
-Texas,Kaufman County,2011,105358,0.0,61537,637
-Texas,Kaufman County,2012,106753,0.0,54224,677
-Texas,Kaufman County,2013,108568,0.0,65258,666
-Texas,Kaufman County,2014,111236,0.0,56098,639
-Texas,Kaufman County,2015,114690,0.0,58141,731
-Texas,Kaufman County,2016,118350,0.0,62033,803
-Texas,Kaufman County,2017,122883,0.0,65841,771
-Texas,Kaufman County,2018,128622,0.0,66668,747
-Texas,Kaufman County,2019,136154,0.0,75775,905
-Texas,Kaufman County,2021,157768,0.0,72175,1113
-Texas,Kaufman County,2022,172366,0.0,94868,1307
-Texas,Liberty County,2005,70116,0.0,32201,468
-Texas,Liberty County,2006,75685,0.0,39310,465
-Texas,Liberty County,2007,75434,0.0,46391,442
-Texas,Liberty County,2008,75333,0.0,51358,444
-Texas,Liberty County,2009,75779,0.0,43138,553
-Texas,Liberty County,2010,75868,0.0,48608,535
-Texas,Liberty County,2011,76206,0.0,45371,495
-Texas,Liberty County,2012,76571,0.0,50006,494
-Texas,Liberty County,2013,76907,0.0,41711,550
-Texas,Liberty County,2014,78117,0.0,44188,522
-Texas,Liberty County,2015,79654,0.0,55152,594
-Texas,Liberty County,2016,81704,0.0,42877,599
-Texas,Liberty County,2017,83658,0.0,45614,539
-Texas,Liberty County,2018,86323,0.0,51955,643
-Texas,Liberty County,2019,88219,0.0,50049,601
-Texas,Liberty County,2021,97621,0.0,55697,673
-Texas,Liberty County,2022,101992,0.0,61525,733
-Texas,Lubbock County,2005,241947,0.0,35189,536
+Texas,Jefferson County,2021,253704,,56904,780
+Texas,Jefferson County,2022,250830,,54797,823
+Texas,Johnson County,2005,143757,,42854,499
+Texas,Johnson County,2006,149016,,50864,521
+Texas,Johnson County,2007,149797,,53289,597
+Texas,Johnson County,2008,153630,,53244,608
+Texas,Johnson County,2009,156997,,56579,604
+Texas,Johnson County,2010,151211,,52275,658
+Texas,Johnson County,2011,152734,,54664,551
+Texas,Johnson County,2012,153441,,57569,711
+Texas,Johnson County,2013,154707,,56253,696
+Texas,Johnson County,2014,157456,,55739,664
+Texas,Johnson County,2015,159990,,58758,744
+Texas,Johnson County,2016,163274,,59895,738
+Texas,Johnson County,2017,167301,,62482,747
+Texas,Johnson County,2018,171361,,62390,821
+Texas,Johnson County,2019,175817,,66319,890
+Texas,Johnson County,2021,187280,,77933,962
+Texas,Johnson County,2022,195506,,76320,1042
+Texas,Kaufman County,2005,87655,,51254,494
+Texas,Kaufman County,2006,93241,,53182,522
+Texas,Kaufman County,2007,96373,,54125,646
+Texas,Kaufman County,2008,100527,,59317,619
+Texas,Kaufman County,2009,103038,,55474,662
+Texas,Kaufman County,2010,103927,,57790,637
+Texas,Kaufman County,2011,105358,,61537,637
+Texas,Kaufman County,2012,106753,,54224,677
+Texas,Kaufman County,2013,108568,,65258,666
+Texas,Kaufman County,2014,111236,,56098,639
+Texas,Kaufman County,2015,114690,,58141,731
+Texas,Kaufman County,2016,118350,,62033,803
+Texas,Kaufman County,2017,122883,,65841,771
+Texas,Kaufman County,2018,128622,,66668,747
+Texas,Kaufman County,2019,136154,,75775,905
+Texas,Kaufman County,2021,157768,,72175,1113
+Texas,Kaufman County,2022,172366,,94868,1307
+Texas,Liberty County,2005,70116,,32201,468
+Texas,Liberty County,2006,75685,,39310,465
+Texas,Liberty County,2007,75434,,46391,442
+Texas,Liberty County,2008,75333,,51358,444
+Texas,Liberty County,2009,75779,,43138,553
+Texas,Liberty County,2010,75868,,48608,535
+Texas,Liberty County,2011,76206,,45371,495
+Texas,Liberty County,2012,76571,,50006,494
+Texas,Liberty County,2013,76907,,41711,550
+Texas,Liberty County,2014,78117,,44188,522
+Texas,Liberty County,2015,79654,,55152,594
+Texas,Liberty County,2016,81704,,42877,599
+Texas,Liberty County,2017,83658,,45614,539
+Texas,Liberty County,2018,86323,,51955,643
+Texas,Liberty County,2019,88219,,50049,601
+Texas,Liberty County,2021,97621,,55697,673
+Texas,Liberty County,2022,101992,,61525,733
+Texas,Lubbock County,2005,241947,,35189,536
 Texas,Lubbock County,2006,254862,4304.0,37863,521
 Texas,Lubbock County,2007,260901,3394.0,41627,578
 Texas,Lubbock County,2008,264418,4527.0,45184,589
@@ -11670,7 +11670,7 @@ Texas,Lubbock County,2018,307412,5981.0,50505,733
 Texas,Lubbock County,2019,310569,5798.0,55003,777
 Texas,Lubbock County,2021,314451,11318.0,57798,825
 Texas,Lubbock County,2022,317561,9687.0,59161,879
-Texas,McLennan County,2005,214582,0.0,36135,469
+Texas,McLennan County,2005,214582,,36135,469
 Texas,McLennan County,2006,226189,1905.0,36442,479
 Texas,McLennan County,2007,228123,3264.0,40511,527
 Texas,McLennan County,2008,230213,2986.0,39700,545
@@ -11680,30 +11680,30 @@ Texas,McLennan County,2011,238564,3492.0,40484,561
 Texas,McLennan County,2012,238707,2136.0,40658,586
 Texas,McLennan County,2013,241481,2740.0,40633,577
 Texas,McLennan County,2014,243441,4374.0,43609,605
-Texas,McLennan County,2015,245671,0.0,46602,656
+Texas,McLennan County,2015,245671,,46602,656
 Texas,McLennan County,2016,247934,4156.0,46860,655
 Texas,McLennan County,2017,251259,4163.0,47267,694
 Texas,McLennan County,2018,254607,3884.0,48713,696
 Texas,McLennan County,2019,256623,4004.0,50845,726
 Texas,McLennan County,2021,263115,13888.0,60437,848
 Texas,McLennan County,2022,266836,13375.0,64320,931
-Texas,Midland County,2005,119720,0.0,41455,415
-Texas,Midland County,2006,124380,0.0,45437,450
-Texas,Midland County,2007,126408,0.0,51197,522
-Texas,Midland County,2008,129494,0.0,57558,612
-Texas,Midland County,2009,132316,0.0,55021,664
-Texas,Midland County,2010,136975,0.0,53170,660
-Texas,Midland County,2011,140308,0.0,54330,734
-Texas,Midland County,2012,146645,0.0,61331,779
-Texas,Midland County,2013,151468,0.0,72050,924
-Texas,Midland County,2014,155830,0.0,77711,1087
-Texas,Midland County,2015,161077,0.0,81064,1062
-Texas,Midland County,2016,162565,0.0,65349,932
-Texas,Midland County,2017,165049,0.0,75590,958
-Texas,Midland County,2018,172578,0.0,81210,1129
-Texas,Midland County,2019,176832,0.0,82558,1222
-Texas,Midland County,2021,167969,0.0,82248,904
-Texas,Midland County,2022,171999,0.0,76332,1128
+Texas,Midland County,2005,119720,,41455,415
+Texas,Midland County,2006,124380,,45437,450
+Texas,Midland County,2007,126408,,51197,522
+Texas,Midland County,2008,129494,,57558,612
+Texas,Midland County,2009,132316,,55021,664
+Texas,Midland County,2010,136975,,53170,660
+Texas,Midland County,2011,140308,,54330,734
+Texas,Midland County,2012,146645,,61331,779
+Texas,Midland County,2013,151468,,72050,924
+Texas,Midland County,2014,155830,,77711,1087
+Texas,Midland County,2015,161077,,81064,1062
+Texas,Midland County,2016,162565,,65349,932
+Texas,Midland County,2017,165049,,75590,958
+Texas,Midland County,2018,172578,,81210,1129
+Texas,Midland County,2019,176832,,82558,1222
+Texas,Midland County,2021,167969,,82248,904
+Texas,Midland County,2022,171999,,76332,1128
 Texas,Montgomery County,2005,376051,7593.0,59623,651
 Texas,Montgomery County,2006,398290,9109.0,60224,632
 Texas,Montgomery County,2007,412638,8770.0,63380,696
@@ -11738,108 +11738,108 @@ Texas,Nueces County,2018,362265,4905.0,54560,829
 Texas,Nueces County,2019,362294,7117.0,56789,870
 Texas,Nueces County,2021,353079,9070.0,59983,926
 Texas,Nueces County,2022,351674,7606.0,60361,961
-Texas,Orange County,2005,83996,0.0,37174,369
-Texas,Orange County,2006,84243,0.0,42210,407
-Texas,Orange County,2007,82669,0.0,48590,435
-Texas,Orange County,2008,83022,0.0,50346,421
-Texas,Orange County,2009,81816,0.0,44803,533
-Texas,Orange County,2010,81930,0.0,44763,554
-Texas,Orange County,2011,82487,0.0,42398,569
-Texas,Orange County,2012,82977,0.0,50574,534
-Texas,Orange County,2013,82957,0.0,52728,553
-Texas,Orange County,2014,83433,0.0,46809,659
-Texas,Orange County,2015,84260,0.0,50429,598
-Texas,Orange County,2016,84964,0.0,53480,646
-Texas,Orange County,2017,85047,0.0,58863,563
-Texas,Orange County,2018,83572,0.0,56420,698
-Texas,Orange County,2019,83396,0.0,69052,711
-Texas,Orange County,2021,84742,0.0,71022,842
-Texas,Orange County,2022,84934,0.0,64601,781
-Texas,Parker County,2005,99846,0.0,54300,511
-Texas,Parker County,2006,106266,0.0,54177,469
-Texas,Parker County,2007,108687,0.0,61433,532
-Texas,Parker County,2008,111776,0.0,61455,608
-Texas,Parker County,2009,114919,0.0,63772,592
-Texas,Parker County,2010,117283,0.0,54712,649
-Texas,Parker County,2011,118376,0.0,69706,649
-Texas,Parker County,2012,119712,0.0,64556,622
-Texas,Parker County,2013,121418,0.0,60454,686
-Texas,Parker County,2014,123164,0.0,68882,683
-Texas,Parker County,2015,126042,0.0,67012,760
-Texas,Parker County,2016,129441,0.0,66548,707
-Texas,Parker County,2017,133463,0.0,75823,852
-Texas,Parker County,2018,138371,0.0,72004,852
-Texas,Parker County,2019,142878,0.0,83262,844
-Texas,Parker County,2021,156764,0.0,85641,985
-Texas,Parker County,2022,165834,0.0,96017,1235
-Texas,Potter County,2005,111882,0.0,29880,433
-Texas,Potter County,2006,121328,0.0,32582,465
-Texas,Potter County,2007,120775,0.0,31788,468
-Texas,Potter County,2008,120918,0.0,37147,504
+Texas,Orange County,2005,83996,,37174,369
+Texas,Orange County,2006,84243,,42210,407
+Texas,Orange County,2007,82669,,48590,435
+Texas,Orange County,2008,83022,,50346,421
+Texas,Orange County,2009,81816,,44803,533
+Texas,Orange County,2010,81930,,44763,554
+Texas,Orange County,2011,82487,,42398,569
+Texas,Orange County,2012,82977,,50574,534
+Texas,Orange County,2013,82957,,52728,553
+Texas,Orange County,2014,83433,,46809,659
+Texas,Orange County,2015,84260,,50429,598
+Texas,Orange County,2016,84964,,53480,646
+Texas,Orange County,2017,85047,,58863,563
+Texas,Orange County,2018,83572,,56420,698
+Texas,Orange County,2019,83396,,69052,711
+Texas,Orange County,2021,84742,,71022,842
+Texas,Orange County,2022,84934,,64601,781
+Texas,Parker County,2005,99846,,54300,511
+Texas,Parker County,2006,106266,,54177,469
+Texas,Parker County,2007,108687,,61433,532
+Texas,Parker County,2008,111776,,61455,608
+Texas,Parker County,2009,114919,,63772,592
+Texas,Parker County,2010,117283,,54712,649
+Texas,Parker County,2011,118376,,69706,649
+Texas,Parker County,2012,119712,,64556,622
+Texas,Parker County,2013,121418,,60454,686
+Texas,Parker County,2014,123164,,68882,683
+Texas,Parker County,2015,126042,,67012,760
+Texas,Parker County,2016,129441,,66548,707
+Texas,Parker County,2017,133463,,75823,852
+Texas,Parker County,2018,138371,,72004,852
+Texas,Parker County,2019,142878,,83262,844
+Texas,Parker County,2021,156764,,85641,985
+Texas,Parker County,2022,165834,,96017,1235
+Texas,Potter County,2005,111882,,29880,433
+Texas,Potter County,2006,121328,,32582,465
+Texas,Potter County,2007,120775,,31788,468
+Texas,Potter County,2008,120918,,37147,504
 Texas,Potter County,2009,121816,655.0,36262,513
-Texas,Potter County,2010,121446,0.0,35003,499
+Texas,Potter County,2010,121446,,35003,499
 Texas,Potter County,2011,122285,2337.0,35956,571
 Texas,Potter County,2012,122335,1546.0,35426,552
 Texas,Potter County,2013,121661,954.0,37823,559
 Texas,Potter County,2014,121627,1065.0,38324,593
-Texas,Potter County,2015,121802,0.0,40536,601
-Texas,Potter County,2016,120832,0.0,42305,608
-Texas,Potter County,2017,120458,0.0,45312,661
-Texas,Potter County,2018,119648,0.0,40797,663
-Texas,Potter County,2019,117415,0.0,37297,662
-Texas,Potter County,2021,116547,0.0,44721,689
-Texas,Potter County,2022,115645,0.0,50661,798
-Texas,Randall County,2005,108383,0.0,46569,519
-Texas,Randall County,2006,111472,0.0,51769,557
-Texas,Randall County,2007,113036,0.0,52985,530
-Texas,Randall County,2008,114546,0.0,57419,594
+Texas,Potter County,2015,121802,,40536,601
+Texas,Potter County,2016,120832,,42305,608
+Texas,Potter County,2017,120458,,45312,661
+Texas,Potter County,2018,119648,,40797,663
+Texas,Potter County,2019,117415,,37297,662
+Texas,Potter County,2021,116547,,44721,689
+Texas,Potter County,2022,115645,,50661,798
+Texas,Randall County,2005,108383,,46569,519
+Texas,Randall County,2006,111472,,51769,557
+Texas,Randall County,2007,113036,,52985,530
+Texas,Randall County,2008,114546,,57419,594
 Texas,Randall County,2009,116483,1862.0,53219,585
-Texas,Randall County,2010,121208,0.0,58096,587
-Texas,Randall County,2011,123351,0.0,57183,580
-Texas,Randall County,2012,125082,0.0,55833,663
-Texas,Randall County,2013,126474,0.0,60801,696
+Texas,Randall County,2010,121208,,58096,587
+Texas,Randall County,2011,123351,,57183,580
+Texas,Randall County,2012,125082,,55833,663
+Texas,Randall County,2013,126474,,60801,696
 Texas,Randall County,2014,128220,1656.0,65749,694
-Texas,Randall County,2015,130269,0.0,61984,717
+Texas,Randall County,2015,130269,,61984,717
 Texas,Randall County,2016,132501,2281.0,67015,742
-Texas,Randall County,2017,134442,0.0,62098,750
-Texas,Randall County,2018,136271,0.0,70108,773
-Texas,Randall County,2019,137713,0.0,70651,806
-Texas,Randall County,2021,143854,0.0,70322,832
-Texas,Randall County,2022,146140,0.0,76744,848
-Texas,Rockwall County,2006,69155,0.0,71224,798
-Texas,Rockwall County,2007,73810,0.0,77861,865
-Texas,Rockwall County,2008,77633,0.0,77184,897
-Texas,Rockwall County,2009,81391,0.0,75340,994
-Texas,Rockwall County,2010,79003,0.0,80209,866
-Texas,Rockwall County,2011,81290,0.0,82061,1015
-Texas,Rockwall County,2012,83021,0.0,82399,982
-Texas,Rockwall County,2013,85245,0.0,93054,1000
-Texas,Rockwall County,2014,87809,0.0,80407,1080
-Texas,Rockwall County,2015,90861,0.0,90940,1072
-Texas,Rockwall County,2016,93978,0.0,95731,1108
-Texas,Rockwall County,2017,96788,0.0,94848,1205
-Texas,Rockwall County,2018,100657,0.0,100595,1574
-Texas,Rockwall County,2019,104915,0.0,103378,1211
-Texas,Rockwall County,2021,116381,0.0,121568,1125
-Texas,Rockwall County,2022,123208,0.0,123767,1763
-Texas,San Patricio County,2005,68077,0.0,37491,514
-Texas,San Patricio County,2006,69522,0.0,39308,489
-Texas,San Patricio County,2007,68520,0.0,37814,492
-Texas,San Patricio County,2008,68399,0.0,47285,545
-Texas,San Patricio County,2009,68223,0.0,47838,538
-Texas,San Patricio County,2010,64586,0.0,45940,629
-Texas,San Patricio County,2011,64726,0.0,50168,620
-Texas,San Patricio County,2012,65600,0.0,50546,635
-Texas,San Patricio County,2013,66137,0.0,46425,632
-Texas,San Patricio County,2014,66915,0.0,53877,636
-Texas,San Patricio County,2015,67357,0.0,54966,714
-Texas,San Patricio County,2016,67655,0.0,53348,622
-Texas,San Patricio County,2017,67215,0.0,51012,666
-Texas,San Patricio County,2018,66893,0.0,55018,790
-Texas,San Patricio County,2019,66730,0.0,57899,889
-Texas,San Patricio County,2021,69699,0.0,59276,937
-Texas,San Patricio County,2022,69954,0.0,64741,986
-Texas,Smith County,2005,185465,0.0,37964,506
+Texas,Randall County,2017,134442,,62098,750
+Texas,Randall County,2018,136271,,70108,773
+Texas,Randall County,2019,137713,,70651,806
+Texas,Randall County,2021,143854,,70322,832
+Texas,Randall County,2022,146140,,76744,848
+Texas,Rockwall County,2006,69155,,71224,798
+Texas,Rockwall County,2007,73810,,77861,865
+Texas,Rockwall County,2008,77633,,77184,897
+Texas,Rockwall County,2009,81391,,75340,994
+Texas,Rockwall County,2010,79003,,80209,866
+Texas,Rockwall County,2011,81290,,82061,1015
+Texas,Rockwall County,2012,83021,,82399,982
+Texas,Rockwall County,2013,85245,,93054,1000
+Texas,Rockwall County,2014,87809,,80407,1080
+Texas,Rockwall County,2015,90861,,90940,1072
+Texas,Rockwall County,2016,93978,,95731,1108
+Texas,Rockwall County,2017,96788,,94848,1205
+Texas,Rockwall County,2018,100657,,100595,1574
+Texas,Rockwall County,2019,104915,,103378,1211
+Texas,Rockwall County,2021,116381,,121568,1125
+Texas,Rockwall County,2022,123208,,123767,1763
+Texas,San Patricio County,2005,68077,,37491,514
+Texas,San Patricio County,2006,69522,,39308,489
+Texas,San Patricio County,2007,68520,,37814,492
+Texas,San Patricio County,2008,68399,,47285,545
+Texas,San Patricio County,2009,68223,,47838,538
+Texas,San Patricio County,2010,64586,,45940,629
+Texas,San Patricio County,2011,64726,,50168,620
+Texas,San Patricio County,2012,65600,,50546,635
+Texas,San Patricio County,2013,66137,,46425,632
+Texas,San Patricio County,2014,66915,,53877,636
+Texas,San Patricio County,2015,67357,,54966,714
+Texas,San Patricio County,2016,67655,,53348,622
+Texas,San Patricio County,2017,67215,,51012,666
+Texas,San Patricio County,2018,66893,,55018,790
+Texas,San Patricio County,2019,66730,,57899,889
+Texas,San Patricio County,2021,69699,,59276,937
+Texas,San Patricio County,2022,69954,,64741,986
+Texas,Smith County,2005,185465,,37964,506
 Texas,Smith County,2006,194635,2982.0,41090,521
 Texas,Smith County,2007,198705,4016.0,44611,542
 Texas,Smith County,2008,201277,7443.0,47159,608
@@ -11850,14 +11850,14 @@ Texas,Smith County,2012,214821,4114.0,46286,640
 Texas,Smith County,2013,216080,2866.0,47745,680
 Texas,Smith County,2014,218842,2268.0,43958,668
 Texas,Smith County,2015,222936,2575.0,49060,711
-Texas,Smith County,2016,225290,0.0,52572,725
+Texas,Smith County,2016,225290,,52572,725
 Texas,Smith County,2017,227727,3862.0,54339,724
 Texas,Smith County,2018,230221,5164.0,58226,785
 Texas,Smith County,2019,232751,7208.0,59584,823
-Texas,Smith County,2021,237186,0.0,63115,839
-Texas,Smith County,2022,241922,0.0,68192,926
-Texas,Starr County,2021,66049,0.0,33367,464
-Texas,Starr County,2022,65728,0.0,33871,516
+Texas,Smith County,2021,237186,,63115,839
+Texas,Smith County,2022,241922,,68192,926
+Texas,Starr County,2021,66049,,33367,464
+Texas,Starr County,2022,65728,,33871,516
 Texas,Tarrant County,2005,1595715,23639.0,49104,580
 Texas,Tarrant County,2006,1671295,29641.0,51813,599
 Texas,Tarrant County,2007,1717435,34260.0,53459,622
@@ -11875,39 +11875,39 @@ Texas,Tarrant County,2018,2084931,50799.0,66063,942
 Texas,Tarrant County,2019,2102515,60047.0,70139,978
 Texas,Tarrant County,2021,2126477,175645.0,71346,1105
 Texas,Tarrant County,2022,2154595,171820.0,76210,1211
-Texas,Taylor County,2005,118744,0.0,35191,444
-Texas,Taylor County,2006,124927,0.0,39825,475
-Texas,Taylor County,2007,126540,0.0,39706,478
-Texas,Taylor County,2008,126791,0.0,41235,524
-Texas,Taylor County,2009,127683,0.0,43672,539
+Texas,Taylor County,2005,118744,,35191,444
+Texas,Taylor County,2006,124927,,39825,475
+Texas,Taylor County,2007,126540,,39706,478
+Texas,Taylor County,2008,126791,,41235,524
+Texas,Taylor County,2009,127683,,43672,539
 Texas,Taylor County,2010,131896,2334.0,41704,571
-Texas,Taylor County,2011,132755,0.0,40123,528
+Texas,Taylor County,2011,132755,,40123,528
 Texas,Taylor County,2012,133473,1405.0,43855,589
 Texas,Taylor County,2013,134117,1316.0,44447,560
 Texas,Taylor County,2014,135143,2932.0,45907,624
-Texas,Taylor County,2015,136051,0.0,48636,611
-Texas,Taylor County,2016,136535,0.0,48803,681
-Texas,Taylor County,2017,136290,0.0,51894,683
-Texas,Taylor County,2018,137640,0.0,47508,732
-Texas,Taylor County,2019,138034,0.0,55351,714
-Texas,Taylor County,2021,143326,0.0,53315,786
-Texas,Taylor County,2022,145163,0.0,62107,903
-Texas,Tom Green County,2005,99178,0.0,38058,448
-Texas,Tom Green County,2006,103938,0.0,35187,478
+Texas,Taylor County,2015,136051,,48636,611
+Texas,Taylor County,2016,136535,,48803,681
+Texas,Taylor County,2017,136290,,51894,683
+Texas,Taylor County,2018,137640,,47508,732
+Texas,Taylor County,2019,138034,,55351,714
+Texas,Taylor County,2021,143326,,53315,786
+Texas,Taylor County,2022,145163,,62107,903
+Texas,Tom Green County,2005,99178,,38058,448
+Texas,Tom Green County,2006,103938,,35187,478
 Texas,Tom Green County,2007,106342,1599.0,40938,519
-Texas,Tom Green County,2008,107864,0.0,43534,514
-Texas,Tom Green County,2009,108378,0.0,40782,565
-Texas,Tom Green County,2010,110679,0.0,38043,525
-Texas,Tom Green County,2011,111823,0.0,43107,567
-Texas,Tom Green County,2012,113281,0.0,44651,548
-Texas,Tom Green County,2013,114954,0.0,45968,630
-Texas,Tom Green County,2014,116608,0.0,44959,637
-Texas,Tom Green County,2015,118105,0.0,48114,688
-Texas,Tom Green County,2016,118386,0.0,48696,687
-Texas,Tom Green County,2017,118019,0.0,51114,698
-Texas,Tom Green County,2018,118189,0.0,52283,731
-Texas,Tom Green County,2019,119200,0.0,55988,801
-Texas,Tom Green County,2021,119411,0.0,61649,795
+Texas,Tom Green County,2008,107864,,43534,514
+Texas,Tom Green County,2009,108378,,40782,565
+Texas,Tom Green County,2010,110679,,38043,525
+Texas,Tom Green County,2011,111823,,43107,567
+Texas,Tom Green County,2012,113281,,44651,548
+Texas,Tom Green County,2013,114954,,45968,630
+Texas,Tom Green County,2014,116608,,44959,637
+Texas,Tom Green County,2015,118105,,48114,688
+Texas,Tom Green County,2016,118386,,48696,687
+Texas,Tom Green County,2017,118019,,51114,698
+Texas,Tom Green County,2018,118189,,52283,731
+Texas,Tom Green County,2019,119200,,55988,801
+Texas,Tom Green County,2021,119411,,61649,795
 Texas,Tom Green County,2022,118892,4523.0,59853,926
 Texas,Travis County,2005,866349,23835.0,48026,634
 Texas,Travis County,2006,921006,26132.0,50777,677
@@ -11926,42 +11926,42 @@ Texas,Travis County,2018,1248743,67095.0,76392,1162
 Texas,Travis County,2019,1273954,80000.0,80726,1199
 Texas,Travis County,2021,1305154,264606.0,84531,1321
 Texas,Travis County,2022,1326436,240875.0,95259,1468
-Texas,Victoria County,2005,84044,0.0,35740,461
+Texas,Victoria County,2005,84044,,35740,461
 Texas,Victoria County,2006,86191,855.0,45542,476
-Texas,Victoria County,2007,86291,0.0,45542,436
-Texas,Victoria County,2008,86755,0.0,45612,525
-Texas,Victoria County,2009,87790,0.0,48247,514
-Texas,Victoria County,2010,86878,0.0,48341,515
-Texas,Victoria County,2011,87545,0.0,45465,594
-Texas,Victoria County,2012,89269,0.0,50076,578
-Texas,Victoria County,2013,90028,0.0,52304,646
-Texas,Victoria County,2014,91081,0.0,50245,656
-Texas,Victoria County,2015,92382,0.0,56545,657
-Texas,Victoria County,2016,92467,0.0,53778,702
-Texas,Victoria County,2017,92084,0.0,51892,741
-Texas,Victoria County,2018,92035,0.0,50210,730
-Texas,Victoria County,2019,92084,0.0,57358,789
-Texas,Victoria County,2021,90964,0.0,54596,820
-Texas,Victoria County,2022,91065,0.0,71192,951
-Texas,Walker County,2010,68185,0.0,35806,568
-Texas,Walker County,2011,68087,0.0,38869,590
-Texas,Walker County,2012,68408,0.0,36382,604
-Texas,Walker County,2013,68817,0.0,38369,595
-Texas,Walker County,2014,69789,0.0,38483,641
-Texas,Walker County,2015,70699,0.0,40448,665
-Texas,Walker County,2016,71484,0.0,42662,752
-Texas,Walker County,2017,72245,0.0,40936,721
-Texas,Walker County,2018,72480,0.0,40100,776
-Texas,Walker County,2019,72971,0.0,47170,765
-Texas,Walker County,2021,77977,0.0,41470,741
-Texas,Walker County,2022,78870,0.0,51528,733
-Texas,Webb County,2005,221478,0.0,31763,439
+Texas,Victoria County,2007,86291,,45542,436
+Texas,Victoria County,2008,86755,,45612,525
+Texas,Victoria County,2009,87790,,48247,514
+Texas,Victoria County,2010,86878,,48341,515
+Texas,Victoria County,2011,87545,,45465,594
+Texas,Victoria County,2012,89269,,50076,578
+Texas,Victoria County,2013,90028,,52304,646
+Texas,Victoria County,2014,91081,,50245,656
+Texas,Victoria County,2015,92382,,56545,657
+Texas,Victoria County,2016,92467,,53778,702
+Texas,Victoria County,2017,92084,,51892,741
+Texas,Victoria County,2018,92035,,50210,730
+Texas,Victoria County,2019,92084,,57358,789
+Texas,Victoria County,2021,90964,,54596,820
+Texas,Victoria County,2022,91065,,71192,951
+Texas,Walker County,2010,68185,,35806,568
+Texas,Walker County,2011,68087,,38869,590
+Texas,Walker County,2012,68408,,36382,604
+Texas,Walker County,2013,68817,,38369,595
+Texas,Walker County,2014,69789,,38483,641
+Texas,Walker County,2015,70699,,40448,665
+Texas,Walker County,2016,71484,,42662,752
+Texas,Walker County,2017,72245,,40936,721
+Texas,Walker County,2018,72480,,40100,776
+Texas,Walker County,2019,72971,,47170,765
+Texas,Walker County,2021,77977,,41470,741
+Texas,Walker County,2022,78870,,51528,733
+Texas,Webb County,2005,221478,,31763,439
 Texas,Webb County,2006,231470,2268.0,33026,447
 Texas,Webb County,2007,233152,4823.0,33905,467
 Texas,Webb County,2008,236941,1277.0,36740,498
 Texas,Webb County,2009,241438,2356.0,38291,550
 Texas,Webb County,2010,251632,4065.0,35770,525
-Texas,Webb County,2011,256496,0.0,36132,563
+Texas,Webb County,2011,256496,,36132,563
 Texas,Webb County,2012,259172,3126.0,36624,531
 Texas,Webb County,2013,262495,2620.0,39991,574
 Texas,Webb County,2014,266673,2371.0,38312,586
@@ -11972,24 +11972,24 @@ Texas,Webb County,2018,275910,3853.0,46862,668
 Texas,Webb County,2019,276652,3996.0,56084,669
 Texas,Webb County,2021,267945,6086.0,51867,696
 Texas,Webb County,2022,267780,8166.0,59603,787
-Texas,Wichita County,2005,114651,0.0,39093,466
-Texas,Wichita County,2006,125158,0.0,35754,465
-Texas,Wichita County,2007,128025,0.0,39011,501
+Texas,Wichita County,2005,114651,,39093,466
+Texas,Wichita County,2006,125158,,35754,465
+Texas,Wichita County,2007,128025,,39011,501
 Texas,Wichita County,2008,127321,2532.0,44745,529
-Texas,Wichita County,2009,127616,0.0,42246,497
-Texas,Wichita County,2010,131685,0.0,38689,529
-Texas,Wichita County,2011,130698,0.0,43292,527
-Texas,Wichita County,2012,131559,0.0,45363,585
+Texas,Wichita County,2009,127616,,42246,497
+Texas,Wichita County,2010,131685,,38689,529
+Texas,Wichita County,2011,130698,,43292,527
+Texas,Wichita County,2012,131559,,45363,585
 Texas,Wichita County,2013,132047,2938.0,43525,589
-Texas,Wichita County,2014,132355,0.0,42996,589
-Texas,Wichita County,2015,131705,0.0,45416,582
+Texas,Wichita County,2014,132355,,42996,589
+Texas,Wichita County,2015,131705,,45416,582
 Texas,Wichita County,2016,131838,2205.0,44769,602
-Texas,Wichita County,2017,132000,0.0,43295,624
+Texas,Wichita County,2017,132000,,43295,624
 Texas,Wichita County,2018,132064,2482.0,47373,622
-Texas,Wichita County,2019,132230,0.0,51749,620
-Texas,Wichita County,2021,130069,0.0,53465,715
+Texas,Wichita County,2019,132230,,51749,620
+Texas,Wichita County,2021,130069,,53465,715
 Texas,Wichita County,2022,129978,3721.0,56944,735
-Texas,Williamson County,2005,328421,0.0,62418,657
+Texas,Williamson County,2005,328421,,62418,657
 Texas,Williamson County,2006,353830,8135.0,62494,739
 Texas,Williamson County,2007,373363,7645.0,68008,768
 Texas,Williamson County,2008,394193,11821.0,69108,782
@@ -12006,12 +12006,12 @@ Texas,Williamson County,2018,566719,23415.0,87454,1215
 Texas,Williamson County,2019,590551,33123.0,92179,1213
 Texas,Williamson County,2021,643026,108195.0,96073,1316
 Texas,Williamson County,2022,671418,96757.0,101323,1585
-Texas,Wise County,2017,66181,0.0,58839,662
-Texas,Wise County,2018,68305,0.0,69040,766
-Texas,Wise County,2019,69984,0.0,71421,719
-Texas,Wise County,2021,71714,0.0,81400,893
-Texas,Wise County,2022,74895,0.0,80305,1012
-Utah,Cache County,2005,94697,0.0,41097,474
+Texas,Wise County,2017,66181,,58839,662
+Texas,Wise County,2018,68305,,69040,766
+Texas,Wise County,2019,69984,,71421,719
+Texas,Wise County,2021,71714,,81400,893
+Texas,Wise County,2022,74895,,80305,1012
+Utah,Cache County,2005,94697,,41097,474
 Utah,Cache County,2006,98662,3128.0,43059,489
 Utah,Cache County,2007,108887,2931.0,45695,493
 Utah,Cache County,2008,112616,2231.0,49256,527
@@ -12028,7 +12028,7 @@ Utah,Cache County,2018,127068,3886.0,59248,663
 Utah,Cache County,2019,128289,4964.0,62507,699
 Utah,Cache County,2021,137417,9586.0,69154,832
 Utah,Cache County,2022,140173,10766.0,76457,1047
-Utah,Davis County,2005,264676,0.0,56809,616
+Utah,Davis County,2005,264676,,56809,616
 Utah,Davis County,2006,276259,5937.0,61263,631
 Utah,Davis County,2007,288146,6704.0,65686,632
 Utah,Davis County,2008,295332,5449.0,66923,733
@@ -12062,11 +12062,11 @@ Utah,Salt Lake County,2018,1152633,40426.0,73801,1029
 Utah,Salt Lake County,2019,1160437,40433.0,80119,1090
 Utah,Salt Lake County,2021,1186421,144450.0,80712,1208
 Utah,Salt Lake County,2022,1186257,121993.0,91924,1348
-Utah,Tooele County,2017,67456,0.0,72386,801
-Utah,Tooele County,2018,69907,0.0,72906,757
-Utah,Tooele County,2019,72259,0.0,80973,797
-Utah,Tooele County,2021,76640,0.0,93908,931
-Utah,Tooele County,2022,79934,0.0,91386,1006
+Utah,Tooele County,2017,67456,,72386,801
+Utah,Tooele County,2018,69907,,72906,757
+Utah,Tooele County,2019,72259,,80973,797
+Utah,Tooele County,2021,76640,,93908,931
+Utah,Tooele County,2022,79934,,91386,1006
 Utah,Utah County,2005,434677,11595.0,47428,594
 Utah,Utah County,2006,464760,11887.0,50544,589
 Utah,Utah County,2007,483702,14123.0,57408,625
@@ -12084,22 +12084,22 @@ Utah,Utah County,2018,622213,19551.0,75349,936
 Utah,Utah County,2019,636235,23487.0,79545,1020
 Utah,Utah County,2021,684986,72279.0,86781,1143
 Utah,Utah County,2022,702434,67685.0,95338,1241
-Utah,Washington County,2005,117385,0.0,43980,617
+Utah,Washington County,2005,117385,,43980,617
 Utah,Washington County,2006,126312,2066.0,45998,759
-Utah,Washington County,2007,133791,0.0,46822,786
-Utah,Washington County,2008,137589,0.0,50333,779
-Utah,Washington County,2009,137473,0.0,46462,753
-Utah,Washington County,2010,138451,0.0,49058,741
-Utah,Washington County,2011,141666,0.0,45854,761
-Utah,Washington County,2012,144809,0.0,43837,776
-Utah,Washington County,2013,147800,0.0,51063,787
-Utah,Washington County,2014,151948,0.0,49981,773
-Utah,Washington County,2015,155602,0.0,54913,814
-Utah,Washington County,2016,160245,0.0,55056,836
-Utah,Washington County,2017,165662,0.0,54842,879
-Utah,Washington County,2018,171700,0.0,56333,886
-Utah,Washington County,2019,177556,0.0,63595,879
-Utah,Washington County,2021,191226,0.0,61186,1094
+Utah,Washington County,2007,133791,,46822,786
+Utah,Washington County,2008,137589,,50333,779
+Utah,Washington County,2009,137473,,46462,753
+Utah,Washington County,2010,138451,,49058,741
+Utah,Washington County,2011,141666,,45854,761
+Utah,Washington County,2012,144809,,43837,776
+Utah,Washington County,2013,147800,,51063,787
+Utah,Washington County,2014,151948,,49981,773
+Utah,Washington County,2015,155602,,54913,814
+Utah,Washington County,2016,160245,,55056,836
+Utah,Washington County,2017,165662,,54842,879
+Utah,Washington County,2018,171700,,56333,886
+Utah,Washington County,2019,177556,,63595,879
+Utah,Washington County,2021,191226,,61186,1094
 Utah,Washington County,2022,197680,13575.0,74543,1390
 Utah,Weber County,2005,207711,4286.0,49107,593
 Utah,Weber County,2006,213247,2907.0,49342,555
@@ -12118,7 +12118,7 @@ Utah,Weber County,2018,256359,6535.0,68669,813
 Utah,Weber County,2019,260213,9566.0,72206,860
 Utah,Weber County,2021,267066,22323.0,72087,952
 Utah,Weber County,2022,269561,22634.0,83949,1084
-Vermont,Chittenden County,2005,142216,0.0,54039,754
+Vermont,Chittenden County,2005,142216,,54039,754
 Vermont,Chittenden County,2006,150069,3038.0,54897,768
 Vermont,Chittenden County,2007,151826,4152.0,57957,811
 Vermont,Chittenden County,2008,152782,4356.0,62171,872
@@ -12135,23 +12135,23 @@ Vermont,Chittenden County,2018,164572,5988.0,75852,1112
 Vermont,Chittenden County,2019,163774,6157.0,76806,1149
 Vermont,Chittenden County,2021,168865,24244.0,85213,1348
 Vermont,Chittenden County,2022,169301,16487.0,87614,1377
-Virginia,Albemarle County,2005,84202,0.0,60398,735
-Virginia,Albemarle County,2006,92035,0.0,57122,796
+Virginia,Albemarle County,2005,84202,,60398,735
+Virginia,Albemarle County,2006,92035,,57122,796
 Virginia,Albemarle County,2007,93117,4678.0,63249,845
-Virginia,Albemarle County,2008,94075,0.0,66690,845
-Virginia,Albemarle County,2009,94908,0.0,63474,910
-Virginia,Albemarle County,2010,99150,0.0,59499,953
-Virginia,Albemarle County,2011,100553,0.0,63001,911
-Virginia,Albemarle County,2012,102251,0.0,72917,910
+Virginia,Albemarle County,2008,94075,,66690,845
+Virginia,Albemarle County,2009,94908,,63474,910
+Virginia,Albemarle County,2010,99150,,59499,953
+Virginia,Albemarle County,2011,100553,,63001,911
+Virginia,Albemarle County,2012,102251,,72917,910
 Virginia,Albemarle County,2013,103000,3909.0,70312,1020
-Virginia,Albemarle County,2014,104489,0.0,64722,976
-Virginia,Albemarle County,2015,105703,0.0,70589,982
-Virginia,Albemarle County,2016,106878,0.0,71975,1091
+Virginia,Albemarle County,2014,104489,,64722,976
+Virginia,Albemarle County,2015,105703,,70589,982
+Virginia,Albemarle County,2016,106878,,71975,1091
 Virginia,Albemarle County,2017,107702,4302.0,77181,1092
-Virginia,Albemarle County,2018,108718,0.0,78584,1171
-Virginia,Albemarle County,2019,109330,0.0,86399,1173
-Virginia,Albemarle County,2021,113535,0.0,92568,1341
-Virginia,Albemarle County,2022,114534,0.0,93691,1380
+Virginia,Albemarle County,2018,108718,,78584,1171
+Virginia,Albemarle County,2019,109330,,86399,1173
+Virginia,Albemarle County,2021,113535,,92568,1341
+Virginia,Albemarle County,2022,114534,,93691,1380
 Virginia,Arlington County,2005,191852,6693.0,80433,1199
 Virginia,Arlington County,2006,199776,6387.0,87350,1224
 Virginia,Arlington County,2007,204568,5677.0,94876,1396
@@ -12169,41 +12169,41 @@ Virginia,Arlington County,2018,237521,13589.0,122394,1865
 Virginia,Arlington County,2019,236842,9087.0,119755,1913
 Virginia,Arlington County,2021,232965,69593.0,125651,1896
 Virginia,Arlington County,2022,234000,53843.0,132380,2042
-Virginia,Augusta County,2005,68370,0.0,44677,510
-Virginia,Augusta County,2006,71672,0.0,45207,449
-Virginia,Augusta County,2007,69522,0.0,49373,589
-Virginia,Augusta County,2008,70634,0.0,49593,525
-Virginia,Augusta County,2009,71594,0.0,49815,568
-Virginia,Augusta County,2010,74192,0.0,49903,558
-Virginia,Augusta County,2011,74897,0.0,47326,603
-Virginia,Augusta County,2012,73658,0.0,47279,665
-Virginia,Augusta County,2013,73912,0.0,55284,586
-Virginia,Augusta County,2014,73862,0.0,58322,686
-Virginia,Augusta County,2015,74314,0.0,56766,687
-Virginia,Augusta County,2016,74997,0.0,55342,686
-Virginia,Augusta County,2017,75144,0.0,57017,690
-Virginia,Augusta County,2018,75457,0.0,59820,717
-Virginia,Augusta County,2019,75558,0.0,62668,769
-Virginia,Augusta County,2021,77563,0.0,68584,726
-Virginia,Augusta County,2022,78064,0.0,80182,823
-Virginia,Bedford County,2005,64764,0.0,51569,408
-Virginia,Bedford County,2006,68043,0.0,49801,436
-Virginia,Bedford County,2007,67018,0.0,53470,422
-Virginia,Bedford County,2008,65805,0.0,53176,448
-Virginia,Bedford County,2009,67154,0.0,52119,583
-Virginia,Bedford County,2010,68735,0.0,49002,523
-Virginia,Bedford County,2011,69246,0.0,59980,622
-Virginia,Bedford County,2012,69590,0.0,57625,608
-Virginia,Bedford County,2013,69825,0.0,57000,627
-Virginia,Bedford County,2014,76583,0.0,56996,638
-Virginia,Bedford County,2015,77724,0.0,54062,574
-Virginia,Bedford County,2016,77960,0.0,56479,561
-Virginia,Bedford County,2017,77974,0.0,66327,633
-Virginia,Bedford County,2018,78747,0.0,64084,738
-Virginia,Bedford County,2019,78997,0.0,69125,691
-Virginia,Bedford County,2021,80131,0.0,66415,637
-Virginia,Bedford County,2022,80848,0.0,71751,726
-Virginia,Chesterfield County,2005,284956,0.0,66659,705
+Virginia,Augusta County,2005,68370,,44677,510
+Virginia,Augusta County,2006,71672,,45207,449
+Virginia,Augusta County,2007,69522,,49373,589
+Virginia,Augusta County,2008,70634,,49593,525
+Virginia,Augusta County,2009,71594,,49815,568
+Virginia,Augusta County,2010,74192,,49903,558
+Virginia,Augusta County,2011,74897,,47326,603
+Virginia,Augusta County,2012,73658,,47279,665
+Virginia,Augusta County,2013,73912,,55284,586
+Virginia,Augusta County,2014,73862,,58322,686
+Virginia,Augusta County,2015,74314,,56766,687
+Virginia,Augusta County,2016,74997,,55342,686
+Virginia,Augusta County,2017,75144,,57017,690
+Virginia,Augusta County,2018,75457,,59820,717
+Virginia,Augusta County,2019,75558,,62668,769
+Virginia,Augusta County,2021,77563,,68584,726
+Virginia,Augusta County,2022,78064,,80182,823
+Virginia,Bedford County,2005,64764,,51569,408
+Virginia,Bedford County,2006,68043,,49801,436
+Virginia,Bedford County,2007,67018,,53470,422
+Virginia,Bedford County,2008,65805,,53176,448
+Virginia,Bedford County,2009,67154,,52119,583
+Virginia,Bedford County,2010,68735,,49002,523
+Virginia,Bedford County,2011,69246,,59980,622
+Virginia,Bedford County,2012,69590,,57625,608
+Virginia,Bedford County,2013,69825,,57000,627
+Virginia,Bedford County,2014,76583,,56996,638
+Virginia,Bedford County,2015,77724,,54062,574
+Virginia,Bedford County,2016,77960,,56479,561
+Virginia,Bedford County,2017,77974,,66327,633
+Virginia,Bedford County,2018,78747,,64084,738
+Virginia,Bedford County,2019,78997,,69125,691
+Virginia,Bedford County,2021,80131,,66415,637
+Virginia,Bedford County,2022,80848,,71751,726
+Virginia,Chesterfield County,2005,284956,,66659,705
 Virginia,Chesterfield County,2006,296718,5703.0,67570,757
 Virginia,Chesterfield County,2007,299689,5624.0,69409,824
 Virginia,Chesterfield County,2008,303469,7234.0,71148,801
@@ -12237,57 +12237,57 @@ Virginia,Fairfax County,2018,1150795,43861.0,122227,1749
 Virginia,Fairfax County,2019,1147532,42851.0,128374,1801
 Virginia,Fairfax County,2021,1139720,221114.0,134115,1873
 Virginia,Fairfax County,2022,1138331,171967.0,145164,1946
-Virginia,Fauquier County,2006,66730,0.0,74716,821
-Virginia,Fauquier County,2007,65957,0.0,84888,899
-Virginia,Fauquier County,2008,66408,0.0,81576,1010
-Virginia,Fauquier County,2009,67342,0.0,88305,961
-Virginia,Fauquier County,2010,62971,0.0,85614,861
-Virginia,Fauquier County,2011,66320,0.0,93762,1030
-Virginia,Fauquier County,2012,66542,0.0,83677,1005
-Virginia,Fauquier County,2013,67207,0.0,82823,884
-Virginia,Fauquier County,2014,68248,0.0,91987,993
-Virginia,Fauquier County,2015,68782,0.0,91940,963
-Virginia,Fauquier County,2016,69069,0.0,94347,1027
-Virginia,Fauquier County,2017,69465,0.0,98585,1343
-Virginia,Fauquier County,2018,70675,0.0,92145,1162
-Virginia,Fauquier County,2019,71222,0.0,104809,1086
-Virginia,Fauquier County,2021,73815,0.0,108497,1103
-Virginia,Fauquier County,2022,74664,0.0,130261,1173
-Virginia,Frederick County,2005,68200,0.0,59294,680
-Virginia,Frederick County,2006,71187,0.0,55231,764
-Virginia,Frederick County,2007,72880,0.0,66114,932
-Virginia,Frederick County,2008,73898,0.0,61453,797
-Virginia,Frederick County,2009,74972,0.0,61806,856
-Virginia,Frederick County,2010,78511,0.0,63331,854
-Virginia,Frederick County,2011,79666,0.0,69155,873
-Virginia,Frederick County,2012,80317,0.0,67289,812
-Virginia,Frederick County,2013,81319,0.0,69332,869
-Virginia,Frederick County,2014,82377,0.0,66167,843
-Virginia,Frederick County,2015,83199,0.0,71993,829
-Virginia,Frederick County,2016,84421,0.0,69827,971
-Virginia,Frederick County,2017,86484,0.0,72405,883
-Virginia,Frederick County,2018,88355,0.0,80953,896
-Virginia,Frederick County,2019,89313,0.0,86229,909
-Virginia,Frederick County,2021,93717,0.0,86044,1160
-Virginia,Frederick County,2022,95051,0.0,98870,1361
-Virginia,Hanover County,2005,95208,0.0,73072,646
-Virginia,Hanover County,2006,98983,0.0,68531,758
-Virginia,Hanover County,2007,98946,0.0,75870,812
-Virginia,Hanover County,2008,99716,0.0,78580,827
-Virginia,Hanover County,2009,99933,0.0,74368,925
-Virginia,Hanover County,2010,99948,0.0,71891,770
-Virginia,Hanover County,2011,100342,0.0,67505,875
-Virginia,Hanover County,2012,100668,0.0,74128,788
-Virginia,Hanover County,2013,101330,0.0,77424,924
-Virginia,Hanover County,2014,101918,0.0,83756,915
-Virginia,Hanover County,2015,103227,0.0,82085,877
-Virginia,Hanover County,2016,104392,0.0,83135,986
-Virginia,Hanover County,2017,105923,0.0,90066,919
-Virginia,Hanover County,2018,107239,0.0,91309,1039
-Virginia,Hanover County,2019,107766,0.0,89812,1060
-Virginia,Hanover County,2021,111603,0.0,94381,1065
-Virginia,Hanover County,2022,112938,0.0,103076,1142
-Virginia,Henrico County,2005,276644,0.0,55356,696
+Virginia,Fauquier County,2006,66730,,74716,821
+Virginia,Fauquier County,2007,65957,,84888,899
+Virginia,Fauquier County,2008,66408,,81576,1010
+Virginia,Fauquier County,2009,67342,,88305,961
+Virginia,Fauquier County,2010,62971,,85614,861
+Virginia,Fauquier County,2011,66320,,93762,1030
+Virginia,Fauquier County,2012,66542,,83677,1005
+Virginia,Fauquier County,2013,67207,,82823,884
+Virginia,Fauquier County,2014,68248,,91987,993
+Virginia,Fauquier County,2015,68782,,91940,963
+Virginia,Fauquier County,2016,69069,,94347,1027
+Virginia,Fauquier County,2017,69465,,98585,1343
+Virginia,Fauquier County,2018,70675,,92145,1162
+Virginia,Fauquier County,2019,71222,,104809,1086
+Virginia,Fauquier County,2021,73815,,108497,1103
+Virginia,Fauquier County,2022,74664,,130261,1173
+Virginia,Frederick County,2005,68200,,59294,680
+Virginia,Frederick County,2006,71187,,55231,764
+Virginia,Frederick County,2007,72880,,66114,932
+Virginia,Frederick County,2008,73898,,61453,797
+Virginia,Frederick County,2009,74972,,61806,856
+Virginia,Frederick County,2010,78511,,63331,854
+Virginia,Frederick County,2011,79666,,69155,873
+Virginia,Frederick County,2012,80317,,67289,812
+Virginia,Frederick County,2013,81319,,69332,869
+Virginia,Frederick County,2014,82377,,66167,843
+Virginia,Frederick County,2015,83199,,71993,829
+Virginia,Frederick County,2016,84421,,69827,971
+Virginia,Frederick County,2017,86484,,72405,883
+Virginia,Frederick County,2018,88355,,80953,896
+Virginia,Frederick County,2019,89313,,86229,909
+Virginia,Frederick County,2021,93717,,86044,1160
+Virginia,Frederick County,2022,95051,,98870,1361
+Virginia,Hanover County,2005,95208,,73072,646
+Virginia,Hanover County,2006,98983,,68531,758
+Virginia,Hanover County,2007,98946,,75870,812
+Virginia,Hanover County,2008,99716,,78580,827
+Virginia,Hanover County,2009,99933,,74368,925
+Virginia,Hanover County,2010,99948,,71891,770
+Virginia,Hanover County,2011,100342,,67505,875
+Virginia,Hanover County,2012,100668,,74128,788
+Virginia,Hanover County,2013,101330,,77424,924
+Virginia,Hanover County,2014,101918,,83756,915
+Virginia,Hanover County,2015,103227,,82085,877
+Virginia,Hanover County,2016,104392,,83135,986
+Virginia,Hanover County,2017,105923,,90066,919
+Virginia,Hanover County,2018,107239,,91309,1039
+Virginia,Hanover County,2019,107766,,89812,1060
+Virginia,Hanover County,2021,111603,,94381,1065
+Virginia,Hanover County,2022,112938,,103076,1142
+Virginia,Henrico County,2005,276644,,55356,696
 Virginia,Henrico County,2006,284399,5409.0,57195,742
 Virginia,Henrico County,2007,289822,5267.0,57741,768
 Virginia,Henrico County,2008,292599,5225.0,61328,788
@@ -12304,18 +12304,18 @@ Virginia,Henrico County,2018,329261,11595.0,68069,991
 Virginia,Henrico County,2019,330818,10705.0,68024,1049
 Virginia,Henrico County,2021,333554,49820.0,78868,1158
 Virginia,Henrico County,2022,333962,37319.0,81985,1247
-Virginia,James City County,2010,67237,0.0,74706,979
-Virginia,James City County,2011,68200,0.0,71667,1061
-Virginia,James City County,2012,68967,0.0,79435,1012
-Virginia,James City County,2013,70516,0.0,73632,1004
-Virginia,James City County,2014,72583,0.0,72622,945
-Virginia,James City County,2015,73147,0.0,73968,1268
-Virginia,James City County,2016,74404,0.0,83455,1153
-Virginia,James City County,2017,75524,0.0,87910,986
-Virginia,James City County,2018,76397,0.0,83190,1143
-Virginia,James City County,2019,76523,0.0,91674,1132
-Virginia,James City County,2021,79882,0.0,88604,1244
-Virginia,James City County,2022,81199,0.0,99432,1422
+Virginia,James City County,2010,67237,,74706,979
+Virginia,James City County,2011,68200,,71667,1061
+Virginia,James City County,2012,68967,,79435,1012
+Virginia,James City County,2013,70516,,73632,1004
+Virginia,James City County,2014,72583,,72622,945
+Virginia,James City County,2015,73147,,73968,1268
+Virginia,James City County,2016,74404,,83455,1153
+Virginia,James City County,2017,75524,,87910,986
+Virginia,James City County,2018,76397,,83190,1143
+Virginia,James City County,2019,76523,,91674,1132
+Virginia,James City County,2021,79882,,88604,1244
+Virginia,James City County,2022,81199,,99432,1422
 Virginia,Loudoun County,2005,254612,6895.0,98483,1097
 Virginia,Loudoun County,2006,268817,7700.0,99371,1244
 Virginia,Loudoun County,2007,278797,9812.0,107207,1306
@@ -12333,23 +12333,23 @@ Virginia,Loudoun County,2018,406850,18106.0,139915,1695
 Virginia,Loudoun County,2019,413538,19635.0,151800,1749
 Virginia,Loudoun County,2021,427592,87374.0,153506,1978
 Virginia,Loudoun County,2022,432085,71123.0,167531,2014
-Virginia,Montgomery County,2005,74962,0.0,37051,580
-Virginia,Montgomery County,2006,84541,0.0,38496,558
-Virginia,Montgomery County,2007,89193,0.0,42139,612
+Virginia,Montgomery County,2005,74962,,37051,580
+Virginia,Montgomery County,2006,84541,,38496,558
+Virginia,Montgomery County,2007,89193,,42139,612
 Virginia,Montgomery County,2008,89967,2837.0,42025,617
 Virginia,Montgomery County,2009,91023,2403.0,43052,642
-Virginia,Montgomery County,2010,94531,0.0,40685,657
-Virginia,Montgomery County,2011,94342,0.0,43982,705
-Virginia,Montgomery County,2012,95194,0.0,41625,651
+Virginia,Montgomery County,2010,94531,,40685,657
+Virginia,Montgomery County,2011,94342,,43982,705
+Virginia,Montgomery County,2012,95194,,41625,651
 Virginia,Montgomery County,2013,96207,1927.0,45679,764
-Virginia,Montgomery County,2014,97244,0.0,42052,748
-Virginia,Montgomery County,2015,97653,0.0,52151,827
-Virginia,Montgomery County,2016,98602,0.0,55706,794
-Virginia,Montgomery County,2017,98559,0.0,56462,875
-Virginia,Montgomery County,2018,98985,0.0,51932,884
-Virginia,Montgomery County,2019,98535,0.0,60045,845
-Virginia,Montgomery County,2021,98473,0.0,55210,929
-Virginia,Montgomery County,2022,98915,0.0,71290,1008
+Virginia,Montgomery County,2014,97244,,42052,748
+Virginia,Montgomery County,2015,97653,,52151,827
+Virginia,Montgomery County,2016,98602,,55706,794
+Virginia,Montgomery County,2017,98559,,56462,875
+Virginia,Montgomery County,2018,98985,,51932,884
+Virginia,Montgomery County,2019,98535,,60045,845
+Virginia,Montgomery County,2021,98473,,55210,929
+Virginia,Montgomery County,2022,98915,,71290,1008
 Virginia,Prince William County,2005,346790,7876.0,81904,996
 Virginia,Prince William County,2006,357503,6629.0,80783,1086
 Virginia,Prince William County,2007,360411,8690.0,87243,1142
@@ -12367,47 +12367,47 @@ Virginia,Prince William County,2018,468011,11149.0,107925,1487
 Virginia,Prince William County,2019,470335,15639.0,106861,1547
 Virginia,Prince William County,2021,484472,56659.0,118117,1618
 Virginia,Prince William County,2022,486943,50935.0,120398,1733
-Virginia,Roanoke County,2005,85900,0.0,52688,544
-Virginia,Roanoke County,2006,90482,0.0,52931,621
-Virginia,Roanoke County,2007,90420,0.0,59679,617
-Virginia,Roanoke County,2008,90867,0.0,60615,642
-Virginia,Roanoke County,2009,91011,0.0,55538,675
-Virginia,Roanoke County,2010,92389,0.0,57212,658
-Virginia,Roanoke County,2011,92740,0.0,61615,599
-Virginia,Roanoke County,2012,92901,0.0,57515,698
-Virginia,Roanoke County,2013,93524,0.0,56400,698
-Virginia,Roanoke County,2014,93785,0.0,62091,744
-Virginia,Roanoke County,2015,94409,0.0,63210,803
-Virginia,Roanoke County,2016,94031,0.0,60454,721
-Virginia,Roanoke County,2017,93730,0.0,64287,806
-Virginia,Roanoke County,2018,94073,0.0,68595,837
-Virginia,Roanoke County,2019,94186,0.0,71715,850
-Virginia,Roanoke County,2021,96589,0.0,72231,940
-Virginia,Roanoke County,2022,96914,0.0,75258,947
-Virginia,Rockingham County,2005,69530,0.0,48452,473
+Virginia,Roanoke County,2005,85900,,52688,544
+Virginia,Roanoke County,2006,90482,,52931,621
+Virginia,Roanoke County,2007,90420,,59679,617
+Virginia,Roanoke County,2008,90867,,60615,642
+Virginia,Roanoke County,2009,91011,,55538,675
+Virginia,Roanoke County,2010,92389,,57212,658
+Virginia,Roanoke County,2011,92740,,61615,599
+Virginia,Roanoke County,2012,92901,,57515,698
+Virginia,Roanoke County,2013,93524,,56400,698
+Virginia,Roanoke County,2014,93785,,62091,744
+Virginia,Roanoke County,2015,94409,,63210,803
+Virginia,Roanoke County,2016,94031,,60454,721
+Virginia,Roanoke County,2017,93730,,64287,806
+Virginia,Roanoke County,2018,94073,,68595,837
+Virginia,Roanoke County,2019,94186,,71715,850
+Virginia,Roanoke County,2021,96589,,72231,940
+Virginia,Roanoke County,2022,96914,,75258,947
+Virginia,Rockingham County,2005,69530,,48452,473
 Virginia,Rockingham County,2006,72564,2315.0,47630,475
-Virginia,Rockingham County,2007,73524,0.0,48883,521
-Virginia,Rockingham County,2008,74394,0.0,53861,559
-Virginia,Rockingham County,2009,75134,0.0,46419,625
-Virginia,Rockingham County,2010,76413,0.0,48243,575
-Virginia,Rockingham County,2011,76589,0.0,51889,573
-Virginia,Rockingham County,2012,77391,0.0,50818,583
-Virginia,Rockingham County,2013,77741,0.0,56074,679
-Virginia,Rockingham County,2014,78171,0.0,56112,575
-Virginia,Rockingham County,2015,78593,0.0,51979,648
-Virginia,Rockingham County,2016,79744,0.0,57755,752
-Virginia,Rockingham County,2017,80227,0.0,59493,709
-Virginia,Rockingham County,2018,81244,0.0,61199,750
-Virginia,Rockingham County,2019,81948,0.0,69423,842
-Virginia,Rockingham County,2021,84394,0.0,73163,786
-Virginia,Rockingham County,2022,85397,0.0,72618,846
-Virginia,Spotsylvania County,2005,115995,0.0,68816,833
+Virginia,Rockingham County,2007,73524,,48883,521
+Virginia,Rockingham County,2008,74394,,53861,559
+Virginia,Rockingham County,2009,75134,,46419,625
+Virginia,Rockingham County,2010,76413,,48243,575
+Virginia,Rockingham County,2011,76589,,51889,573
+Virginia,Rockingham County,2012,77391,,50818,583
+Virginia,Rockingham County,2013,77741,,56074,679
+Virginia,Rockingham County,2014,78171,,56112,575
+Virginia,Rockingham County,2015,78593,,51979,648
+Virginia,Rockingham County,2016,79744,,57755,752
+Virginia,Rockingham County,2017,80227,,59493,709
+Virginia,Rockingham County,2018,81244,,61199,750
+Virginia,Rockingham County,2019,81948,,69423,842
+Virginia,Rockingham County,2021,84394,,73163,786
+Virginia,Rockingham County,2022,85397,,72618,846
+Virginia,Spotsylvania County,2005,115995,,68816,833
 Virginia,Spotsylvania County,2006,119529,1950.0,72453,1043
 Virginia,Spotsylvania County,2007,119194,2184.0,74881,990
 Virginia,Spotsylvania County,2008,120031,1909.0,79558,944
 Virginia,Spotsylvania County,2009,120977,1787.0,76425,943
 Virginia,Spotsylvania County,2010,122853,2413.0,72217,999
-Virginia,Spotsylvania County,2011,124327,0.0,76475,1121
+Virginia,Spotsylvania County,2011,124327,,76475,1121
 Virginia,Spotsylvania County,2012,125684,2526.0,78914,1087
 Virginia,Spotsylvania County,2013,127348,2537.0,71901,1197
 Virginia,Spotsylvania County,2014,129188,2181.0,75686,1086
@@ -12415,10 +12415,10 @@ Virginia,Spotsylvania County,2015,130475,2102.0,75535,1184
 Virginia,Spotsylvania County,2016,132010,3970.0,81146,1192
 Virginia,Spotsylvania County,2017,133033,3665.0,86491,1210
 Virginia,Spotsylvania County,2018,134238,3192.0,88431,1295
-Virginia,Spotsylvania County,2019,136215,0.0,91073,1275
-Virginia,Spotsylvania County,2021,143676,0.0,101289,1349
+Virginia,Spotsylvania County,2019,136215,,91073,1275
+Virginia,Spotsylvania County,2021,143676,,101289,1349
 Virginia,Spotsylvania County,2022,146688,13950.0,95870,1478
-Virginia,Stafford County,2005,116424,0.0,78675,958
+Virginia,Stafford County,2005,116424,,78675,958
 Virginia,Stafford County,2006,120170,1284.0,85014,1096
 Virginia,Stafford County,2007,120723,2648.0,87629,1067
 Virginia,Stafford County,2008,121736,5145.0,87783,1055
@@ -12433,21 +12433,21 @@ Virginia,Stafford County,2016,144361,3409.0,97484,1363
 Virginia,Stafford County,2017,146649,4365.0,112795,1296
 Virginia,Stafford County,2018,149960,4785.0,110307,1349
 Virginia,Stafford County,2019,152882,3582.0,110446,1234
-Virginia,Stafford County,2021,160877,0.0,117251,1575
+Virginia,Stafford County,2021,160877,,117251,1575
 Virginia,Stafford County,2022,163380,15812.0,138378,1549
-Virginia,York County,2010,65467,0.0,79120,1030
-Virginia,York County,2011,66134,0.0,84167,1274
-Virginia,York County,2012,66146,0.0,71974,1145
-Virginia,York County,2013,66269,0.0,78073,1350
-Virginia,York County,2014,66342,0.0,81636,1311
-Virginia,York County,2015,67837,0.0,84580,1278
-Virginia,York County,2016,67976,0.0,89418,1343
-Virginia,York County,2017,67739,0.0,83993,1240
-Virginia,York County,2018,67846,0.0,83593,1288
-Virginia,York County,2019,68280,0.0,91241,1365
-Virginia,York County,2021,70915,0.0,97758,1566
-Virginia,York County,2022,71341,0.0,116524,1363
-Virginia,Alexandria city,2005,133479,0.0,66116,1063
+Virginia,York County,2010,65467,,79120,1030
+Virginia,York County,2011,66134,,84167,1274
+Virginia,York County,2012,66146,,71974,1145
+Virginia,York County,2013,66269,,78073,1350
+Virginia,York County,2014,66342,,81636,1311
+Virginia,York County,2015,67837,,84580,1278
+Virginia,York County,2016,67976,,89418,1343
+Virginia,York County,2017,67739,,83993,1240
+Virginia,York County,2018,67846,,83593,1288
+Virginia,York County,2019,68280,,91241,1365
+Virginia,York County,2021,70915,,97758,1566
+Virginia,York County,2022,71341,,116524,1363
+Virginia,Alexandria city,2005,133479,,66116,1063
 Virginia,Alexandria city,2006,136974,2928.0,80449,1156
 Virginia,Alexandria city,2007,140024,2535.0,80806,1174
 Virginia,Alexandria city,2008,143885,2944.0,86682,1237
@@ -12464,7 +12464,7 @@ Virginia,Alexandria city,2018,160530,6254.0,101215,1666
 Virginia,Alexandria city,2019,159428,6035.0,103284,1687
 Virginia,Alexandria city,2021,154706,39424.0,101162,1742
 Virginia,Alexandria city,2022,155525,30015.0,111955,1864
-Virginia,Chesapeake city,2005,214835,0.0,60817,650
+Virginia,Chesapeake city,2005,214835,,60817,650
 Virginia,Chesapeake city,2006,220560,2230.0,62126,714
 Virginia,Chesapeake city,2007,219154,3208.0,63517,845
 Virginia,Chesapeake city,2008,220111,3139.0,67996,790
@@ -12473,49 +12473,49 @@ Virginia,Chesapeake city,2010,222986,2514.0,68955,922
 Virginia,Chesapeake city,2011,225050,2789.0,66563,962
 Virginia,Chesapeake city,2012,228417,3086.0,65562,907
 Virginia,Chesapeake city,2013,230571,3153.0,67252,1002
-Virginia,Chesapeake city,2014,233371,0.0,66712,905
+Virginia,Chesapeake city,2014,233371,,66712,905
 Virginia,Chesapeake city,2015,235429,5366.0,67491,1038
 Virginia,Chesapeake city,2016,237940,4961.0,72928,1006
-Virginia,Chesapeake city,2017,240397,0.0,76629,1015
+Virginia,Chesapeake city,2017,240397,,76629,1015
 Virginia,Chesapeake city,2018,242634,5568.0,80265,1050
-Virginia,Chesapeake city,2019,244835,0.0,77847,1071
-Virginia,Chesapeake city,2021,251269,0.0,88815,1110
-Virginia,Chesapeake city,2022,252488,0.0,87749,1219
-Virginia,Hampton city,2005,133584,0.0,45105,645
+Virginia,Chesapeake city,2019,244835,,77847,1071
+Virginia,Chesapeake city,2021,251269,,88815,1110
+Virginia,Chesapeake city,2022,252488,,87749,1219
+Virginia,Hampton city,2005,133584,,45105,645
 Virginia,Hampton city,2006,145017,1435.0,47636,689
 Virginia,Hampton city,2007,146439,1898.0,46571,702
-Virginia,Hampton city,2008,145494,0.0,47039,726
-Virginia,Hampton city,2009,144236,0.0,46440,782
-Virginia,Hampton city,2010,137381,0.0,51275,778
-Virginia,Hampton city,2011,136401,0.0,49848,784
+Virginia,Hampton city,2008,145494,,47039,726
+Virginia,Hampton city,2009,144236,,46440,782
+Virginia,Hampton city,2010,137381,,51275,778
+Virginia,Hampton city,2011,136401,,49848,784
 Virginia,Hampton city,2012,136836,2526.0,47472,792
-Virginia,Hampton city,2013,136699,0.0,43785,811
+Virginia,Hampton city,2013,136699,,43785,811
 Virginia,Hampton city,2014,136879,1861.0,47312,847
 Virginia,Hampton city,2015,136454,2288.0,51867,898
 Virginia,Hampton city,2016,135410,1045.0,50435,874
 Virginia,Hampton city,2017,134669,1867.0,54062,917
-Virginia,Hampton city,2018,134313,0.0,55466,929
-Virginia,Hampton city,2019,134510,0.0,56930,934
-Virginia,Hampton city,2021,137746,0.0,57647,1013
-Virginia,Hampton city,2022,138037,0.0,64924,1092
-Virginia,Lynchburg city,2005,60378,0.0,35744,396
-Virginia,Lynchburg city,2006,68158,0.0,36010,450
-Virginia,Lynchburg city,2007,69335,0.0,34720,490
-Virginia,Lynchburg city,2008,73839,0.0,40396,496
-Virginia,Lynchburg city,2009,73933,0.0,38314,496
-Virginia,Lynchburg city,2010,75686,0.0,35156,534
-Virginia,Lynchburg city,2011,76503,0.0,36627,570
-Virginia,Lynchburg city,2012,77113,0.0,36912,552
-Virginia,Lynchburg city,2013,78014,0.0,40477,568
-Virginia,Lynchburg city,2014,79047,0.0,40594,647
-Virginia,Lynchburg city,2015,79812,0.0,39374,658
-Virginia,Lynchburg city,2016,80212,0.0,41264,591
+Virginia,Hampton city,2018,134313,,55466,929
+Virginia,Hampton city,2019,134510,,56930,934
+Virginia,Hampton city,2021,137746,,57647,1013
+Virginia,Hampton city,2022,138037,,64924,1092
+Virginia,Lynchburg city,2005,60378,,35744,396
+Virginia,Lynchburg city,2006,68158,,36010,450
+Virginia,Lynchburg city,2007,69335,,34720,490
+Virginia,Lynchburg city,2008,73839,,40396,496
+Virginia,Lynchburg city,2009,73933,,38314,496
+Virginia,Lynchburg city,2010,75686,,35156,534
+Virginia,Lynchburg city,2011,76503,,36627,570
+Virginia,Lynchburg city,2012,77113,,36912,552
+Virginia,Lynchburg city,2013,78014,,40477,568
+Virginia,Lynchburg city,2014,79047,,40594,647
+Virginia,Lynchburg city,2015,79812,,39374,658
+Virginia,Lynchburg city,2016,80212,,41264,591
 Virginia,Lynchburg city,2017,80995,2475.0,45239,700
-Virginia,Lynchburg city,2018,82126,0.0,42389,664
-Virginia,Lynchburg city,2019,82168,0.0,54850,733
-Virginia,Lynchburg city,2021,79009,0.0,56110,793
-Virginia,Lynchburg city,2022,79287,0.0,49076,742
-Virginia,Newport News city,2005,176591,0.0,46641,634
+Virginia,Lynchburg city,2018,82126,,42389,664
+Virginia,Lynchburg city,2019,82168,,54850,733
+Virginia,Lynchburg city,2021,79009,,56110,793
+Virginia,Lynchburg city,2022,79287,,49076,742
+Virginia,Newport News city,2005,176591,,46641,634
 Virginia,Newport News city,2006,178281,3504.0,44226,636
 Virginia,Newport News city,2007,179153,2670.0,45359,684
 Virginia,Newport News city,2008,179614,2304.0,49664,727
@@ -12530,9 +12530,9 @@ Virginia,Newport News city,2016,181825,2433.0,50524,858
 Virginia,Newport News city,2017,179388,2076.0,49716,817
 Virginia,Newport News city,2018,178626,3984.0,50180,850
 Virginia,Newport News city,2019,179225,4772.0,53029,917
-Virginia,Newport News city,2021,184587,0.0,58937,931
+Virginia,Newport News city,2021,184587,,58937,931
 Virginia,Newport News city,2022,184306,7154.0,64102,1013
-Virginia,Norfolk city,2005,206172,0.0,36920,578
+Virginia,Norfolk city,2005,206172,,36920,578
 Virginia,Norfolk city,2006,229112,12524.0,40230,625
 Virginia,Norfolk city,2007,235747,15068.0,40701,665
 Virginia,Norfolk city,2008,234220,9848.0,40416,670
@@ -12549,24 +12549,24 @@ Virginia,Norfolk city,2018,244076,3613.0,49587,864
 Virginia,Norfolk city,2019,242742,4154.0,53093,853
 Virginia,Norfolk city,2021,235089,14772.0,58591,938
 Virginia,Norfolk city,2022,232995,9042.0,61090,1035
-Virginia,Portsmouth city,2005,95183,0.0,40172,561
-Virginia,Portsmouth city,2006,101377,0.0,41670,658
-Virginia,Portsmouth city,2007,101967,0.0,44374,692
-Virginia,Portsmouth city,2008,100577,0.0,47813,708
-Virginia,Portsmouth city,2009,99321,0.0,43082,754
+Virginia,Portsmouth city,2005,95183,,40172,561
+Virginia,Portsmouth city,2006,101377,,41670,658
+Virginia,Portsmouth city,2007,101967,,44374,692
+Virginia,Portsmouth city,2008,100577,,47813,708
+Virginia,Portsmouth city,2009,99321,,43082,754
 Virginia,Portsmouth city,2010,95696,347.0,43674,745
 Virginia,Portsmouth city,2011,95684,1483.0,42647,756
-Virginia,Portsmouth city,2012,96470,0.0,42487,792
-Virginia,Portsmouth city,2013,96205,0.0,43904,766
-Virginia,Portsmouth city,2014,96004,0.0,44905,788
-Virginia,Portsmouth city,2015,96201,0.0,49242,794
+Virginia,Portsmouth city,2012,96470,,42487,792
+Virginia,Portsmouth city,2013,96205,,43904,766
+Virginia,Portsmouth city,2014,96004,,44905,788
+Virginia,Portsmouth city,2015,96201,,49242,794
 Virginia,Portsmouth city,2016,95252,1238.0,48516,809
-Virginia,Portsmouth city,2017,94572,0.0,50242,815
-Virginia,Portsmouth city,2018,94632,0.0,47919,855
-Virginia,Portsmouth city,2019,94398,0.0,51195,861
-Virginia,Portsmouth city,2021,97840,0.0,54429,918
-Virginia,Portsmouth city,2022,97029,0.0,54611,1047
-Virginia,Richmond city,2005,180757,0.0,34396,576
+Virginia,Portsmouth city,2017,94572,,50242,815
+Virginia,Portsmouth city,2018,94632,,47919,855
+Virginia,Portsmouth city,2019,94398,,51195,861
+Virginia,Portsmouth city,2021,97840,,54429,918
+Virginia,Portsmouth city,2022,97029,,54611,1047
+Virginia,Richmond city,2005,180757,,34396,576
 Virginia,Richmond city,2006,192913,1768.0,35764,588
 Virginia,Richmond city,2007,200123,3064.0,38461,613
 Virginia,Richmond city,2008,202002,3869.0,36157,638
@@ -12583,40 +12583,40 @@ Virginia,Richmond city,2018,228783,4431.0,48987,861
 Virginia,Richmond city,2019,230436,7813.0,51285,909
 Virginia,Richmond city,2021,226604,27408.0,51770,976
 Virginia,Richmond city,2022,229395,25388.0,58988,1050
-Virginia,Roanoke city,2005,90074,0.0,32432,475
-Virginia,Roanoke city,2006,91552,0.0,35532,473
-Virginia,Roanoke city,2007,92600,0.0,37270,522
-Virginia,Roanoke city,2008,92967,0.0,36234,474
-Virginia,Roanoke city,2009,94482,0.0,34166,534
-Virginia,Roanoke city,2010,96967,0.0,37472,521
-Virginia,Roanoke city,2011,96714,0.0,39040,511
-Virginia,Roanoke city,2012,97469,0.0,37890,573
-Virginia,Roanoke city,2013,98465,0.0,36651,561
+Virginia,Roanoke city,2005,90074,,32432,475
+Virginia,Roanoke city,2006,91552,,35532,473
+Virginia,Roanoke city,2007,92600,,37270,522
+Virginia,Roanoke city,2008,92967,,36234,474
+Virginia,Roanoke city,2009,94482,,34166,534
+Virginia,Roanoke city,2010,96967,,37472,521
+Virginia,Roanoke city,2011,96714,,39040,511
+Virginia,Roanoke city,2012,97469,,37890,573
+Virginia,Roanoke city,2013,98465,,36651,561
 Virginia,Roanoke city,2014,99428,563.0,41697,617
-Virginia,Roanoke city,2015,99897,0.0,39835,597
-Virginia,Roanoke city,2016,99660,0.0,37044,592
-Virginia,Roanoke city,2017,99837,0.0,43799,638
-Virginia,Roanoke city,2018,99920,0.0,42711,670
-Virginia,Roanoke city,2019,99143,0.0,45838,681
-Virginia,Roanoke city,2021,98865,0.0,47202,696
-Virginia,Roanoke city,2022,97847,0.0,49570,773
-Virginia,Suffolk city,2005,77922,0.0,60484,471
-Virginia,Suffolk city,2006,81071,0.0,60703,599
-Virginia,Suffolk city,2007,81332,0.0,59417,548
-Virginia,Suffolk city,2008,82302,0.0,59431,636
-Virginia,Suffolk city,2009,83659,0.0,57083,701
-Virginia,Suffolk city,2010,84906,0.0,69294,736
-Virginia,Suffolk city,2011,84930,0.0,64334,767
-Virginia,Suffolk city,2012,85181,0.0,65394,736
-Virginia,Suffolk city,2013,85728,0.0,60637,735
-Virginia,Suffolk city,2014,86806,0.0,62079,771
-Virginia,Suffolk city,2015,88161,0.0,61203,800
-Virginia,Suffolk city,2016,89273,0.0,66669,884
-Virginia,Suffolk city,2017,90237,0.0,70277,879
-Virginia,Suffolk city,2018,91185,0.0,71829,869
-Virginia,Suffolk city,2019,92108,0.0,80481,1027
-Virginia,Suffolk city,2021,96194,0.0,79556,1044
-Virginia,Suffolk city,2022,98537,0.0,83144,1209
+Virginia,Roanoke city,2015,99897,,39835,597
+Virginia,Roanoke city,2016,99660,,37044,592
+Virginia,Roanoke city,2017,99837,,43799,638
+Virginia,Roanoke city,2018,99920,,42711,670
+Virginia,Roanoke city,2019,99143,,45838,681
+Virginia,Roanoke city,2021,98865,,47202,696
+Virginia,Roanoke city,2022,97847,,49570,773
+Virginia,Suffolk city,2005,77922,,60484,471
+Virginia,Suffolk city,2006,81071,,60703,599
+Virginia,Suffolk city,2007,81332,,59417,548
+Virginia,Suffolk city,2008,82302,,59431,636
+Virginia,Suffolk city,2009,83659,,57083,701
+Virginia,Suffolk city,2010,84906,,69294,736
+Virginia,Suffolk city,2011,84930,,64334,767
+Virginia,Suffolk city,2012,85181,,65394,736
+Virginia,Suffolk city,2013,85728,,60637,735
+Virginia,Suffolk city,2014,86806,,62079,771
+Virginia,Suffolk city,2015,88161,,61203,800
+Virginia,Suffolk city,2016,89273,,66669,884
+Virginia,Suffolk city,2017,90237,,70277,879
+Virginia,Suffolk city,2018,91185,,71829,869
+Virginia,Suffolk city,2019,92108,,80481,1027
+Virginia,Suffolk city,2021,96194,,79556,1044
+Virginia,Suffolk city,2022,98537,,83144,1209
 Virginia,Virginia Beach city,2005,430856,6472.0,58545,838
 Virginia,Virginia Beach city,2006,435619,8603.0,61333,875
 Virginia,Virginia Beach city,2007,434743,12122.0,61462,920
@@ -12634,7 +12634,7 @@ Virginia,Virginia Beach city,2018,450189,10721.0,77059,1153
 Virginia,Virginia Beach city,2019,449974,11654.0,79054,1195
 Virginia,Virginia Beach city,2021,457672,38703.0,81634,1260
 Virginia,Virginia Beach city,2022,455618,36727.0,83245,1401
-Washington,Benton County,2005,157127,0.0,51814,630
+Washington,Benton County,2005,157127,,51814,630
 Washington,Benton County,2006,159463,1635.0,50688,569
 Washington,Benton County,2007,159414,2286.0,51464,571
 Washington,Benton County,2008,163058,2271.0,54774,631
@@ -12648,43 +12648,43 @@ Washington,Benton County,2015,190309,3540.0,62484,725
 Washington,Benton County,2016,193686,2533.0,62508,781
 Washington,Benton County,2017,198171,4898.0,63346,888
 Washington,Benton County,2018,201877,4470.0,68115,843
-Washington,Benton County,2019,204390,0.0,72084,903
-Washington,Benton County,2021,210025,0.0,77059,934
+Washington,Benton County,2019,204390,,72084,903
+Washington,Benton County,2021,210025,,77059,934
 Washington,Benton County,2022,212791,13587.0,85529,980
-Washington,Chelan County,2005,68709,0.0,38269,508
-Washington,Chelan County,2006,71034,0.0,49092,535
-Washington,Chelan County,2007,70993,0.0,45858,510
-Washington,Chelan County,2008,71540,0.0,43939,633
-Washington,Chelan County,2009,72372,0.0,49638,642
-Washington,Chelan County,2010,72735,0.0,46515,687
-Washington,Chelan County,2011,73477,0.0,50986,648
-Washington,Chelan County,2012,73687,0.0,45837,672
-Washington,Chelan County,2013,73967,0.0,51101,674
-Washington,Chelan County,2014,74588,0.0,50177,735
-Washington,Chelan County,2015,75644,0.0,56890,723
-Washington,Chelan County,2016,76338,0.0,52080,778
-Washington,Chelan County,2017,76533,0.0,61615,764
-Washington,Chelan County,2018,77036,0.0,57132,874
-Washington,Chelan County,2019,77200,0.0,59161,907
-Washington,Chelan County,2021,79646,0.0,65847,989
-Washington,Chelan County,2022,79926,0.0,86282,1211
-Washington,Clallam County,2005,68147,0.0,43357,543
+Washington,Chelan County,2005,68709,,38269,508
+Washington,Chelan County,2006,71034,,49092,535
+Washington,Chelan County,2007,70993,,45858,510
+Washington,Chelan County,2008,71540,,43939,633
+Washington,Chelan County,2009,72372,,49638,642
+Washington,Chelan County,2010,72735,,46515,687
+Washington,Chelan County,2011,73477,,50986,648
+Washington,Chelan County,2012,73687,,45837,672
+Washington,Chelan County,2013,73967,,51101,674
+Washington,Chelan County,2014,74588,,50177,735
+Washington,Chelan County,2015,75644,,56890,723
+Washington,Chelan County,2016,76338,,52080,778
+Washington,Chelan County,2017,76533,,61615,764
+Washington,Chelan County,2018,77036,,57132,874
+Washington,Chelan County,2019,77200,,59161,907
+Washington,Chelan County,2021,79646,,65847,989
+Washington,Chelan County,2022,79926,,86282,1211
+Washington,Clallam County,2005,68147,,43357,543
 Washington,Clallam County,2006,70400,1637.0,40672,576
-Washington,Clallam County,2007,70474,0.0,41008,596
-Washington,Clallam County,2008,71021,0.0,47721,644
-Washington,Clallam County,2009,71413,0.0,42583,693
-Washington,Clallam County,2010,71515,0.0,38841,659
+Washington,Clallam County,2007,70474,,41008,596
+Washington,Clallam County,2008,71021,,47721,644
+Washington,Clallam County,2009,71413,,42583,693
+Washington,Clallam County,2010,71515,,38841,659
 Washington,Clallam County,2011,71838,1245.0,50161,622
-Washington,Clallam County,2012,71863,0.0,42485,714
-Washington,Clallam County,2013,72312,0.0,46566,637
-Washington,Clallam County,2014,72715,0.0,46469,751
-Washington,Clallam County,2015,73486,0.0,44929,741
-Washington,Clallam County,2016,74570,0.0,48587,785
-Washington,Clallam County,2017,75474,0.0,47907,801
-Washington,Clallam County,2018,76737,0.0,59001,843
-Washington,Clallam County,2019,77331,0.0,57126,807
-Washington,Clallam County,2021,78209,0.0,62695,807
-Washington,Clallam County,2022,77805,0.0,66139,963
+Washington,Clallam County,2012,71863,,42485,714
+Washington,Clallam County,2013,72312,,46566,637
+Washington,Clallam County,2014,72715,,46469,751
+Washington,Clallam County,2015,73486,,44929,741
+Washington,Clallam County,2016,74570,,48587,785
+Washington,Clallam County,2017,75474,,47907,801
+Washington,Clallam County,2018,76737,,59001,843
+Washington,Clallam County,2019,77331,,57126,807
+Washington,Clallam County,2021,78209,,62695,807
+Washington,Clallam County,2022,77805,,66139,963
 Washington,Clark County,2005,400722,9112.0,50836,659
 Washington,Clark County,2006,412938,10477.0,55405,685
 Washington,Clark County,2007,418070,11328.0,58116,707
@@ -12702,74 +12702,74 @@ Washington,Clark County,2018,481857,19071.0,74060,1212
 Washington,Clark County,2019,488241,18707.0,80555,1262
 Washington,Clark County,2021,511404,48881.0,83837,1344
 Washington,Clark County,2022,516779,50356.0,91248,1471
-Washington,Cowlitz County,2005,95905,0.0,41647,503
-Washington,Cowlitz County,2006,99905,0.0,43728,515
-Washington,Cowlitz County,2007,100467,0.0,44118,563
-Washington,Cowlitz County,2008,101254,0.0,47398,592
-Washington,Cowlitz County,2009,101966,0.0,45493,575
-Washington,Cowlitz County,2010,102501,0.0,41054,610
-Washington,Cowlitz County,2011,102478,0.0,42031,564
-Washington,Cowlitz County,2012,101996,0.0,47692,652
-Washington,Cowlitz County,2013,101860,0.0,48417,632
+Washington,Cowlitz County,2005,95905,,41647,503
+Washington,Cowlitz County,2006,99905,,43728,515
+Washington,Cowlitz County,2007,100467,,44118,563
+Washington,Cowlitz County,2008,101254,,47398,592
+Washington,Cowlitz County,2009,101966,,45493,575
+Washington,Cowlitz County,2010,102501,,41054,610
+Washington,Cowlitz County,2011,102478,,42031,564
+Washington,Cowlitz County,2012,101996,,47692,652
+Washington,Cowlitz County,2013,101860,,48417,632
 Washington,Cowlitz County,2014,102133,1653.0,42223,636
-Washington,Cowlitz County,2015,103468,0.0,49949,682
-Washington,Cowlitz County,2016,105160,0.0,50637,650
-Washington,Cowlitz County,2017,106910,0.0,49456,719
-Washington,Cowlitz County,2018,108987,0.0,59225,707
-Washington,Cowlitz County,2019,110593,0.0,55497,808
-Washington,Cowlitz County,2021,111524,0.0,71194,851
-Washington,Cowlitz County,2022,111956,0.0,72055,976
-Washington,Franklin County,2006,66570,0.0,42417,433
-Washington,Franklin County,2007,69578,0.0,48457,516
+Washington,Cowlitz County,2015,103468,,49949,682
+Washington,Cowlitz County,2016,105160,,50637,650
+Washington,Cowlitz County,2017,106910,,49456,719
+Washington,Cowlitz County,2018,108987,,59225,707
+Washington,Cowlitz County,2019,110593,,55497,808
+Washington,Cowlitz County,2021,111524,,71194,851
+Washington,Cowlitz County,2022,111956,,72055,976
+Washington,Franklin County,2006,66570,,42417,433
+Washington,Franklin County,2007,69578,,48457,516
 Washington,Franklin County,2008,72783,1627.0,43998,516
-Washington,Franklin County,2009,77355,0.0,47885,588
-Washington,Franklin County,2010,79223,0.0,51457,578
-Washington,Franklin County,2011,83455,0.0,49176,602
-Washington,Franklin County,2012,85845,0.0,55392,626
-Washington,Franklin County,2013,86638,0.0,56631,683
-Washington,Franklin County,2014,87809,0.0,57890,757
-Washington,Franklin County,2015,88807,0.0,59664,715
-Washington,Franklin County,2016,90160,0.0,57670,655
-Washington,Franklin County,2017,92125,0.0,64344,681
-Washington,Franklin County,2018,94347,0.0,60012,742
-Washington,Franklin County,2019,95222,0.0,61951,901
-Washington,Franklin County,2021,98268,0.0,81940,881
-Washington,Franklin County,2022,98678,0.0,79224,1059
-Washington,Grant County,2005,80136,0.0,38521,440
-Washington,Grant County,2006,82612,0.0,36965,477
-Washington,Grant County,2007,83047,0.0,42198,464
-Washington,Grant County,2008,84697,0.0,43500,528
-Washington,Grant County,2009,88098,0.0,46883,532
-Washington,Grant County,2010,89744,0.0,42337,612
-Washington,Grant County,2011,91265,0.0,43076,559
-Washington,Grant County,2012,91723,0.0,46295,534
-Washington,Grant County,2013,91878,0.0,46728,588
-Washington,Grant County,2014,93147,0.0,51949,640
-Washington,Grant County,2015,93259,0.0,51667,629
-Washington,Grant County,2016,93546,0.0,48335,593
-Washington,Grant County,2017,95158,0.0,58644,662
-Washington,Grant County,2018,97331,0.0,53057,645
-Washington,Grant County,2019,97733,0.0,56997,705
-Washington,Grant County,2021,100297,0.0,62227,836
-Washington,Grant County,2022,101311,0.0,63819,970
-Washington,Grays Harbor County,2005,68309,0.0,37120,450
-Washington,Grays Harbor County,2006,71587,0.0,40272,477
-Washington,Grays Harbor County,2007,71335,0.0,42402,494
-Washington,Grays Harbor County,2008,71342,0.0,41464,565
+Washington,Franklin County,2009,77355,,47885,588
+Washington,Franklin County,2010,79223,,51457,578
+Washington,Franklin County,2011,83455,,49176,602
+Washington,Franklin County,2012,85845,,55392,626
+Washington,Franklin County,2013,86638,,56631,683
+Washington,Franklin County,2014,87809,,57890,757
+Washington,Franklin County,2015,88807,,59664,715
+Washington,Franklin County,2016,90160,,57670,655
+Washington,Franklin County,2017,92125,,64344,681
+Washington,Franklin County,2018,94347,,60012,742
+Washington,Franklin County,2019,95222,,61951,901
+Washington,Franklin County,2021,98268,,81940,881
+Washington,Franklin County,2022,98678,,79224,1059
+Washington,Grant County,2005,80136,,38521,440
+Washington,Grant County,2006,82612,,36965,477
+Washington,Grant County,2007,83047,,42198,464
+Washington,Grant County,2008,84697,,43500,528
+Washington,Grant County,2009,88098,,46883,532
+Washington,Grant County,2010,89744,,42337,612
+Washington,Grant County,2011,91265,,43076,559
+Washington,Grant County,2012,91723,,46295,534
+Washington,Grant County,2013,91878,,46728,588
+Washington,Grant County,2014,93147,,51949,640
+Washington,Grant County,2015,93259,,51667,629
+Washington,Grant County,2016,93546,,48335,593
+Washington,Grant County,2017,95158,,58644,662
+Washington,Grant County,2018,97331,,53057,645
+Washington,Grant County,2019,97733,,56997,705
+Washington,Grant County,2021,100297,,62227,836
+Washington,Grant County,2022,101311,,63819,970
+Washington,Grays Harbor County,2005,68309,,37120,450
+Washington,Grays Harbor County,2006,71587,,40272,477
+Washington,Grays Harbor County,2007,71335,,42402,494
+Washington,Grays Harbor County,2008,71342,,41464,565
 Washington,Grays Harbor County,2009,71797,1687.0,36345,552
-Washington,Grays Harbor County,2010,72882,0.0,40019,562
-Washington,Grays Harbor County,2011,72546,0.0,40993,543
-Washington,Grays Harbor County,2012,71692,0.0,42057,541
-Washington,Grays Harbor County,2013,71078,0.0,41315,608
-Washington,Grays Harbor County,2014,70818,0.0,43356,626
-Washington,Grays Harbor County,2015,71122,0.0,44122,625
-Washington,Grays Harbor County,2016,71628,0.0,49623,604
-Washington,Grays Harbor County,2017,72697,0.0,47445,587
-Washington,Grays Harbor County,2018,73901,0.0,48255,606
-Washington,Grays Harbor County,2019,75061,0.0,61026,695
-Washington,Grays Harbor County,2021,76841,0.0,54631,699
-Washington,Grays Harbor County,2022,77038,0.0,62523,797
-Washington,Island County,2005,77698,0.0,46695,720
+Washington,Grays Harbor County,2010,72882,,40019,562
+Washington,Grays Harbor County,2011,72546,,40993,543
+Washington,Grays Harbor County,2012,71692,,42057,541
+Washington,Grays Harbor County,2013,71078,,41315,608
+Washington,Grays Harbor County,2014,70818,,43356,626
+Washington,Grays Harbor County,2015,71122,,44122,625
+Washington,Grays Harbor County,2016,71628,,49623,604
+Washington,Grays Harbor County,2017,72697,,47445,587
+Washington,Grays Harbor County,2018,73901,,48255,606
+Washington,Grays Harbor County,2019,75061,,61026,695
+Washington,Grays Harbor County,2021,76841,,54631,699
+Washington,Grays Harbor County,2022,77038,,62523,797
+Washington,Island County,2005,77698,,46695,720
 Washington,Island County,2006,81489,2228.0,49022,788
 Washington,Island County,2007,81326,1387.0,58857,751
 Washington,Island County,2008,81424,2283.0,55525,848
@@ -12779,13 +12779,13 @@ Washington,Island County,2011,78971,2449.0,59467,933
 Washington,Island County,2012,79177,2643.0,57381,903
 Washington,Island County,2013,78801,2538.0,51893,1011
 Washington,Island County,2014,79275,2975.0,59934,925
-Washington,Island County,2015,80593,0.0,60532,952
+Washington,Island County,2015,80593,,60532,952
 Washington,Island County,2016,82636,2500.0,64813,981
 Washington,Island County,2017,83159,2852.0,59644,942
 Washington,Island County,2018,84460,2197.0,64793,1103
 Washington,Island County,2019,85141,4101.0,72066,1312
-Washington,Island County,2021,87432,0.0,76505,1298
-Washington,Island County,2022,86625,0.0,81783,1465
+Washington,Island County,2021,87432,,76505,1298
+Washington,Island County,2022,86625,,81783,1465
 Washington,King County,2005,1755818,46380.0,58370,762
 Washington,King County,2006,1826732,55605.0,63489,789
 Washington,King County,2007,1859284,48044.0,67010,842
@@ -12820,27 +12820,27 @@ Washington,Kitsap County,2018,269805,7585.0,76945,1151
 Washington,Kitsap County,2019,271473,7447.0,79624,1308
 Washington,Kitsap County,2021,274314,23501.0,87314,1362
 Washington,Kitsap County,2022,277673,18196.0,94775,1549
-Washington,Lewis County,2005,71430,0.0,41712,503
-Washington,Lewis County,2006,73585,0.0,41983,521
-Washington,Lewis County,2007,73645,0.0,43473,614
-Washington,Lewis County,2008,74132,0.0,42513,545
-Washington,Lewis County,2009,74741,0.0,42523,616
-Washington,Lewis County,2010,75487,0.0,38643,580
-Washington,Lewis County,2011,75901,0.0,41931,623
-Washington,Lewis County,2012,75621,0.0,42927,681
-Washington,Lewis County,2013,75081,0.0,40601,658
-Washington,Lewis County,2014,75128,0.0,43575,648
-Washington,Lewis County,2015,75882,0.0,48179,707
-Washington,Lewis County,2016,77066,0.0,45523,676
-Washington,Lewis County,2017,78200,0.0,49827,712
-Washington,Lewis County,2018,79604,0.0,61058,758
-Washington,Lewis County,2019,80707,0.0,58911,719
-Washington,Lewis County,2021,84398,0.0,65047,783
-Washington,Lewis County,2022,85370,0.0,69067,857
-Washington,Mason County,2018,65507,0.0,58094,871
-Washington,Mason County,2019,66768,0.0,63983,771
-Washington,Mason County,2021,67615,0.0,77070,847
-Washington,Mason County,2022,68166,0.0,80139,1001
+Washington,Lewis County,2005,71430,,41712,503
+Washington,Lewis County,2006,73585,,41983,521
+Washington,Lewis County,2007,73645,,43473,614
+Washington,Lewis County,2008,74132,,42513,545
+Washington,Lewis County,2009,74741,,42523,616
+Washington,Lewis County,2010,75487,,38643,580
+Washington,Lewis County,2011,75901,,41931,623
+Washington,Lewis County,2012,75621,,42927,681
+Washington,Lewis County,2013,75081,,40601,658
+Washington,Lewis County,2014,75128,,43575,648
+Washington,Lewis County,2015,75882,,48179,707
+Washington,Lewis County,2016,77066,,45523,676
+Washington,Lewis County,2017,78200,,49827,712
+Washington,Lewis County,2018,79604,,61058,758
+Washington,Lewis County,2019,80707,,58911,719
+Washington,Lewis County,2021,84398,,65047,783
+Washington,Lewis County,2022,85370,,69067,857
+Washington,Mason County,2018,65507,,58094,871
+Washington,Mason County,2019,66768,,63983,771
+Washington,Mason County,2021,67615,,77070,847
+Washington,Mason County,2022,68166,,80139,1001
 Washington,Pierce County,2005,731598,10630.0,49584,675
 Washington,Pierce County,2006,766878,16238.0,53923,694
 Washington,Pierce County,2007,773165,16126.0,55725,728
@@ -12858,7 +12858,7 @@ Washington,Pierce County,2018,891299,24763.0,75407,1152
 Washington,Pierce County,2019,904980,22089.0,79243,1218
 Washington,Pierce County,2021,925708,71869.0,85866,1390
 Washington,Pierce County,2022,927380,68558.0,93420,1561
-Washington,Skagit County,2005,111330,0.0,48773,687
+Washington,Skagit County,2005,111330,,48773,687
 Washington,Skagit County,2006,115700,2299.0,48222,723
 Washington,Skagit County,2007,116397,2725.0,51554,748
 Washington,Skagit County,2008,118000,1934.0,53348,762
@@ -12873,8 +12873,8 @@ Washington,Skagit County,2016,123681,3115.0,60983,881
 Washington,Skagit County,2017,125619,3977.0,66066,949
 Washington,Skagit County,2018,128206,4672.0,73206,993
 Washington,Skagit County,2019,129205,2879.0,67175,957
-Washington,Skagit County,2021,130696,0.0,72648,1066
-Washington,Skagit County,2022,131179,0.0,79001,1274
+Washington,Skagit County,2021,130696,,72648,1066
+Washington,Skagit County,2022,131179,,79001,1274
 Washington,Snohomish County,2005,646299,12564.0,54173,719
 Washington,Snohomish County,2006,669887,15386.0,60002,749
 Washington,Snohomish County,2007,676898,16009.0,65448,827
@@ -12943,10 +12943,10 @@ Washington,Whatcom County,2018,225685,6644.0,62268,1015
 Washington,Whatcom County,2019,229247,8710.0,69372,1021
 Washington,Whatcom County,2021,228831,18391.0,72055,1215
 Washington,Whatcom County,2022,230677,18432.0,79220,1358
-Washington,Yakima County,2005,227809,0.0,34412,471
+Washington,Yakima County,2005,227809,,34412,471
 Washington,Yakima County,2006,233105,3305.0,38909,479
 Washington,Yakima County,2007,233062,2771.0,42686,515
-Washington,Yakima County,2008,234564,0.0,45242,515
+Washington,Yakima County,2008,234564,,45242,515
 Washington,Yakima County,2009,239054,4628.0,41249,545
 Washington,Yakima County,2010,244485,3988.0,40648,583
 Washington,Yakima County,2011,247141,3253.0,42173,591
@@ -12955,131 +12955,131 @@ Washington,Yakima County,2013,247044,3278.0,41917,630
 Washington,Yakima County,2014,247687,2773.0,44648,631
 Washington,Yakima County,2015,248830,5092.0,47223,626
 Washington,Yakima County,2016,249636,3637.0,48965,627
-Washington,Yakima County,2017,250193,0.0,47402,625
+Washington,Yakima County,2017,250193,,47402,625
 Washington,Yakima County,2018,251446,1864.0,51555,660
 Washington,Yakima County,2019,250873,3063.0,56233,695
 Washington,Yakima County,2021,256035,7643.0,61012,770
 Washington,Yakima County,2022,257001,8216.0,63865,880
-West Virginia,Berkeley County,2005,92140,0.0,47796,547
-West Virginia,Berkeley County,2006,97534,0.0,54097,523
-West Virginia,Berkeley County,2007,99734,0.0,54625,589
-West Virginia,Berkeley County,2008,102044,0.0,52857,612
-West Virginia,Berkeley County,2009,103854,0.0,51392,608
-West Virginia,Berkeley County,2010,104641,0.0,50724,532
-West Virginia,Berkeley County,2011,105750,0.0,50526,661
-West Virginia,Berkeley County,2012,107098,0.0,53248,702
-West Virginia,Berkeley County,2013,108706,0.0,55134,679
-West Virginia,Berkeley County,2014,110497,0.0,58754,677
-West Virginia,Berkeley County,2015,111901,0.0,53548,699
-West Virginia,Berkeley County,2016,113525,0.0,57357,783
-West Virginia,Berkeley County,2017,114920,0.0,59142,806
-West Virginia,Berkeley County,2018,117123,0.0,59328,718
-West Virginia,Berkeley County,2019,119171,0.0,62370,794
-West Virginia,Berkeley County,2021,126069,0.0,71733,879
-West Virginia,Berkeley County,2022,129490,0.0,69558,950
-West Virginia,Cabell County,2005,90514,0.0,32832,395
-West Virginia,Cabell County,2006,93904,0.0,34943,423
-West Virginia,Cabell County,2007,94435,0.0,31592,425
-West Virginia,Cabell County,2008,94631,0.0,32008,450
+West Virginia,Berkeley County,2005,92140,,47796,547
+West Virginia,Berkeley County,2006,97534,,54097,523
+West Virginia,Berkeley County,2007,99734,,54625,589
+West Virginia,Berkeley County,2008,102044,,52857,612
+West Virginia,Berkeley County,2009,103854,,51392,608
+West Virginia,Berkeley County,2010,104641,,50724,532
+West Virginia,Berkeley County,2011,105750,,50526,661
+West Virginia,Berkeley County,2012,107098,,53248,702
+West Virginia,Berkeley County,2013,108706,,55134,679
+West Virginia,Berkeley County,2014,110497,,58754,677
+West Virginia,Berkeley County,2015,111901,,53548,699
+West Virginia,Berkeley County,2016,113525,,57357,783
+West Virginia,Berkeley County,2017,114920,,59142,806
+West Virginia,Berkeley County,2018,117123,,59328,718
+West Virginia,Berkeley County,2019,119171,,62370,794
+West Virginia,Berkeley County,2021,126069,,71733,879
+West Virginia,Berkeley County,2022,129490,,69558,950
+West Virginia,Cabell County,2005,90514,,32832,395
+West Virginia,Cabell County,2006,93904,,34943,423
+West Virginia,Cabell County,2007,94435,,31592,425
+West Virginia,Cabell County,2008,94631,,32008,450
 West Virginia,Cabell County,2009,95214,1660.0,34684,462
-West Virginia,Cabell County,2010,96378,0.0,36153,463
-West Virginia,Cabell County,2011,96653,0.0,37279,478
-West Virginia,Cabell County,2012,96974,0.0,35567,502
-West Virginia,Cabell County,2013,97133,0.0,39019,505
-West Virginia,Cabell County,2014,97109,0.0,34046,500
-West Virginia,Cabell County,2015,96844,0.0,38839,536
-West Virginia,Cabell County,2016,95987,0.0,38823,555
-West Virginia,Cabell County,2017,94958,0.0,33750,537
-West Virginia,Cabell County,2018,93224,0.0,38162,619
-West Virginia,Cabell County,2019,91945,0.0,40788,565
-West Virginia,Cabell County,2021,93418,0.0,47020,625
-West Virginia,Cabell County,2022,92730,0.0,52237,666
-West Virginia,Harrison County,2005,67252,0.0,37086,290
-West Virginia,Harrison County,2006,68745,0.0,37512,400
-West Virginia,Harrison County,2007,68309,0.0,37899,373
-West Virginia,Harrison County,2008,68853,0.0,38346,379
-West Virginia,Harrison County,2009,68911,0.0,40941,387
-West Virginia,Harrison County,2010,69233,0.0,40589,419
-West Virginia,Harrison County,2011,69436,0.0,38795,421
-West Virginia,Harrison County,2012,69141,0.0,40022,464
-West Virginia,Harrison County,2013,68972,0.0,41698,478
-West Virginia,Harrison County,2014,68761,0.0,41333,497
-West Virginia,Harrison County,2015,68714,0.0,48285,472
-West Virginia,Harrison County,2016,68400,0.0,47204,511
-West Virginia,Harrison County,2017,67811,0.0,58082,580
-West Virginia,Harrison County,2018,67554,0.0,46569,588
-West Virginia,Harrison County,2019,67256,0.0,54314,611
-West Virginia,Harrison County,2021,65158,0.0,51533,617
-West Virginia,Harrison County,2022,64915,0.0,58092,669
-West Virginia,Kanawha County,2005,190137,0.0,38807,413
+West Virginia,Cabell County,2010,96378,,36153,463
+West Virginia,Cabell County,2011,96653,,37279,478
+West Virginia,Cabell County,2012,96974,,35567,502
+West Virginia,Cabell County,2013,97133,,39019,505
+West Virginia,Cabell County,2014,97109,,34046,500
+West Virginia,Cabell County,2015,96844,,38839,536
+West Virginia,Cabell County,2016,95987,,38823,555
+West Virginia,Cabell County,2017,94958,,33750,537
+West Virginia,Cabell County,2018,93224,,38162,619
+West Virginia,Cabell County,2019,91945,,40788,565
+West Virginia,Cabell County,2021,93418,,47020,625
+West Virginia,Cabell County,2022,92730,,52237,666
+West Virginia,Harrison County,2005,67252,,37086,290
+West Virginia,Harrison County,2006,68745,,37512,400
+West Virginia,Harrison County,2007,68309,,37899,373
+West Virginia,Harrison County,2008,68853,,38346,379
+West Virginia,Harrison County,2009,68911,,40941,387
+West Virginia,Harrison County,2010,69233,,40589,419
+West Virginia,Harrison County,2011,69436,,38795,421
+West Virginia,Harrison County,2012,69141,,40022,464
+West Virginia,Harrison County,2013,68972,,41698,478
+West Virginia,Harrison County,2014,68761,,41333,497
+West Virginia,Harrison County,2015,68714,,48285,472
+West Virginia,Harrison County,2016,68400,,47204,511
+West Virginia,Harrison County,2017,67811,,58082,580
+West Virginia,Harrison County,2018,67554,,46569,588
+West Virginia,Harrison County,2019,67256,,54314,611
+West Virginia,Harrison County,2021,65158,,51533,617
+West Virginia,Harrison County,2022,64915,,58092,669
+West Virginia,Kanawha County,2005,190137,,38807,413
 West Virginia,Kanawha County,2006,192419,2239.0,36166,418
 West Virginia,Kanawha County,2007,191306,2384.0,40936,448
 West Virginia,Kanawha County,2008,191018,2725.0,41522,432
-West Virginia,Kanawha County,2009,191663,0.0,41960,472
-West Virginia,Kanawha County,2010,192976,0.0,43474,472
+West Virginia,Kanawha County,2009,191663,,41960,472
+West Virginia,Kanawha County,2010,192976,,43474,472
 West Virginia,Kanawha County,2011,192315,2352.0,39928,520
 West Virginia,Kanawha County,2012,192179,3051.0,46914,512
 West Virginia,Kanawha County,2013,191275,2107.0,46325,494
 West Virginia,Kanawha County,2014,190223,1401.0,44186,532
-West Virginia,Kanawha County,2015,188332,0.0,45028,543
+West Virginia,Kanawha County,2015,188332,,45028,543
 West Virginia,Kanawha County,2016,186241,2688.0,45001,535
 West Virginia,Kanawha County,2017,183293,3214.0,42197,511
-West Virginia,Kanawha County,2018,180454,0.0,41141,582
+West Virginia,Kanawha County,2018,180454,,41141,582
 West Virginia,Kanawha County,2019,178124,3129.0,47759,545
 West Virginia,Kanawha County,2021,177952,7009.0,56122,657
-West Virginia,Kanawha County,2022,175515,0.0,55215,619
-West Virginia,Monongalia County,2005,77321,0.0,31333,480
-West Virginia,Monongalia County,2006,84752,0.0,35222,477
-West Virginia,Monongalia County,2007,87516,0.0,42064,501
-West Virginia,Monongalia County,2008,88221,0.0,42414,490
-West Virginia,Monongalia County,2009,90080,0.0,32477,514
-West Virginia,Monongalia County,2010,96791,0.0,42028,591
-West Virginia,Monongalia County,2011,98528,0.0,44049,609
-West Virginia,Monongalia County,2012,100332,0.0,39532,577
-West Virginia,Monongalia County,2013,102274,0.0,49534,633
-West Virginia,Monongalia County,2014,103463,0.0,41955,664
+West Virginia,Kanawha County,2022,175515,,55215,619
+West Virginia,Monongalia County,2005,77321,,31333,480
+West Virginia,Monongalia County,2006,84752,,35222,477
+West Virginia,Monongalia County,2007,87516,,42064,501
+West Virginia,Monongalia County,2008,88221,,42414,490
+West Virginia,Monongalia County,2009,90080,,32477,514
+West Virginia,Monongalia County,2010,96791,,42028,591
+West Virginia,Monongalia County,2011,98528,,44049,609
+West Virginia,Monongalia County,2012,100332,,39532,577
+West Virginia,Monongalia County,2013,102274,,49534,633
+West Virginia,Monongalia County,2014,103463,,41955,664
 West Virginia,Monongalia County,2015,104236,1928.0,45880,788
 West Virginia,Monongalia County,2016,104622,3083.0,50953,661
-West Virginia,Monongalia County,2017,105030,0.0,50888,697
-West Virginia,Monongalia County,2018,106420,0.0,50834,716
-West Virginia,Monongalia County,2019,105612,0.0,55940,680
-West Virginia,Monongalia County,2021,106387,0.0,56347,734
-West Virginia,Monongalia County,2022,106869,0.0,55708,763
-West Virginia,Raleigh County,2005,75436,0.0,30818,382
-West Virginia,Raleigh County,2006,79302,0.0,38924,373
-West Virginia,Raleigh County,2007,79170,0.0,39498,383
-West Virginia,Raleigh County,2008,79357,0.0,33803,428
-West Virginia,Raleigh County,2009,79187,0.0,35170,405
-West Virginia,Raleigh County,2010,78904,0.0,37982,395
-West Virginia,Raleigh County,2011,79127,0.0,38304,427
-West Virginia,Raleigh County,2012,79021,0.0,40705,446
-West Virginia,Raleigh County,2013,78833,0.0,40178,475
-West Virginia,Raleigh County,2014,78241,0.0,40561,545
-West Virginia,Raleigh County,2015,77510,0.0,37262,465
-West Virginia,Raleigh County,2016,76601,0.0,45863,529
-West Virginia,Raleigh County,2017,75022,0.0,42121,502
-West Virginia,Raleigh County,2018,74254,0.0,39122,540
-West Virginia,Raleigh County,2019,73361,0.0,46540,563
-West Virginia,Raleigh County,2021,73771,0.0,38687,551
-West Virginia,Raleigh County,2022,72882,0.0,51705,545
-West Virginia,Wood County,2005,85634,0.0,32438,375
-West Virginia,Wood County,2006,86597,0.0,36542,406
-West Virginia,Wood County,2007,86088,0.0,40073,394
-West Virginia,Wood County,2008,86204,0.0,42410,419
-West Virginia,Wood County,2009,86888,0.0,39416,429
-West Virginia,Wood County,2010,86990,0.0,39689,428
-West Virginia,Wood County,2011,87120,0.0,36954,444
-West Virginia,Wood County,2012,86701,0.0,42857,426
-West Virginia,Wood County,2013,86569,0.0,41408,465
-West Virginia,Wood County,2014,86237,0.0,42014,460
-West Virginia,Wood County,2015,86452,0.0,39991,508
-West Virginia,Wood County,2016,85643,0.0,48655,529
-West Virginia,Wood County,2017,85104,0.0,44115,550
-West Virginia,Wood County,2018,84203,0.0,43563,575
-West Virginia,Wood County,2019,83518,0.0,47944,555
-West Virginia,Wood County,2021,83624,0.0,54153,569
-West Virginia,Wood County,2022,83340,0.0,58787,612
-Wisconsin,Brown County,2005,231333,0.0,48460,554
+West Virginia,Monongalia County,2017,105030,,50888,697
+West Virginia,Monongalia County,2018,106420,,50834,716
+West Virginia,Monongalia County,2019,105612,,55940,680
+West Virginia,Monongalia County,2021,106387,,56347,734
+West Virginia,Monongalia County,2022,106869,,55708,763
+West Virginia,Raleigh County,2005,75436,,30818,382
+West Virginia,Raleigh County,2006,79302,,38924,373
+West Virginia,Raleigh County,2007,79170,,39498,383
+West Virginia,Raleigh County,2008,79357,,33803,428
+West Virginia,Raleigh County,2009,79187,,35170,405
+West Virginia,Raleigh County,2010,78904,,37982,395
+West Virginia,Raleigh County,2011,79127,,38304,427
+West Virginia,Raleigh County,2012,79021,,40705,446
+West Virginia,Raleigh County,2013,78833,,40178,475
+West Virginia,Raleigh County,2014,78241,,40561,545
+West Virginia,Raleigh County,2015,77510,,37262,465
+West Virginia,Raleigh County,2016,76601,,45863,529
+West Virginia,Raleigh County,2017,75022,,42121,502
+West Virginia,Raleigh County,2018,74254,,39122,540
+West Virginia,Raleigh County,2019,73361,,46540,563
+West Virginia,Raleigh County,2021,73771,,38687,551
+West Virginia,Raleigh County,2022,72882,,51705,545
+West Virginia,Wood County,2005,85634,,32438,375
+West Virginia,Wood County,2006,86597,,36542,406
+West Virginia,Wood County,2007,86088,,40073,394
+West Virginia,Wood County,2008,86204,,42410,419
+West Virginia,Wood County,2009,86888,,39416,429
+West Virginia,Wood County,2010,86990,,39689,428
+West Virginia,Wood County,2011,87120,,36954,444
+West Virginia,Wood County,2012,86701,,42857,426
+West Virginia,Wood County,2013,86569,,41408,465
+West Virginia,Wood County,2014,86237,,42014,460
+West Virginia,Wood County,2015,86452,,39991,508
+West Virginia,Wood County,2016,85643,,48655,529
+West Virginia,Wood County,2017,85104,,44115,550
+West Virginia,Wood County,2018,84203,,43563,575
+West Virginia,Wood County,2019,83518,,47944,555
+West Virginia,Wood County,2021,83624,,54153,569
+West Virginia,Wood County,2022,83340,,58787,612
+Wisconsin,Brown County,2005,231333,,48460,554
 Wisconsin,Brown County,2006,240213,3612.0,49978,550
 Wisconsin,Brown County,2007,243132,3102.0,52139,547
 Wisconsin,Brown County,2008,245018,6009.0,52869,550
@@ -13096,8 +13096,8 @@ Wisconsin,Brown County,2018,263378,5414.0,61651,709
 Wisconsin,Brown County,2019,264542,6693.0,64458,697
 Wisconsin,Brown County,2021,269591,20148.0,66191,744
 Wisconsin,Brown County,2022,270036,16471.0,71127,771
-Wisconsin,Chippewa County,2021,66865,0.0,60533,641
-Wisconsin,Chippewa County,2022,66807,0.0,75128,691
+Wisconsin,Chippewa County,2021,66865,,60533,641
+Wisconsin,Chippewa County,2022,66807,,75128,691
 Wisconsin,Dane County,2005,442336,9516.0,53537,683
 Wisconsin,Dane County,2006,463826,9442.0,57693,692
 Wisconsin,Dane County,2007,476785,10831.0,60791,723
@@ -13115,47 +13115,47 @@ Wisconsin,Dane County,2018,542364,13730.0,71582,968
 Wisconsin,Dane County,2019,546695,18149.0,77504,1017
 Wisconsin,Dane County,2021,563951,76358.0,77221,1090
 Wisconsin,Dane County,2022,568203,64396.0,84831,1162
-Wisconsin,Dodge County,2005,82177,0.0,50086,514
+Wisconsin,Dodge County,2005,82177,,50086,514
 Wisconsin,Dodge County,2006,88983,1746.0,49266,536
-Wisconsin,Dodge County,2007,87786,0.0,51269,574
+Wisconsin,Dodge County,2007,87786,,51269,574
 Wisconsin,Dodge County,2008,87912,1579.0,52397,569
 Wisconsin,Dodge County,2009,87335,1842.0,49883,563
-Wisconsin,Dodge County,2010,88748,0.0,50797,603
-Wisconsin,Dodge County,2011,88661,0.0,51948,610
+Wisconsin,Dodge County,2010,88748,,50797,603
+Wisconsin,Dodge County,2011,88661,,51948,610
 Wisconsin,Dodge County,2012,88415,1147.0,50781,635
-Wisconsin,Dodge County,2013,88344,0.0,51151,595
-Wisconsin,Dodge County,2014,88574,0.0,53139,643
-Wisconsin,Dodge County,2015,88502,0.0,55832,642
-Wisconsin,Dodge County,2016,88068,0.0,55856,606
-Wisconsin,Dodge County,2017,87786,0.0,56421,633
-Wisconsin,Dodge County,2018,87847,0.0,63077,672
-Wisconsin,Dodge County,2019,87839,0.0,61300,705
-Wisconsin,Dodge County,2021,89313,0.0,65773,694
-Wisconsin,Dodge County,2022,88282,0.0,67762,779
-Wisconsin,Eau Claire County,2005,89003,0.0,41384,492
+Wisconsin,Dodge County,2013,88344,,51151,595
+Wisconsin,Dodge County,2014,88574,,53139,643
+Wisconsin,Dodge County,2015,88502,,55832,642
+Wisconsin,Dodge County,2016,88068,,55856,606
+Wisconsin,Dodge County,2017,87786,,56421,633
+Wisconsin,Dodge County,2018,87847,,63077,672
+Wisconsin,Dodge County,2019,87839,,61300,705
+Wisconsin,Dodge County,2021,89313,,65773,694
+Wisconsin,Dodge County,2022,88282,,67762,779
+Wisconsin,Eau Claire County,2005,89003,,41384,492
 Wisconsin,Eau Claire County,2006,94741,2530.0,46927,518
 Wisconsin,Eau Claire County,2007,97406,2096.0,43146,504
 Wisconsin,Eau Claire County,2008,98286,1573.0,48308,525
 Wisconsin,Eau Claire County,2009,99409,1349.0,43370,532
-Wisconsin,Eau Claire County,2010,98928,0.0,42807,540
+Wisconsin,Eau Claire County,2010,98928,,42807,540
 Wisconsin,Eau Claire County,2011,99879,3217.0,48167,581
 Wisconsin,Eau Claire County,2012,100677,2516.0,47913,590
 Wisconsin,Eau Claire County,2013,101438,2727.0,49204,598
 Wisconsin,Eau Claire County,2014,101564,3930.0,47043,629
 Wisconsin,Eau Claire County,2015,102105,2703.0,51667,656
-Wisconsin,Eau Claire County,2016,102965,0.0,49821,667
-Wisconsin,Eau Claire County,2017,103671,0.0,54963,669
+Wisconsin,Eau Claire County,2016,102965,,49821,667
+Wisconsin,Eau Claire County,2017,103671,,54963,669
 Wisconsin,Eau Claire County,2018,104534,3584.0,60475,705
 Wisconsin,Eau Claire County,2019,104646,4498.0,65662,712
-Wisconsin,Eau Claire County,2021,106452,0.0,62445,738
-Wisconsin,Eau Claire County,2022,106837,0.0,70411,831
-Wisconsin,Fond du Lac County,2005,94964,0.0,48186,483
+Wisconsin,Eau Claire County,2021,106452,,62445,738
+Wisconsin,Eau Claire County,2022,106837,,70411,831
+Wisconsin,Fond du Lac County,2005,94964,,48186,483
 Wisconsin,Fond du Lac County,2006,99243,1291.0,48551,515
 Wisconsin,Fond du Lac County,2007,99124,2333.0,50024,502
 Wisconsin,Fond du Lac County,2008,99453,2187.0,52937,522
-Wisconsin,Fond du Lac County,2009,100070,0.0,50216,543
+Wisconsin,Fond du Lac County,2009,100070,,50216,543
 Wisconsin,Fond du Lac County,2010,101665,2360.0,49718,535
-Wisconsin,Fond du Lac County,2011,102079,0.0,53202,547
+Wisconsin,Fond du Lac County,2011,102079,,53202,547
 Wisconsin,Fond du Lac County,2012,101843,2021.0,53065,582
 Wisconsin,Fond du Lac County,2013,101798,1634.0,54198,623
 Wisconsin,Fond du Lac County,2014,101759,2077.0,51717,585
@@ -13163,27 +13163,27 @@ Wisconsin,Fond du Lac County,2015,101973,2441.0,57620,587
 Wisconsin,Fond du Lac County,2016,102144,2281.0,58310,604
 Wisconsin,Fond du Lac County,2017,102548,1947.0,61417,637
 Wisconsin,Fond du Lac County,2018,103066,1842.0,57415,635
-Wisconsin,Fond du Lac County,2019,103403,0.0,65329,647
+Wisconsin,Fond du Lac County,2019,103403,,65329,647
 Wisconsin,Fond du Lac County,2021,104362,5901.0,69068,693
 Wisconsin,Fond du Lac County,2022,103836,4889.0,69948,731
-Wisconsin,Jefferson County,2005,75761,0.0,47362,546
-Wisconsin,Jefferson County,2006,80025,0.0,50852,599
-Wisconsin,Jefferson County,2007,80213,0.0,54659,566
+Wisconsin,Jefferson County,2005,75761,,47362,546
+Wisconsin,Jefferson County,2006,80025,,50852,599
+Wisconsin,Jefferson County,2007,80213,,54659,566
 Wisconsin,Jefferson County,2008,80792,1455.0,55581,600
 Wisconsin,Jefferson County,2009,80833,1568.0,52833,595
-Wisconsin,Jefferson County,2010,83693,0.0,49611,598
-Wisconsin,Jefferson County,2011,83943,0.0,53217,625
+Wisconsin,Jefferson County,2010,83693,,49611,598
+Wisconsin,Jefferson County,2011,83943,,53217,625
 Wisconsin,Jefferson County,2012,84498,1735.0,53675,595
-Wisconsin,Jefferson County,2013,84509,0.0,51235,620
-Wisconsin,Jefferson County,2014,84395,0.0,55675,671
+Wisconsin,Jefferson County,2013,84509,,51235,620
+Wisconsin,Jefferson County,2014,84395,,55675,671
 Wisconsin,Jefferson County,2015,84559,1913.0,62399,644
-Wisconsin,Jefferson County,2016,84625,0.0,58703,665
-Wisconsin,Jefferson County,2017,84832,0.0,56675,686
-Wisconsin,Jefferson County,2018,85129,0.0,65651,699
-Wisconsin,Jefferson County,2019,84769,0.0,71708,736
-Wisconsin,Jefferson County,2021,84943,0.0,68319,767
-Wisconsin,Jefferson County,2022,85784,0.0,78628,838
-Wisconsin,Kenosha County,2005,156308,0.0,53035,634
+Wisconsin,Jefferson County,2016,84625,,58703,665
+Wisconsin,Jefferson County,2017,84832,,56675,686
+Wisconsin,Jefferson County,2018,85129,,65651,699
+Wisconsin,Jefferson County,2019,84769,,71708,736
+Wisconsin,Jefferson County,2021,84943,,68319,767
+Wisconsin,Jefferson County,2022,85784,,78628,838
+Wisconsin,Kenosha County,2005,156308,,53035,634
 Wisconsin,Kenosha County,2006,162001,1596.0,51941,632
 Wisconsin,Kenosha County,2007,162921,2508.0,53117,660
 Wisconsin,Kenosha County,2008,164465,2496.0,55025,691
@@ -13200,41 +13200,41 @@ Wisconsin,Kenosha County,2018,169290,2033.0,65330,769
 Wisconsin,Kenosha County,2019,169561,2958.0,65997,850
 Wisconsin,Kenosha County,2021,168732,8729.0,70971,916
 Wisconsin,Kenosha County,2022,167817,9836.0,74534,902
-Wisconsin,La Crosse County,2005,103687,0.0,43488,480
+Wisconsin,La Crosse County,2005,103687,,43488,480
 Wisconsin,La Crosse County,2006,109404,2358.0,44785,476
-Wisconsin,La Crosse County,2007,111411,0.0,48474,553
+Wisconsin,La Crosse County,2007,111411,,48474,553
 Wisconsin,La Crosse County,2008,112627,3083.0,48626,504
 Wisconsin,La Crosse County,2009,113679,2674.0,50245,580
 Wisconsin,La Crosse County,2010,114874,2702.0,47085,570
 Wisconsin,La Crosse County,2011,115572,1865.0,49966,589
-Wisconsin,La Crosse County,2012,116461,0.0,47360,631
+Wisconsin,La Crosse County,2012,116461,,47360,631
 Wisconsin,La Crosse County,2013,116713,1880.0,51551,595
 Wisconsin,La Crosse County,2014,118011,1825.0,48872,650
 Wisconsin,La Crosse County,2015,118212,1472.0,49933,644
 Wisconsin,La Crosse County,2016,118122,2779.0,54823,681
 Wisconsin,La Crosse County,2017,118274,2210.0,57033,701
-Wisconsin,La Crosse County,2018,118230,0.0,60905,740
+Wisconsin,La Crosse County,2018,118230,,60905,740
 Wisconsin,La Crosse County,2019,118016,3848.0,58921,737
 Wisconsin,La Crosse County,2021,120433,7086.0,60382,825
 Wisconsin,La Crosse County,2022,120294,6395.0,69492,794
-Wisconsin,Manitowoc County,2005,80612,0.0,44418,403
-Wisconsin,Manitowoc County,2006,81911,0.0,46926,417
+Wisconsin,Manitowoc County,2005,80612,,44418,403
+Wisconsin,Manitowoc County,2006,81911,,46926,417
 Wisconsin,Manitowoc County,2007,80928,2245.0,47382,437
-Wisconsin,Manitowoc County,2008,80641,0.0,49755,458
-Wisconsin,Manitowoc County,2009,80583,0.0,48088,456
-Wisconsin,Manitowoc County,2010,81349,0.0,47298,454
-Wisconsin,Manitowoc County,2011,80976,0.0,48272,488
+Wisconsin,Manitowoc County,2008,80641,,49755,458
+Wisconsin,Manitowoc County,2009,80583,,48088,456
+Wisconsin,Manitowoc County,2010,81349,,47298,454
+Wisconsin,Manitowoc County,2011,80976,,48272,488
 Wisconsin,Manitowoc County,2012,80671,1076.0,46045,490
 Wisconsin,Manitowoc County,2013,80654,1269.0,47181,497
-Wisconsin,Manitowoc County,2014,80160,0.0,45136,474
-Wisconsin,Manitowoc County,2015,79806,0.0,50302,487
+Wisconsin,Manitowoc County,2014,80160,,45136,474
+Wisconsin,Manitowoc County,2015,79806,,50302,487
 Wisconsin,Manitowoc County,2016,79536,1882.0,51752,544
-Wisconsin,Manitowoc County,2017,79175,0.0,54785,555
+Wisconsin,Manitowoc County,2017,79175,,54785,555
 Wisconsin,Manitowoc County,2018,79074,1619.0,54393,520
 Wisconsin,Manitowoc County,2019,78981,2063.0,60785,598
-Wisconsin,Manitowoc County,2021,81505,0.0,57918,583
+Wisconsin,Manitowoc County,2021,81505,,57918,583
 Wisconsin,Manitowoc County,2022,81172,2843.0,61673,633
-Wisconsin,Marathon County,2005,127080,0.0,49906,479
+Wisconsin,Marathon County,2005,127080,,49906,479
 Wisconsin,Marathon County,2006,130223,2339.0,50443,478
 Wisconsin,Marathon County,2007,129958,2682.0,53377,462
 Wisconsin,Marathon County,2008,130962,2245.0,54649,545
@@ -13285,41 +13285,41 @@ Wisconsin,Outagamie County,2018,187365,4258.0,64759,674
 Wisconsin,Outagamie County,2019,187885,4254.0,66234,714
 Wisconsin,Outagamie County,2021,191545,14791.0,73057,727
 Wisconsin,Outagamie County,2022,192127,11560.0,78234,828
-Wisconsin,Ozaukee County,2005,84295,0.0,74730,632
-Wisconsin,Ozaukee County,2006,86321,0.0,69452,630
-Wisconsin,Ozaukee County,2007,85602,0.0,74665,633
-Wisconsin,Ozaukee County,2008,85874,0.0,69376,666
-Wisconsin,Ozaukee County,2009,86311,0.0,72905,712
-Wisconsin,Ozaukee County,2010,86365,0.0,72213,645
-Wisconsin,Ozaukee County,2011,86568,0.0,73703,673
-Wisconsin,Ozaukee County,2012,86823,0.0,75170,743
-Wisconsin,Ozaukee County,2013,87054,0.0,70899,671
+Wisconsin,Ozaukee County,2005,84295,,74730,632
+Wisconsin,Ozaukee County,2006,86321,,69452,630
+Wisconsin,Ozaukee County,2007,85602,,74665,633
+Wisconsin,Ozaukee County,2008,85874,,69376,666
+Wisconsin,Ozaukee County,2009,86311,,72905,712
+Wisconsin,Ozaukee County,2010,86365,,72213,645
+Wisconsin,Ozaukee County,2011,86568,,73703,673
+Wisconsin,Ozaukee County,2012,86823,,75170,743
+Wisconsin,Ozaukee County,2013,87054,,70899,671
 Wisconsin,Ozaukee County,2014,87470,2374.0,72103,697
-Wisconsin,Ozaukee County,2015,87850,0.0,79048,751
-Wisconsin,Ozaukee County,2016,88314,0.0,84415,788
-Wisconsin,Ozaukee County,2017,88429,0.0,82869,772
-Wisconsin,Ozaukee County,2018,89147,0.0,81104,848
-Wisconsin,Ozaukee County,2019,89221,0.0,88154,788
-Wisconsin,Ozaukee County,2021,92497,0.0,85402,850
-Wisconsin,Ozaukee County,2022,93009,0.0,88781,961
-Wisconsin,Portage County,2005,64103,0.0,46399,521
+Wisconsin,Ozaukee County,2015,87850,,79048,751
+Wisconsin,Ozaukee County,2016,88314,,84415,788
+Wisconsin,Ozaukee County,2017,88429,,82869,772
+Wisconsin,Ozaukee County,2018,89147,,81104,848
+Wisconsin,Ozaukee County,2019,89221,,88154,788
+Wisconsin,Ozaukee County,2021,92497,,85402,850
+Wisconsin,Ozaukee County,2022,93009,,88781,961
+Wisconsin,Portage County,2005,64103,,46399,521
 Wisconsin,Portage County,2006,67484,1030.0,52354,504
 Wisconsin,Portage County,2007,68272,1512.0,48715,490
 Wisconsin,Portage County,2008,68744,1084.0,49858,475
 Wisconsin,Portage County,2009,69176,1342.0,50282,527
-Wisconsin,Portage County,2010,70053,0.0,48620,560
-Wisconsin,Portage County,2011,70084,0.0,49680,568
+Wisconsin,Portage County,2010,70053,,48620,560
+Wisconsin,Portage County,2011,70084,,49680,568
 Wisconsin,Portage County,2012,70433,1017.0,45215,568
-Wisconsin,Portage County,2013,70380,0.0,49872,573
-Wisconsin,Portage County,2014,70482,0.0,51399,527
-Wisconsin,Portage County,2015,70408,0.0,57244,620
-Wisconsin,Portage County,2016,70447,0.0,53655,597
-Wisconsin,Portage County,2017,70474,0.0,52247,672
-Wisconsin,Portage County,2018,70942,0.0,57452,679
+Wisconsin,Portage County,2013,70380,,49872,573
+Wisconsin,Portage County,2014,70482,,51399,527
+Wisconsin,Portage County,2015,70408,,57244,620
+Wisconsin,Portage County,2016,70447,,53655,597
+Wisconsin,Portage County,2017,70474,,52247,672
+Wisconsin,Portage County,2018,70942,,57452,679
 Wisconsin,Portage County,2019,70772,1584.0,56358,694
-Wisconsin,Portage County,2021,70468,0.0,65928,716
-Wisconsin,Portage County,2022,70718,0.0,70061,703
-Wisconsin,Racine County,2005,190368,0.0,50465,548
+Wisconsin,Portage County,2021,70468,,65928,716
+Wisconsin,Portage County,2022,70718,,70061,703
+Wisconsin,Racine County,2005,190368,,50465,548
 Wisconsin,Racine County,2006,196096,2401.0,50758,537
 Wisconsin,Racine County,2007,195099,2001.0,51375,570
 Wisconsin,Racine County,2008,199510,2352.0,54541,580
@@ -13331,12 +13331,12 @@ Wisconsin,Racine County,2013,195041,3082.0,54209,645
 Wisconsin,Racine County,2014,195163,3832.0,54525,643
 Wisconsin,Racine County,2015,195080,3066.0,57232,672
 Wisconsin,Racine County,2016,195140,2790.0,55706,676
-Wisconsin,Racine County,2017,196071,0.0,60897,691
+Wisconsin,Racine County,2017,196071,,60897,691
 Wisconsin,Racine County,2018,196584,4042.0,59759,713
 Wisconsin,Racine County,2019,196311,3260.0,60779,715
 Wisconsin,Racine County,2021,196896,10812.0,68758,762
 Wisconsin,Racine County,2022,195846,8867.0,71788,839
-Wisconsin,Rock County,2005,154296,0.0,46267,515
+Wisconsin,Rock County,2005,154296,,46267,515
 Wisconsin,Rock County,2006,159153,2010.0,46190,526
 Wisconsin,Rock County,2007,159623,2762.0,48663,550
 Wisconsin,Rock County,2008,160213,2875.0,51400,562
@@ -13348,82 +13348,82 @@ Wisconsin,Rock County,2013,160739,3270.0,47118,611
 Wisconsin,Rock County,2014,161188,2940.0,50610,629
 Wisconsin,Rock County,2015,161448,2145.0,53777,631
 Wisconsin,Rock County,2016,161620,2255.0,50729,626
-Wisconsin,Rock County,2017,162309,0.0,55304,666
+Wisconsin,Rock County,2017,162309,,55304,666
 Wisconsin,Rock County,2018,163129,2722.0,57037,686
 Wisconsin,Rock County,2019,163354,2492.0,61243,728
-Wisconsin,Rock County,2021,164381,0.0,66090,748
+Wisconsin,Rock County,2021,164381,,66090,748
 Wisconsin,Rock County,2022,164060,7467.0,66451,828
-Wisconsin,St. Croix County,2005,76227,0.0,65999,634
+Wisconsin,St. Croix County,2005,76227,,65999,634
 Wisconsin,St. Croix County,2006,80015,2196.0,67199,674
-Wisconsin,St. Croix County,2007,81131,0.0,65691,687
+Wisconsin,St. Croix County,2007,81131,,65691,687
 Wisconsin,St. Croix County,2008,82487,1656.0,68592,753
-Wisconsin,St. Croix County,2009,83351,0.0,65551,674
-Wisconsin,St. Croix County,2010,84442,0.0,62386,682
-Wisconsin,St. Croix County,2011,84922,0.0,61811,688
+Wisconsin,St. Croix County,2009,83351,,65551,674
+Wisconsin,St. Croix County,2010,84442,,62386,682
+Wisconsin,St. Croix County,2011,84922,,61811,688
 Wisconsin,St. Croix County,2012,85242,2755.0,67870,770
-Wisconsin,St. Croix County,2013,85930,0.0,67502,739
-Wisconsin,St. Croix County,2014,86759,0.0,76024,775
+Wisconsin,St. Croix County,2013,85930,,67502,739
+Wisconsin,St. Croix County,2014,86759,,76024,775
 Wisconsin,St. Croix County,2015,87513,2507.0,71449,730
-Wisconsin,St. Croix County,2016,88029,0.0,72865,834
+Wisconsin,St. Croix County,2016,88029,,72865,834
 Wisconsin,St. Croix County,2017,88703,2522.0,80512,747
-Wisconsin,St. Croix County,2018,89694,0.0,81453,805
-Wisconsin,St. Croix County,2019,90687,0.0,85594,851
-Wisconsin,St. Croix County,2021,95044,0.0,93547,1022
-Wisconsin,St. Croix County,2022,96017,0.0,96130,857
-Wisconsin,Sauk County,2021,65697,0.0,70914,732
+Wisconsin,St. Croix County,2018,89694,,81453,805
+Wisconsin,St. Croix County,2019,90687,,85594,851
+Wisconsin,St. Croix County,2021,95044,,93547,1022
+Wisconsin,St. Croix County,2022,96017,,96130,857
+Wisconsin,Sauk County,2021,65697,,70914,732
 Wisconsin,Sauk County,2022,65777,3614.0,69475,815
-Wisconsin,Sheboygan County,2005,111100,0.0,51034,481
+Wisconsin,Sheboygan County,2005,111100,,51034,481
 Wisconsin,Sheboygan County,2006,114756,2082.0,46375,479
 Wisconsin,Sheboygan County,2007,114504,1775.0,52082,484
 Wisconsin,Sheboygan County,2008,114561,1636.0,51881,507
 Wisconsin,Sheboygan County,2009,114560,2296.0,52217,526
-Wisconsin,Sheboygan County,2010,115472,0.0,49440,513
+Wisconsin,Sheboygan County,2010,115472,,49440,513
 Wisconsin,Sheboygan County,2011,115149,1969.0,50935,519
 Wisconsin,Sheboygan County,2012,115009,1656.0,51899,517
-Wisconsin,Sheboygan County,2013,114922,0.0,50678,540
+Wisconsin,Sheboygan County,2013,114922,,50678,540
 Wisconsin,Sheboygan County,2014,115290,2180.0,54042,558
 Wisconsin,Sheboygan County,2015,115569,1841.0,57047,546
 Wisconsin,Sheboygan County,2016,115427,2762.0,54059,569
 Wisconsin,Sheboygan County,2017,115344,3227.0,58361,600
-Wisconsin,Sheboygan County,2018,115456,0.0,60896,611
-Wisconsin,Sheboygan County,2019,115340,0.0,60706,644
-Wisconsin,Sheboygan County,2021,117747,0.0,62188,661
-Wisconsin,Sheboygan County,2022,117841,0.0,62978,744
-Wisconsin,Walworth County,2005,96394,0.0,48656,587
-Wisconsin,Walworth County,2006,101007,0.0,51846,588
-Wisconsin,Walworth County,2007,100800,0.0,54022,586
-Wisconsin,Walworth County,2008,100749,0.0,54190,656
+Wisconsin,Sheboygan County,2018,115456,,60896,611
+Wisconsin,Sheboygan County,2019,115340,,60706,644
+Wisconsin,Sheboygan County,2021,117747,,62188,661
+Wisconsin,Sheboygan County,2022,117841,,62978,744
+Wisconsin,Walworth County,2005,96394,,48656,587
+Wisconsin,Walworth County,2006,101007,,51846,588
+Wisconsin,Walworth County,2007,100800,,54022,586
+Wisconsin,Walworth County,2008,100749,,54190,656
 Wisconsin,Walworth County,2009,100593,2967.0,49482,652
-Wisconsin,Walworth County,2010,102205,0.0,53388,639
-Wisconsin,Walworth County,2011,102931,0.0,52250,711
-Wisconsin,Walworth County,2012,102851,0.0,48940,680
-Wisconsin,Walworth County,2013,102945,0.0,52057,662
+Wisconsin,Walworth County,2010,102205,,53388,639
+Wisconsin,Walworth County,2011,102931,,52250,711
+Wisconsin,Walworth County,2012,102851,,48940,680
+Wisconsin,Walworth County,2013,102945,,52057,662
 Wisconsin,Walworth County,2014,103527,2499.0,52277,648
-Wisconsin,Walworth County,2015,102804,0.0,58537,704
-Wisconsin,Walworth County,2016,102959,0.0,58302,710
-Wisconsin,Walworth County,2017,103082,0.0,60178,728
-Wisconsin,Walworth County,2018,103718,0.0,63800,732
+Wisconsin,Walworth County,2015,102804,,58537,704
+Wisconsin,Walworth County,2016,102959,,58302,710
+Wisconsin,Walworth County,2017,103082,,60178,728
+Wisconsin,Walworth County,2018,103718,,63800,732
 Wisconsin,Walworth County,2019,103868,2990.0,63549,764
-Wisconsin,Walworth County,2021,106799,0.0,69996,836
-Wisconsin,Walworth County,2022,105380,0.0,72713,877
-Wisconsin,Washington County,2005,124849,0.0,60106,602
-Wisconsin,Washington County,2006,127578,0.0,58600,594
+Wisconsin,Walworth County,2021,106799,,69996,836
+Wisconsin,Walworth County,2022,105380,,72713,877
+Wisconsin,Washington County,2005,124849,,60106,602
+Wisconsin,Washington County,2006,127578,,58600,594
 Wisconsin,Washington County,2007,128211,2409.0,65357,607
-Wisconsin,Washington County,2008,129477,0.0,63332,613
-Wisconsin,Washington County,2009,130681,0.0,60549,668
-Wisconsin,Washington County,2010,131971,0.0,60446,679
-Wisconsin,Washington County,2011,132386,0.0,67232,653
-Wisconsin,Washington County,2012,132661,0.0,64221,666
-Wisconsin,Washington County,2013,132739,0.0,66391,676
-Wisconsin,Washington County,2014,133251,0.0,68424,741
+Wisconsin,Washington County,2008,129477,,63332,613
+Wisconsin,Washington County,2009,130681,,60549,668
+Wisconsin,Washington County,2010,131971,,60446,679
+Wisconsin,Washington County,2011,132386,,67232,653
+Wisconsin,Washington County,2012,132661,,64221,666
+Wisconsin,Washington County,2013,132739,,66391,676
+Wisconsin,Washington County,2014,133251,,68424,741
 Wisconsin,Washington County,2015,133674,2006.0,69713,721
-Wisconsin,Washington County,2016,134296,0.0,73502,713
-Wisconsin,Washington County,2017,135101,0.0,75453,744
-Wisconsin,Washington County,2018,135693,0.0,73435,745
-Wisconsin,Washington County,2019,136034,0.0,80513,777
-Wisconsin,Washington County,2021,137175,0.0,83384,795
-Wisconsin,Washington County,2022,137688,0.0,88807,868
-Wisconsin,Waukesha County,2005,373401,0.0,67222,723
+Wisconsin,Washington County,2016,134296,,73502,713
+Wisconsin,Washington County,2017,135101,,75453,744
+Wisconsin,Washington County,2018,135693,,73435,745
+Wisconsin,Washington County,2019,136034,,80513,777
+Wisconsin,Washington County,2021,137175,,83384,795
+Wisconsin,Washington County,2022,137688,,88807,868
+Wisconsin,Waukesha County,2005,373401,,67222,723
 Wisconsin,Waukesha County,2006,380985,7575.0,69398,738
 Wisconsin,Waukesha County,2007,379333,6986.0,72073,729
 Wisconsin,Waukesha County,2008,380629,9016.0,75372,775
@@ -13440,7 +13440,7 @@ Wisconsin,Waukesha County,2018,403072,12116.0,86968,931
 Wisconsin,Waukesha County,2019,404198,13091.0,90548,944
 Wisconsin,Waukesha County,2021,408756,41561.0,94171,1017
 Wisconsin,Waukesha County,2022,410434,33082.0,98849,1087
-Wisconsin,Winnebago County,2005,150687,0.0,46322,492
+Wisconsin,Winnebago County,2005,150687,,46322,492
 Wisconsin,Winnebago County,2006,160593,2422.0,49043,507
 Wisconsin,Winnebago County,2007,162154,2335.0,50442,496
 Wisconsin,Winnebago County,2008,162111,2370.0,53157,508
@@ -13457,54 +13457,54 @@ Wisconsin,Winnebago County,2018,171020,2205.0,56589,636
 Wisconsin,Winnebago County,2019,171907,5076.0,58347,666
 Wisconsin,Winnebago County,2021,171623,11290.0,64095,695
 Wisconsin,Winnebago County,2022,170718,10727.0,69405,756
-Wisconsin,Wood County,2005,73988,0.0,44062,442
-Wisconsin,Wood County,2006,74774,0.0,45937,402
-Wisconsin,Wood County,2007,73944,0.0,50430,444
-Wisconsin,Wood County,2008,73756,0.0,44149,445
+Wisconsin,Wood County,2005,73988,,44062,442
+Wisconsin,Wood County,2006,74774,,45937,402
+Wisconsin,Wood County,2007,73944,,50430,444
+Wisconsin,Wood County,2008,73756,,44149,445
 Wisconsin,Wood County,2009,73932,1464.0,44909,467
-Wisconsin,Wood County,2010,74793,0.0,43319,466
+Wisconsin,Wood County,2010,74793,,43319,466
 Wisconsin,Wood County,2011,74785,1616.0,45891,440
 Wisconsin,Wood County,2012,74424,1265.0,44568,465
 Wisconsin,Wood County,2013,73959,1151.0,47726,457
 Wisconsin,Wood County,2014,73608,1137.0,50831,524
-Wisconsin,Wood County,2015,73435,0.0,50796,528
-Wisconsin,Wood County,2016,73107,0.0,51887,508
-Wisconsin,Wood County,2017,73126,0.0,52110,582
-Wisconsin,Wood County,2018,73055,0.0,55273,623
-Wisconsin,Wood County,2019,72999,0.0,56278,579
-Wisconsin,Wood County,2021,74070,0.0,52627,625
-Wisconsin,Wood County,2022,73993,0.0,63643,719
-Wyoming,Laramie County,2005,81793,0.0,44790,510
-Wyoming,Laramie County,2006,85384,0.0,50907,557
-Wyoming,Laramie County,2007,86353,0.0,52521,547
-Wyoming,Laramie County,2008,87542,0.0,56820,518
+Wisconsin,Wood County,2015,73435,,50796,528
+Wisconsin,Wood County,2016,73107,,51887,508
+Wisconsin,Wood County,2017,73126,,52110,582
+Wisconsin,Wood County,2018,73055,,55273,623
+Wisconsin,Wood County,2019,72999,,56278,579
+Wisconsin,Wood County,2021,74070,,52627,625
+Wisconsin,Wood County,2022,73993,,63643,719
+Wyoming,Laramie County,2005,81793,,44790,510
+Wyoming,Laramie County,2006,85384,,50907,557
+Wyoming,Laramie County,2007,86353,,52521,547
+Wyoming,Laramie County,2008,87542,,56820,518
 Wyoming,Laramie County,2009,88854,2181.0,49744,596
-Wyoming,Laramie County,2010,92127,0.0,48784,549
-Wyoming,Laramie County,2011,92680,0.0,54053,679
-Wyoming,Laramie County,2012,94483,0.0,54192,684
+Wyoming,Laramie County,2010,92127,,48784,549
+Wyoming,Laramie County,2011,92680,,54053,679
+Wyoming,Laramie County,2012,94483,,54192,684
 Wyoming,Laramie County,2013,95809,1490.0,61661,662
-Wyoming,Laramie County,2014,96389,0.0,57551,693
+Wyoming,Laramie County,2014,96389,,57551,693
 Wyoming,Laramie County,2015,97121,1033.0,60599,761
-Wyoming,Laramie County,2016,98136,0.0,62221,822
-Wyoming,Laramie County,2017,98327,0.0,61961,775
-Wyoming,Laramie County,2018,98976,0.0,64306,772
-Wyoming,Laramie County,2019,99500,0.0,70567,752
-Wyoming,Laramie County,2021,100863,0.0,61381,805
-Wyoming,Laramie County,2022,100723,0.0,71621,949
-Wyoming,Natrona County,2005,68203,0.0,49519,442
-Wyoming,Natrona County,2006,70401,0.0,45833,466
-Wyoming,Natrona County,2007,71750,0.0,43807,488
-Wyoming,Natrona County,2008,73129,0.0,50756,577
+Wyoming,Laramie County,2016,98136,,62221,822
+Wyoming,Laramie County,2017,98327,,61961,775
+Wyoming,Laramie County,2018,98976,,64306,772
+Wyoming,Laramie County,2019,99500,,70567,752
+Wyoming,Laramie County,2021,100863,,61381,805
+Wyoming,Laramie County,2022,100723,,71621,949
+Wyoming,Natrona County,2005,68203,,49519,442
+Wyoming,Natrona County,2006,70401,,45833,466
+Wyoming,Natrona County,2007,71750,,43807,488
+Wyoming,Natrona County,2008,73129,,50756,577
 Wyoming,Natrona County,2009,74508,1439.0,56197,581
-Wyoming,Natrona County,2010,75507,0.0,51735,622
-Wyoming,Natrona County,2011,76366,0.0,52603,671
-Wyoming,Natrona County,2012,78621,0.0,54526,715
-Wyoming,Natrona County,2013,80973,0.0,58635,675
+Wyoming,Natrona County,2010,75507,,51735,622
+Wyoming,Natrona County,2011,76366,,52603,671
+Wyoming,Natrona County,2012,78621,,54526,715
+Wyoming,Natrona County,2013,80973,,58635,675
 Wyoming,Natrona County,2014,81624,1662.0,56392,735
-Wyoming,Natrona County,2015,82178,0.0,52886,708
-Wyoming,Natrona County,2016,81039,0.0,59474,693
-Wyoming,Natrona County,2017,79547,0.0,60546,773
-Wyoming,Natrona County,2018,79115,0.0,64833,754
-Wyoming,Natrona County,2019,79858,0.0,65034,685
-Wyoming,Natrona County,2021,79555,0.0,63605,841
-Wyoming,Natrona County,2022,79601,0.0,69627,824
+Wyoming,Natrona County,2015,82178,,52886,708
+Wyoming,Natrona County,2016,81039,,59474,693
+Wyoming,Natrona County,2017,79547,,60546,773
+Wyoming,Natrona County,2018,79115,,64833,754
+Wyoming,Natrona County,2019,79858,,65034,685
+Wyoming,Natrona County,2021,79555,,63605,841
+Wyoming,Natrona County,2022,79601,,69627,824

--- a/gen_county_data.py
+++ b/gen_county_data.py
@@ -108,12 +108,18 @@ print("Check to make sure no single varible is not used for completely different
 print_labels_for_variables_over_time(df_merge)
 
 # Merge the two columns that have work from home data.
-# But ensure that, for each row, at most one of them has data
-# (For small regions, both values will be na)
-for i in range(len(df_merge.index)):
-    assert pd.isna(df_merge.iloc[i]['B08006_021E']) or pd.isna(df_merge.iloc[i]['B08006_017E']) 
+def splice_wfh_columns(row):
+    # Error check: ensure that, for each row, at *most* one of them has data
+    # (For small regions, both values will be NA)
+    assert pd.isna(row['B08006_021E']) or pd.isna(row['B08006_017E']) 
 
-df_merge['Worked from Home'] = df_merge['B08006_021E'].fillna(0) + df_merge['B08006_017E'].fillna(0)
+    # If the first is not NA, then return it
+    if not pd.isna(row['B08006_021E']):
+        return row['B08006_021E']
+    else:
+        return row['B08006_017E']
+
+df_merge['Worked from Home'] = df_merge.apply(splice_wfh_columns, axis=1)
 del df_merge['B08006_021E']
 del df_merge['B08006_017E']
 


### PR DESCRIPTION
was filling the NA values as 0. This only works when there is a valid value in one of the two constituent time series. But for counties like Hays County, Texas, the data is sometimes just not reported in *either* time series (it's just NA). This was completely messing up the ranking data, which relies on a % change calculation.

The graphs for this case are still not ideal, but at least we are avoiding the "-100%" and "Inf" errors that were previously there.