### PR TITLE
Make line graph had dots for values as well.

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -30,7 +30,7 @@ with tab1:
     col1, col2 = st.columns(2)
     with col1:
         # Line graph of raw data
-        st.pyplot(df.plot(x='YEAR', y=var).figure)
+        st.pyplot(df.plot(x='YEAR', y=var, style='-o').figure)
     with col2:
         # Bar plot showing % change
         df['Percent Change'] = df[var].pct_change() * 100


### PR DESCRIPTION
This solves a few problems:
1. For graphs like Hays County, TX Work from Home, where the values oscillate between NA and a number, the line graph shows nothing. I guess the rule there is "only show of a line if the adjacent x value exists" (i.e. it doesn't make lines that "skip"). So now those values appear.
2. It makes it a bit clearer (in the line graph at least) that 2020 has no data.