### PR TITLE
Move map to quartiles instead of continuous scale

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -3,7 +3,7 @@ import numpy as np
 from census_vars import census_vars
 import json
 
-df = pd.read_csv('county_data.csv', dtype={'FIPS': str})
+df = pd.read_csv('county_data.csv', dtype={'FIPS': str, 'YEAR': str})
 with open("county_map.json", "r") as read_file:
     county_map = json.load(read_file)
 
@@ -40,7 +40,7 @@ def get_ranking_df(column):
     df2 = df.copy() # We don't want to modify the global variable
 
     # Select just the rows and columns we need
-    df2 = df2.loc[(df2['YEAR'] == 2019) | (df2['YEAR'] == 2021)]
+    df2 = df2.loc[(df2['YEAR'] == '2019') | (df2['YEAR'] == '2021')]
     df2 = df2[['STATE_NAME', 'COUNTY_NAME', 'YEAR', column]]
 
     # Combine state and county into a single column
@@ -49,8 +49,8 @@ def get_ranking_df(column):
 
     # Pivot for structure we need, calculate change and percent change, sort
     df2 = df2.pivot_table(index='County', columns='YEAR', values=column)
-    df2['Change'] = df2[2021] - df2[2019]
-    df2['Percent Change'] = (df2[2021] - df2[2019]) / df2[2019] * 100
+    df2['Change'] = df2['2021'] - df2['2019']
+    df2['Percent Change'] = (df2['2021'] - df2['2019']) / df2['2019'] * 100
     df2['Percent Change'] = df2['Percent Change'].round(1)
     df2 = df2.sort_values('Percent Change', ascending=False)
 
@@ -78,7 +78,7 @@ def get_mapping_df(column):
     df2 = df.copy() # We don't want to modify the global variable
 
     # Select just the rows and columns we need
-    df2 = df2.loc[(df2['YEAR'] == 2019) | (df2['YEAR'] == 2021)]
+    df2 = df2.loc[(df2['YEAR'] == '2019') | (df2['YEAR'] == '2021')]
     df2 = df2[['FIPS', 'STATE_NAME', 'COUNTY_NAME', 'YEAR', column]]
 
     # Combine state and county into a single column
@@ -87,10 +87,15 @@ def get_mapping_df(column):
 
     # Pivot for structure we need, calculate change and percent change, sort
     df2 = df2.pivot_table(index=['FIPS', 'County'], columns='YEAR', values=column)
-    df2['Change'] = df2[2021] - df2[2019]
-    df2['Percent Change'] = (df2[2021] - df2[2019]) / df2[2019] * 100
+    df2['Change'] = df2['2021'] - df2['2019']
+    df2['Percent Change'] = (df2['2021'] - df2['2019']) / df2['2019'] * 100
     df2['Percent Change'] = df2['Percent Change'].round(1)
     df2 = df2.sort_values('Percent Change', ascending=False)
+
+    # Color the map with 4 quartiles. This allows the user to quickly see high-level geographic
+    # patterns in the data. The default (continuous) scale highlights outliers, which we already
+    # show in the "Rankings" tab.
+    df2['Quartile'] = pd.qcut(df2['Percent Change'], q=4)
 
     df2 = (
         df2

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -43,14 +43,13 @@ with tab2:
     st.dataframe(ranking_df)
 
 with tab3:
-    st.write("Data is provided only for counties with a population of at least 65,000. See the **About** section to learn more.")
-    fig = px.choropleth(be.get_mapping_df(var), geojson=be.county_map, locations='FIPS', color='Percent Change',
-                        color_continuous_scale="Viridis",
+    st.write("Data is provided only for counties with a population of at least 65,000.")          
+    fig = px.choropleth(be.get_mapping_df(var), geojson=be.county_map, locations='FIPS', color='Quartile',
+                        color_discrete_sequence = ['#ffffcc','#a1dab4','#41b6c4','#225ea8'],
                         scope="usa",
                         hover_name='County',
-                        hover_data={'FIPS': False}, #, 'Percent Change': ':.1%'},
-                        labels={'Percent Change':'Percent Change', 'FIPS': 'NAME'})
-    fig.update_layout(margin={"r":0,"t":0,"l":0,"b":0})
+                        hover_data={'FIPS': False, 'Percent Change': True},
+                        labels={'Quartile':'Percent Change', 'FIPS': 'NAME'})
     st.plotly_chart(fig)
 
 with tab4:


### PR DESCRIPTION
This has the effect of making high-level geographic patterns in the data easy to spot at a glance. Individual datapoints are still accessible via rollover. The problem with the continuous scale was that it was dominated by outliers.

Also: read in YEAR data as a string so that matplotlib stops adding ".0" to the end of it in the x-axis.