### PR TITLE
Change UI

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -52,7 +52,7 @@ def get_ranking_df(column, year1, year2, display_col):
     df2["Change"] = df2[year2] - df2[year1]
     df2["Percent Change"] = (df2[year2] - df2[year1]) / df2[year1] * 100
     df2["Percent Change"] = df2["Percent Change"].round(1)
-    df2 = df2.sort_values(display_col, ascending=False)
+    df2 = df2.sort_values(display_col)
 
     # Drop Columns with Infinite percent change (first or last year has 0)
     df2 = df2.replace([np.inf, -np.inf], np.nan).dropna()
@@ -74,8 +74,8 @@ def get_ranking_text(state, county, var, ranking_df, year1, year2, display_col):
     num_counties = len(ranking_df.index)
 
     return (
-        f"{full_name} ranks **{rank} of {num_counties}** for {display_col} in {var} "
-        f"between {year1} and {year2}."
+        f"{display_col} of {var} between {year1} and {year2}.<br>"
+        f"{full_name} ranks **{rank}** of {num_counties} counties."
     )
 
 
@@ -205,7 +205,7 @@ def get_histogram(df, var, year1, year2, state_name, county_name, display_col):
     )
     ax.legend()
 
-    ax.set_title(f"{display_col} of {var}\nBetween {year1} and {year2}")
+    ax.set_title(f"{display_col} of {var}\nAll Counties, {year1} to {year2}")
     ax.set_xlabel(display_col)
     ax.set_ylabel("Number of Counties")
 

--- a/backend.py
+++ b/backend.py
@@ -210,3 +210,28 @@ def get_histogram(df, var, year1, year2, state_name, county_name, display_col):
     ax.set_ylabel("Number of Counties")
 
     return fig
+
+
+def get_boxplot(df, var, year1, year2, state_name, county_name, display_col):
+    fig, ax = plt.subplots()
+
+    df.boxplot(column=display_col, ax=ax)
+
+    # If the highlighted county is present in both years, add a vertical line to highlight its value
+    full_name = ", ".join([county_name, state_name])
+    if not df.loc[df["County"] == full_name, display_col].empty:
+        highlight_value = df.loc[df["County"] == full_name, display_col].values[0]
+        ax.axhline(
+            highlight_value,
+            color="orange",
+            linestyle="--",
+            linewidth=2,
+            label=f"{county_name}",
+        )
+        ax.legend()
+
+    ax.set_title(f"{display_col} of {var}\nAll Counties, {year1} to {year2}")
+    ax.set_ylabel(display_col)
+    ax.xaxis.set_visible(False)
+
+    return fig

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,10 +6,6 @@ import pandas as pd
 
 st.header("How has your County Changed Since Covid?")
 
-# Comparisons "since Covid" are hard-coded to the year right before Covid (2019) and the last year of data
-YEAR1 = "2019"
-YEAR2 = "2023"
-
 # Let the user select data to view and how to view it
 state_col, county_col, demographic_col = st.columns(3)
 with state_col:
@@ -21,8 +17,14 @@ with county_col:
     )
 with demographic_col:
     var = st.selectbox("Demographic:", be.get_unique_census_labels())
-graph_type = st.radio("View data as: ", ["Counts", "Percent Change"], horizontal=True)
-display_col = "Percent Change" if graph_type == "Percent Change" else "Change"
+
+# At one point the app was designed to let people toggle between viewing Count data vs. Percent Change data, and 
+# also change which years they used to compare when looking at percent change calculations.
+# All the graphing functions still maintain that flexibility. But I'm now experimenting with hard-coding both
+# of these variables
+display_col = "Percent Change"
+YEAR1 = "2019"
+YEAR2 = "2023"
 
 # Now display the data the user requested
 county_tab, table_tab, map_tab, about_tab = st.tabs(
@@ -48,13 +50,8 @@ with county_tab:
 
     col1, col2 = st.columns(2)
     with col1:
-        # All data for this county
-        if graph_type == "Counts":
-            fig = be.get_line_graph(df, var, state_name, county_name)
-        elif graph_type == "Percent Change":
-            df["Percent Change"] = df[var].pct_change() * 100
-            fig = be.get_bar_graph(df, var, state_name, county_name)
-
+        # Time Series graph data for this county, for the given variable
+        fig = be.get_line_graph(df, var, state_name, county_name)
         st.pyplot(fig)
 
     with col2:
@@ -71,7 +68,7 @@ with table_tab:
         state_name, county_name, var, ranking_df, YEAR1, YEAR2, display_col
     )
 
-    st.write(ranking_text)
+    st.markdown(ranking_text, unsafe_allow_html=True)
 
     # The styling here are things like the gradient on the column the user selected
     ranking_df = ranking_df.style.pipe(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -18,7 +18,7 @@ with county_col:
 with demographic_col:
     var = st.selectbox("Demographic:", be.get_unique_census_labels())
 
-# At one point the app was designed to let people toggle between viewing Count data vs. Percent Change data, and 
+# At one point the app was designed to let people toggle between viewing Count data vs. Percent Change data, and
 # also change which years they used to compare when looking at percent change calculations.
 # All the graphing functions still maintain that flexibility. But I'm now experimenting with hard-coding both
 # of these variables

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -57,7 +57,7 @@ with county_tab:
     with col2:
         # How does this county compare to all other counties?
         ranking_df = be.get_ranking_df(var, YEAR1, YEAR2, display_col)
-        fig = be.get_histogram(
+        fig = be.get_boxplot(
             ranking_df, var, YEAR1, YEAR2, state_name, county_name, display_col
         )
         st.pyplot(fig)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -25,8 +25,8 @@ graph_type = st.radio("View data as: ", ["Counts", "Percent Change"], horizontal
 display_col = "Percent Change" if graph_type == "Percent Change" else "Change"
 
 # Now display the data the user requested
-county_tab, map_tab, table_tab, about_tab = st.tabs(
-    ["📈 Graphs", "🗺️ Map ", "📋 Table", "ℹ️ About"]
+county_tab, table_tab, map_tab, about_tab = st.tabs(
+    ["📈 Graphs", "📋 Table", "🗺️ Map ", "ℹ️ About"]
 )
 
 with county_tab:
@@ -65,6 +65,20 @@ with county_tab:
         )
         st.pyplot(fig)
 
+with table_tab:
+    ranking_df = be.get_ranking_df(var, YEAR1, YEAR2, display_col)
+    ranking_text = be.get_ranking_text(
+        state_name, county_name, var, ranking_df, YEAR1, YEAR2, display_col
+    )
+
+    st.write(ranking_text)
+
+    # The styling here are things like the gradient on the column the user selected
+    ranking_df = ranking_df.style.pipe(
+        uih.apply_styles, state_name, county_name, YEAR1, YEAR2, display_col
+    )
+    st.dataframe(ranking_df)
+
 with map_tab:
     fig = px.choropleth(
         be.get_mapping_df(var, YEAR1, YEAR2, display_col),
@@ -79,20 +93,6 @@ with map_tab:
     )
     fig.update_layout(title_text=f"{display_col} of {var} between {YEAR1} and {YEAR2}")
     st.plotly_chart(fig)
-
-with table_tab:
-    ranking_df = be.get_ranking_df(var, YEAR1, YEAR2, display_col)
-    ranking_text = be.get_ranking_text(
-        state_name, county_name, var, ranking_df, YEAR1, YEAR2, display_col
-    )
-
-    st.write(ranking_text)
-
-    # The styling here are things like the gradient on the column the user selected
-    ranking_df = ranking_df.style.pipe(
-        uih.apply_styles, state_name, county_name, YEAR1, YEAR2, display_col
-    )
-    st.dataframe(ranking_df)
 
 with about_tab:
     text = open("about.md").read()


### PR DESCRIPTION
Change graph 2 from a histogram to a boxplot. The problem with the histogram is that the outliers had no visible bars, so people wondered why there was so much "empty space". 

Remove the UI widget that lets people toggle between counts and percent change. Graph 1 is now fixed to show counts, and graph 2 is now fixed to show percent change (and between fixed years of 2019 and 2023, as well). 

Also move table to tab 2 (it seems like the most natural followup to viewing the graphs tab).