### PR TITLE
Add radio button for viewing data as counts or percent change

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -201,3 +201,27 @@ def get_percent_change_histogram(df, var, year1, year2, state_name, county_name)
     ax.set_ylabel("Number of Counties")
 
     return fig
+
+
+def get_change_histogram(df, var, year1, year2, state_name, county_name):
+    fig, ax = plt.subplots()
+
+    df.hist(column="Change", ax=ax, color="black", edgecolor="white")
+
+    # Add a vertical line to highlight the selected county
+    full_name = ", ".join([county_name, state_name])
+    highlight_value = df.loc[df["County"] == full_name, "Change"].values[0]
+    ax.axvline(
+        highlight_value,
+        color="blue",
+        linestyle="--",
+        linewidth=2,
+        label=f"{county_name}",
+    )
+    ax.legend()
+
+    ax.set_title(f"Change of {var}\nBetween {year1} and {year2}")
+    ax.set_xlabel("Change")
+    ax.set_ylabel("Number of Counties")
+
+    return fig

--- a/backend.py
+++ b/backend.py
@@ -74,8 +74,8 @@ def get_ranking_text(state, county, var, ranking_df, year1, year2):
     num_counties = len(ranking_df.index)
 
     return (
-        f"**{full_name}** ranks **{rank}** of {num_counties} for its percent change in **{var}** "
-        f"between **{year1}** and **{year2}**."
+        f"{full_name} ranks **{rank} of {num_counties}** for its percent change in {var} "
+        f"between {year1} and {year2}."
     )
 
 
@@ -182,14 +182,14 @@ def get_bar_graph(df, var, state_name, county_name):
 def get_percent_change_histogram(df, var, year1, year2, state_name, county_name):
     fig, ax = plt.subplots()
 
-    df.hist(column="Percent Change", ax=ax)
+    df.hist(column="Percent Change", ax=ax, color="black", edgecolor="white")
 
     # Add a vertical line to highlight the selected county
     full_name = ", ".join([county_name, state_name])
     highlight_value = df.loc[df["County"] == full_name, "Percent Change"].values[0]
     ax.axvline(
         highlight_value,
-        color="yellow",
+        color="blue",
         linestyle="--",
         linewidth=2,
         label=f"{county_name}",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -21,7 +21,7 @@ with county_col:
     )
 with demographic_col:
     var = st.selectbox("Demographic:", be.get_unique_census_labels())
-st.radio("View data as: ", ["Counts", "Percent Change"], horizontal=True)
+graph_type = st.radio("View data as: ", ["Counts", "Percent Change"], horizontal=True)
 
 # Now display the data the user requested
 county_tab, map_tab, table_tab, about_tab = st.tabs(
@@ -48,7 +48,12 @@ with county_tab:
     col1, col2 = st.columns(2)
     with col1:
         # All data for this county
-        fig = be.get_line_graph(df, var, state_name, county_name)
+        if graph_type == "Counts":
+            fig = be.get_line_graph(df, var, state_name, county_name)
+        elif graph_type == "Percent Change":
+            df["Percent Change"] = df[var].pct_change() * 100
+            fig = be.get_bar_graph(df, var, state_name, county_name)
+
         st.pyplot(fig)
 
     with col2:
@@ -59,11 +64,6 @@ with county_tab:
                 ranking_df, var, YEAR1, YEAR2, state_name, county_name
             )
         )
-
-        # Bar plot showing % change
-        # df["Percent Change"] = df[var].pct_change() * 100
-        # fig = be.get_bar_graph(df, var, state_name, county_name)
-        # st.pyplot(fig)
 
 with map_tab:
     fig = px.choropleth(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,7 +6,11 @@ import pandas as pd
 
 st.header("How has your County Changed Since Covid?")
 
-# Let the user select a (state, county, demographic) combination to get data on
+# Comparisons "since Covid" are hard-coded to the last year before Covid (2019) and the last year of data
+YEAR1 = "2019"
+YEAR2 = "2023"
+
+# Let the user select data to view and how to view it
 state_col, county_col, demographic_col = st.columns(3)
 with state_col:
     state_name = st.selectbox("State:", be.get_state_names(), index=4)  # 4 = California
@@ -17,12 +21,14 @@ with county_col:
     )
 with demographic_col:
     var = st.selectbox("Demographic:", be.get_unique_census_labels())
+st.radio("View data as: ", ["Counts", "Percent Change"], horizontal=True)
 
 # Now display the data the user requested
-tab1, tab2, tab3 = st.tabs(["📈 Single County", "🥇 County Comparison", "ℹ️ About"])
+county_tab, map_tab, table_tab, about_tab = st.tabs(
+    ["📈 Single County", "🗺️ Map ", "📋 Table", "ℹ️ About"]
+)
 
-# Tab 1: Time series data on selected county / demographic combination
-with tab1:
+with county_tab:
     df = be.get_census_data(state_name, county_name, var)
 
     # Add in NA data for 2020 because having the time series jump from 2019 to 2021
@@ -41,61 +47,54 @@ with tab1:
 
     col1, col2 = st.columns(2)
     with col1:
+        # All data for this county
         fig = be.get_line_graph(df, var, state_name, county_name)
         st.pyplot(fig)
 
     with col2:
+        # How does this county compare to all other counties?
+        ranking_df = be.get_ranking_df(var, YEAR1, YEAR2)
+        st.pyplot(
+            be.get_percent_change_histogram(
+                ranking_df, var, YEAR1, YEAR2, state_name, county_name
+            )
+        )
+
         # Bar plot showing % change
-        df["Percent Change"] = df[var].pct_change() * 100
-        fig = be.get_bar_graph(df, var, state_name, county_name)
-        st.pyplot(fig)
+        # df["Percent Change"] = df[var].pct_change() * 100
+        # fig = be.get_bar_graph(df, var, state_name, county_name)
+        # st.pyplot(fig)
 
-# Tab 2: Ranking of all counties for that demographic
-with tab2:
-    # Let the user selecting years to compare when ranking how counties changed.
-    # The ACS 1-year estimates are available for each year since 2005 with the exception of 2020.
-    years = [str(year) for year in range(2005, 2023 + 1) if year != 2020]
-    col1, col2 = st.columns(2)
-    with col1:
-        year1 = st.selectbox("Starting Year:", years, index=14)
-    with col2:
-        year2 = st.selectbox("Ending Year:", years, index=17)
+with map_tab:
+    fig = px.choropleth(
+        be.get_mapping_df(var, YEAR1, YEAR2),
+        geojson=be.county_map,
+        locations="FIPS",
+        color="Quartile",
+        color_discrete_sequence=["#ffffcc", "#a1dab4", "#41b6c4", "#225ea8"],
+        scope="usa",
+        hover_name="County",
+        hover_data={"FIPS": False, "Percent Change": True},
+        labels={"Quartile": "Percent Change", "FIPS": "NAME"},
+    )
+    fig.update_layout(title_text=f"Percent Change of {var} between {YEAR1} and {YEAR2}")
+    st.plotly_chart(fig)
 
-    ranking_df = be.get_ranking_df(var, year1, year2)
+with table_tab:
+    ranking_df = be.get_ranking_df(var, YEAR1, YEAR2)
     ranking_text = be.get_ranking_text(
-        state_name, county_name, var, ranking_df, year1, year2
+        state_name, county_name, var, ranking_df, YEAR1, YEAR2
     )
 
     st.write(ranking_text)
 
-    subtab = st.radio("Choose a visualization:", ["Histogram", "Table", "Map"])
-    if subtab == "Histogram":
-        st.pyplot(
-            be.get_percent_change_histogram(
-                ranking_df, var, year1, year2, state_name, county_name
-            )
-        )
-    elif subtab == "Table":
-        # The styling here are things like the gradient on the "Percent Change" column
-        ranking_df = ranking_df.style.pipe(
-            uih.apply_styles, state_name, county_name, year1, year2
-        )
-        st.dataframe(ranking_df)
-    elif subtab == "Map":
-        fig = px.choropleth(
-            be.get_mapping_df(var, year1, year2),
-            geojson=be.county_map,
-            locations="FIPS",
-            color="Quartile",
-            color_discrete_sequence=["#ffffcc", "#a1dab4", "#41b6c4", "#225ea8"],
-            scope="usa",
-            hover_name="County",
-            hover_data={"FIPS": False, "Percent Change": True},
-            labels={"Quartile": "Percent Change", "FIPS": "NAME"},
-        )
-        st.plotly_chart(fig)
+    # The styling here are things like the gradient on the "Percent Change" column
+    ranking_df = ranking_df.style.pipe(
+        uih.apply_styles, state_name, county_name, YEAR1, YEAR2
+    )
+    st.dataframe(ranking_df)
 
-with tab3:
+with about_tab:
     text = open("about.md").read()
     st.write(text)
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -25,7 +25,7 @@ graph_type = st.radio("View data as: ", ["Counts", "Percent Change"], horizontal
 
 # Now display the data the user requested
 county_tab, map_tab, table_tab, about_tab = st.tabs(
-    ["📈 Single County", "🗺️ Map ", "📋 Table", "ℹ️ About"]
+    ["📈 Graphs", "🗺️ Map ", "📋 Table", "ℹ️ About"]
 )
 
 with county_tab:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -59,11 +59,16 @@ with county_tab:
     with col2:
         # How does this county compare to all other counties?
         ranking_df = be.get_ranking_df(var, YEAR1, YEAR2)
-        st.pyplot(
-            be.get_percent_change_histogram(
+        if graph_type == "Counts":
+            fig = be.get_change_histogram(
                 ranking_df, var, YEAR1, YEAR2, state_name, county_name
             )
-        )
+        elif graph_type == "Percent Change":
+            fig = be.get_percent_change_histogram(
+                ranking_df, var, YEAR1, YEAR2, state_name, county_name
+            )
+
+        st.pyplot(fig)
 
 with map_tab:
     fig = px.choropleth(


### PR DESCRIPTION
Remove ability for user to select years to compare. Force comparisons to be between 2019 (year right before covid) and 2023 (last year of data).

Add UI radio to let user select between Counts and Percent Change.

Change tabs to be: "Graphs", "Map", "Table", "About".

Make default tab have 2 graphs: (a) time series for county and (b) histogram showing how selected county compares to all other counties.

Remove radio button for selecting visualizations that used to be on 2nd tab. Now it only shows map.

Todo: Map needs to be responsive to "Counts vs. Percent Change" radio button.

Todo: I think a lot of the backend code is likely now redunant. E.g. be.get_change_histogram and be.get_percent_change_histogram are very similar and can likely be collapsed into a single function. Prioritizing getting this new UX finished and will then revisit code.