### PR TITLE
Bug fix: Handle case of county not having a ranking

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -63,6 +63,10 @@ def get_ranking_df(column):
 
 def get_ranking_text(state, county, var, ranking_df):
     full_name = ', '.join([county, state])
+
+    if not full_name in ranking_df['County']:
+        return f"**{full_name}** does not have a ranking for **{var}**."
+    
     rank = (
         ranking_df
         [ranking_df['County'] == full_name]


### PR DESCRIPTION
Counties always have a ranking for total population. But they do not always have a ranking for other variables. App was previously crashing when this happened. This fix handles this situation better.

Closes #37 