### PR TITLE
Improve charts

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,7 +1,7 @@
 I just added a linting CI workflow. To run the tests locally type:
 
 ```
-uv run black
+uv run black .
 uv run flake8 ./*.py # It runs in .venv, etc. otherwise
 uv run ruff check .
 ```

--- a/backend.py
+++ b/backend.py
@@ -4,6 +4,7 @@ from census_vars import census_vars
 import json
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
+import matplotlib.patches as mpatches
 
 df = pd.read_csv("county_data.csv", dtype={"FIPS": str, "YEAR": str})
 with open("county_map.json", "r") as read_file:
@@ -131,5 +132,36 @@ def get_line_graph(df, var, state_name, county_name):
     ax.set_title(f"{var}\n{county_name}, {state_name}")
     ax.get_yaxis().set_major_formatter(ticker.StrMethodFormatter("{x:,.0f}"))
     ax.legend()
+
+    return fig
+
+
+def get_bar_graph(df, var, state_name, county_name):
+    fig, ax = plt.subplots()
+
+    df["YEAR"] = df["YEAR"].astype(int)
+
+    df.plot(kind="bar", x="YEAR", y="Percent Change", ax=ax)
+
+    # Modify bar colors based on YEAR values
+    for bar, year in zip(ax.patches, df["YEAR"]):
+        if year <= 2019:
+            bar.set_facecolor("blue")
+        elif year == 2020:
+            bar.set_facecolor("gray")
+        elif year >= 2021:
+            bar.set_facecolor("red")
+
+    # Formatting
+    ax.set_title(f"Percent Change of {var}\n{county_name}, {state_name}")
+    selected_years = [2005, 2010, 2015, 2020]  # Define the specific years to display
+    ax.set_xticklabels(
+        [str(year) if year in selected_years else "" for year in df["YEAR"]], rotation=0
+    )
+
+    # Manually create custom legend
+    pre_covid_patch = mpatches.Patch(color="blue", label="Pre-Covid")
+    post_covid_patch = mpatches.Patch(color="red", label="Post-Covid")
+    ax.legend(handles=[pre_covid_patch, post_covid_patch])
 
     return fig

--- a/backend.py
+++ b/backend.py
@@ -2,6 +2,8 @@ import pandas as pd
 import numpy as np
 from census_vars import census_vars
 import json
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
 
 df = pd.read_csv("county_data.csv", dtype={"FIPS": str, "YEAR": str})
 with open("county_map.json", "r") as read_file:
@@ -98,3 +100,36 @@ def get_mapping_df(column):
     df2["Quartile"] = pd.qcut(df2["Percent Change"], q=4)
 
     return df2
+
+
+def get_line_graph(df, var, state_name, county_name):
+    fig, ax = plt.subplots()
+
+    df["YEAR"] = df["YEAR"].astype(int)
+
+    # Plot pre-Covid data (before 2020) in blue
+    df_pre = df[df["YEAR"] <= 2019]
+    ax.plot(df_pre["YEAR"], df_pre[var], "-o", color="blue", label="Pre-Covid")
+
+    # Plot post-COVID data (2021 onwards) in red
+    df_post = df[df["YEAR"] >= 2021]
+    ax.plot(df_post["YEAR"], df_post[var], "-o", color="red", label="Post-Covid")
+
+    # Connect 2019 to 2021 with a dashed line
+    value_2019 = df.loc[df["YEAR"] == 2019, var].values[0]
+    value_2021 = df.loc[df["YEAR"] == 2021, var].values[0]
+    ax.plot(
+        [2019, 2021], [value_2019, value_2021], "--", color="gray", label="Covid Gap"
+    )
+
+    # Set custom x-axis labels
+    selected_years = [2005, 2010, 2015, 2020]  # Define the specific years to display
+    ax.set_xticks(selected_years)  # Set ticks at these positions
+    ax.set_xticklabels(selected_years)  # Ensure labels match the chosen ticks
+
+    # Formatting
+    ax.set_title(f"{var}\n{county_name}, {state_name}")
+    ax.get_yaxis().set_major_formatter(ticker.StrMethodFormatter("{x:,.0f}"))
+    ax.legend()
+
+    return fig

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,11 +1,9 @@
 import backend as be
 import ui_helpers as uih
 import streamlit as st
-import matplotlib
 import matplotlib.pyplot as plt
 import plotly.express as px
-
-# import pandas as pd
+import pandas as pd
 
 st.header("How did your County Change During Covid?")
 
@@ -30,34 +28,29 @@ tab1, tab2, tab3, tab4 = st.tabs(["📈 Details", "🥇 Rankings", "🗺️ Map"
 
 # Tab 1: Time series data on selected county / demographic combination
 with tab1:
+    st.write("Note that data was not reported in 2020 due to Covid-19.")
+
     df = be.get_census_data(state_name, county_name, var)
 
     # Add in NA data for 2020 because having the time series jump from 2019 to 2021
     # with no space in between looks odd.
-    # This adds a discontinuity in the line graph, so comment out for now.
-    # row_for_2020 = pd.DataFrame(
-    #     [
-    #         {
-    #             "STATE_NAME": df.iloc[0]["STATE_NAME"],
-    #             "COUNTY_NAME": df.iloc[0]["COUNTY_NAME"],
-    #             "YEAR": "2020",
-    #         }
-    #     ]
-    # )
-    # df = pd.concat([df, row_for_2020])
-    # df = df.sort_values(["STATE_NAME", "COUNTY_NAME", "YEAR"])
+    row_for_2020 = pd.DataFrame(
+        [
+            {
+                "STATE_NAME": df.iloc[0]["STATE_NAME"],
+                "COUNTY_NAME": df.iloc[0]["COUNTY_NAME"],
+                "YEAR": "2020",
+            }
+        ]
+    )
+    df = pd.concat([df, row_for_2020])
+    df = df.sort_values(["STATE_NAME", "COUNTY_NAME", "YEAR"])
 
     col1, col2 = st.columns(2)
     with col1:
-        # Line graph of raw data. Set y-axis formatter to use commas
-        fig, ax = plt.subplots()
-        df.plot(x="YEAR", y=var, style="-o", ax=ax)
-        ax.set_title(f"{var}\n{county_name}, {state_name}")
-        ax.get_yaxis().set_major_formatter(
-            matplotlib.ticker.StrMethodFormatter("{x:,.0f}")
-        )
-        ax.legend().remove()
+        fig = be.get_line_graph(df, var, state_name, county_name)
         st.pyplot(fig)
+
     with col2:
         # Bar plot showing % change
         df["Percent Change"] = df[var].pct_change() * 100

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,6 +2,7 @@ import backend as be
 import ui_helpers as uih
 import streamlit as st
 import matplotlib
+import matplotlib.pyplot as plt
 import plotly.express as px
 
 st.header("How did your County Change During Covid?")
@@ -27,21 +28,29 @@ tab1, tab2, tab3, tab4 = st.tabs(["📈 Details", "🥇 Rankings", "🗺️ Map"
 
 # Tab 1: Time series data on selected county / demographic combination
 with tab1:
-    st.write(f"All data for **{county_name}, {state_name}** for **{var}**.")
     df = be.get_census_data(state_name, county_name, var)
 
     col1, col2 = st.columns(2)
     with col1:
         # Line graph of raw data. Set y-axis formatter to use commas
-        fig = df.plot(x="YEAR", y=var, style="-o").figure
-        fig.gca().get_yaxis().set_major_formatter(
+        fig, ax = plt.subplots()
+        df.plot(x="YEAR", y=var, style="-o", ax=ax)
+        ax.set_title(f"{var}\n{county_name}, {state_name}")
+        ax.get_yaxis().set_major_formatter(
             matplotlib.ticker.StrMethodFormatter("{x:,.0f}")
         )
+        ax.legend().remove()
         st.pyplot(fig)
     with col2:
         # Bar plot showing % change
         df["Percent Change"] = df[var].pct_change() * 100
-        st.pyplot(df.plot(kind="bar", x="YEAR", y="Percent Change").figure)
+
+        fig, ax = plt.subplots()
+        df.plot(kind="bar", x="YEAR", y="Percent Change", ax=ax)
+        ax.set_title(f"Percent Change of {var}\n{county_name}, {state_name}")
+        ax.set_xticklabels(df["YEAR"], rotation=-45)
+        ax.legend().remove()
+        st.pyplot(fig)
 
 # Tab 2: Ranking of all counties for that demographic (2019-2021)
 with tab2:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -5,6 +5,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 import plotly.express as px
 
+# import pandas as pd
+
 st.header("How did your County Change During Covid?")
 
 # Let the user select a (state, county, demographic) combination to get data on
@@ -29,6 +31,21 @@ tab1, tab2, tab3, tab4 = st.tabs(["📈 Details", "🥇 Rankings", "🗺️ Map"
 # Tab 1: Time series data on selected county / demographic combination
 with tab1:
     df = be.get_census_data(state_name, county_name, var)
+
+    # Add in NA data for 2020 because having the time series jump from 2019 to 2021
+    # with no space in between looks odd.
+    # This adds a discontinuity in the line graph, so comment out for now.
+    # row_for_2020 = pd.DataFrame(
+    #     [
+    #         {
+    #             "STATE_NAME": df.iloc[0]["STATE_NAME"],
+    #             "COUNTY_NAME": df.iloc[0]["COUNTY_NAME"],
+    #             "YEAR": "2020",
+    #         }
+    #     ]
+    # )
+    # df = pd.concat([df, row_for_2020])
+    # df = df.sort_values(["STATE_NAME", "COUNTY_NAME", "YEAR"])
 
     col1, col2 = st.columns(2)
     with col1:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,7 +1,6 @@
 import backend as be
 import ui_helpers as uih
 import streamlit as st
-import matplotlib.pyplot as plt
 import plotly.express as px
 import pandas as pd
 
@@ -28,8 +27,6 @@ tab1, tab2, tab3, tab4 = st.tabs(["📈 Details", "🥇 Rankings", "🗺️ Map"
 
 # Tab 1: Time series data on selected county / demographic combination
 with tab1:
-    st.write("Note that data was not reported in 2020 due to Covid-19.")
-
     df = be.get_census_data(state_name, county_name, var)
 
     # Add in NA data for 2020 because having the time series jump from 2019 to 2021
@@ -54,13 +51,10 @@ with tab1:
     with col2:
         # Bar plot showing % change
         df["Percent Change"] = df[var].pct_change() * 100
-
-        fig, ax = plt.subplots()
-        df.plot(kind="bar", x="YEAR", y="Percent Change", ax=ax)
-        ax.set_title(f"Percent Change of {var}\n{county_name}, {state_name}")
-        ax.set_xticklabels(df["YEAR"], rotation=-45)
-        ax.legend().remove()
+        fig = be.get_bar_graph(df, var, state_name, county_name)
         st.pyplot(fig)
+
+    st.write("Data is not available for 2020 due to Covid-19.")
 
 # Tab 2: Ranking of all counties for that demographic (2019-2021)
 with tab2:


### PR DESCRIPTION
Add an NA value for 2020 to indicate covid. Previously we had no entry, and that made the graphs a bit misleading.

Have both the line and bar chart change color based on the year. Blue is pre-covid, Red is post-covid and gray is covid. 

For the bar chart covid is a gray dashed line. For the bar chart it's technically gray, but since the % change is 0, it doesn't appear at all.